### PR TITLE
graph: bound pending CI on the autonomous dispatch path (tactic-autonomous-ci-pending-liveness-bound)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
@@ -250,6 +250,16 @@ for spec in "$@"; do
     10)
       # ci-waiting: a draft PR's checks are still in progress. Leave the
       # reservation; the next tick re-selects once the CI verdict lands.
+      #
+      # DELIBERATELY NOT COUNTED (tactic-autonomous-ci-pending-liveness-bound).
+      # Reaching here is an INTRA-TICK RACE, not a sustained state: the
+      # selector's ci-ready gate passed moments earlier and CI went pending
+      # between selection and provision. The SUSTAINED form of the same state
+      # is counted at graph-select-target's `ci-pending` arm, against
+      # DISPATCH_CI_PENDING_STRIKE_CAP, keyed on the PR's head SHA. A second
+      # independent counter here would double-count the same stalled run —
+      # both counters advancing on alternating ticks — and could fire the hold
+      # at half the intended budget. One counter, one place.
       echo "waiting $id"
       ;;
     11)

--- a/.claude/skills/dispatch-propagate/scripts/graph-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/graph-select-target
@@ -36,9 +36,21 @@
 # `hold-node --kind fix-attempt-cap --reset-fix-attempt` writes a born-parked
 # hold tactic plus a `blocked_by` edge on the source, in one graph-commit) —
 # dropping the node out of the eligible set via that edge rather than
-# re-arming another retry forever. These graph-commit writes (this script's
-# own via `_graph_commit_fix`, and hold-node's own internal commit) are the
-# only writes selection makes.
+# re-arming another retry forever.
+#
+# A SECOND hold producer lives on the qa/review CI gate
+# (tactic-autonomous-ci-pending-liveness-bound): a draft PR whose CI verdict
+# stays `pending` on the SAME head SHA for DISPATCH_CI_PENDING_STRIKE_CAP
+# consecutive autonomous ticks (its checks never started, or started and never
+# concluded) lands a `ci-pending-stalled` hold through the same `hold-node`
+# primitive. Below the cap it is NOT a graph write at all — the consecutive
+# count is a sidecar file outside every checkout (ci_pending_strike_bump /
+# ci_pending_strike_clear in lib.sh), on the same "ticks are cheap, graph
+# records are not" reasoning as dispatch-graph-execute's CONFLICT_STRIKE_CAP.
+#
+# These graph-commit writes (this script's own via `_graph_commit_fix`, and
+# hold-node's own internal commit on the fix-attempt-cap and ci-pending-stalled
+# hold paths) are the only writes selection makes.
 #
 # Usage: graph-select-target [--top <n>] [--pace-exempt-only] [--standalone] [--node <id>]
 #
@@ -508,6 +520,49 @@ _hold_node_fix_cap() {
   return $rc
 }
 
+# _hold_node_ci_pending <id> <pr> <strikes> <sha> — the CI-pending liveness
+# bound's hold producer (tactic-autonomous-ci-pending-liveness-bound). Modelled
+# on _hold_node_fix_cap above: build the reason/recommendation files hold-node
+# requires and land a `ci-pending-stalled` hold (a born-parked hold tactic plus
+# a `blocked_by` edge on <id>, in one graph-commit; the source's own
+# office_hours is never written). NO --reset-fix-attempt: this hold has nothing
+# to do with the fix ladder. rc mirrors hold-node's own exit code.
+#
+# The `>/dev/null 2>&1` redirect is load-bearing (same as _hold_node_fix_cap's):
+# sensor_gate runs inside a command substitution, so any stray stdout from
+# hold-node would be parsed as the emitted phase.
+_hold_node_ci_pending() {
+  local id="$1" pr="$2" strikes="$3" sha="$4"
+  local tmpdir reason_file rec_file rc minutes
+  tmpdir=$(mktemp -d) || return 1
+  reason_file="$tmpdir/reason.txt"
+  rec_file="$tmpdir/recommendation.txt"
+  minutes=$(( strikes * 15 ))
+  {
+    printf "This tactic's draft PR #%s has reported a \`pending\` CI verdict on head SHA " "$pr"
+    printf '%s for %s consecutive autonomous ticks (~%s minutes); its checks either ' \
+      "$sha" "$strikes" "$minutes"
+    printf 'never started (an empty status-check rollup) or started and never concluded, '
+    printf 'so no phase worker can be launched and no verdict can ever arrive on its own.\n'
+  } > "$reason_file"
+  {
+    printf "Inspect the PR's Checks tab. If no workflow run exists, re-trigger it "
+    printf '(close/reopen the PR, or push an empty commit to the node'"'"'s branch) — a new '
+    printf 'head SHA also resets the strike counter. If a run is stuck or was cancelled by '
+    printf 'a queue/runner problem, re-run it. Then resolve THIS HOLD TACTIC to '
+    printf '`phase: done` and prune it — clearing `office_hours` alone does not unblock '
+    printf 'the source.\n'
+  } > "$rec_file"
+
+  ( cd "$NATIVE_ROOT" && packages/intentionsutil/scripts/hold-node "$id" \
+      --kind ci-pending-stalled \
+      --reason-file "$reason_file" --recommendation-file "$rec_file" ) \
+    >/dev/null 2>&1
+  rc=$?
+  rm -rf "$tmpdir"
+  return $rc
+}
+
 # _read_pr_ci <pr> — one gh_pr_view_rest + one CI verdict, into globals
 # _CI_MERGED / _CI_HEAD / _CI_VERDICT. rc 1 when the PR is unreadable.
 _read_pr_ci() {
@@ -633,14 +688,58 @@ sensor_gate() {
       # state `closed`, not MERGED; the merged signal is `mergedAt != null`
       # (same field reconcile-graph-merged reads). A read failure is non-fatal:
       # fall through to the CI-verdict check rather than misclassify.
-      if merged_at=$(gh_pr_view_rest "$pr" 2>/dev/null | jq -r '.mergedAt // empty'); then
-        if [[ -n "$merged_at" ]]; then echo "pr-merged-awaiting-reconcile"; return 1; fi
-      fi
+      #
+      # ONE PR read serves both consumers: the merged check here and the head
+      # SHA the ci-pending strike ladder below keys on. Do NOT reach for the
+      # `_CI_HEAD` global `_gate_maybe_interrupt`/`_read_pr_ci` set — it can
+      # hold a stale value from a PREVIOUS candidate (they clear it only when
+      # they actually run a read). `<<<` never `echo | jq` (.claude/rules/
+      # shell-json.md). On a read failure `pv` is empty, `merged_at` and
+      # `head_sha` are both empty, and the gate falls through to the CI check
+      # with the strike ladder disarmed — fail open, never misclassify.
+      local pv head_sha
+      pv=$(gh_pr_view_rest "$pr" 2>/dev/null) || pv=""
+      merged_at=$(jq -r '.mergedAt // empty' <<<"$pv" 2>/dev/null)
+      head_sha=$(jq -r '.headRefOid // empty' <<<"$pv" 2>/dev/null)
+      if [[ -n "$merged_at" ]]; then echo "pr-merged-awaiting-reconcile"; return 1; fi
       "$SCRIPT_DIR/dispatch-ci-ready" "$id" >/dev/null 2>&1
       rc=$?
       case "$rc" in
-        0) echo "$phase"; return 0 ;;
-        1) echo "ci-pending"; return 1 ;;
+        0)
+          # CI concluded. Clear the ladder so its count always means
+          # CONSECUTIVE pending observations, not a lifetime total (mirrors
+          # dispatch-graph-execute's exit-0 conflict-strike reset, lines
+          # 230-235).
+          ci_pending_strike_clear "$NATIVE_ROOT" "$id"
+          echo "$phase"; return 0 ;;
+        1)
+          # CI verdict `pending` — the bounded arm
+          # (tactic-autonomous-ci-pending-liveness-bound). Two lanes are
+          # exempt from counting and keep the pre-bound behaviour verbatim:
+          #   - --node <id>: the explicit human lane. A human running
+          #     `dispatch <node-id>` repeatedly must not burn the AUTONOMOUS
+          #     strike budget — this bound exists for the unattended tick.
+          #   - an empty head SHA: the PR read failed, so there is no SHA to
+          #     key consecutiveness on. Fail open rather than count blind.
+          if [[ -n "$NODE_TARGET" || -z "$head_sha" ]]; then
+            echo "ci-pending"; return 1
+          fi
+          local strikes
+          strikes=$(ci_pending_strike_bump "$NATIVE_ROOT" "$id" "$head_sha") \
+            || { echo "ci-pending"; return 1; }
+          if (( strikes < DISPATCH_CI_PENDING_STRIKE_CAP )); then
+            echo "ci-pending (strike $strikes/$DISPATCH_CI_PENDING_STRIKE_CAP)"
+            return 1
+          fi
+          # At the cap: escalate to a tracked hold. On failure the sidecar is
+          # deliberately LEFT in place so the next tick retries the hold (the
+          # same posture as the fix-cap hold failure above and
+          # dispatch-graph-execute's own hold-failed path).
+          if ! _hold_node_ci_pending "$id" "$pr" "$strikes" "$head_sha"; then
+            echo "ci-pending-hold-failed"; return 1
+          fi
+          ci_pending_strike_clear "$NATIVE_ROOT" "$id"
+          echo "ci-pending-cap-held"; return 1 ;;
         *) echo "graph-select-target: dispatch-ci-ready failed (exit $rc) for $id" >&2; return 2 ;;
       esac ;;
     main-qa)

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -826,6 +826,66 @@ dispatch_ci_verdict_rest() {
   printf '%s\n' "$verdict"
 }
 
+# --- CI-pending liveness bound (tactic-autonomous-ci-pending-liveness-bound) ---
+# Consecutive-observation cap for a draft PR whose CI verdict stays `pending`
+# on the SAME head SHA. A baked-in constant, deliberately NOT a dispatch.config
+# tunable — parity with CONFLICT_STRIKE_CAP (dispatch-graph-execute:145) and
+# FIX_ATTEMPT_CAP (packages/intentionsutil/src/transitions.ts:101). The tick
+# fires every 15 minutes (OnCalendar=*:0/15, lib.sh:3082), so 8 consecutive
+# observations is ~2 hours of a single CI run never concluding — far past any
+# legitimate run in this repo, and cheap because every observation below the
+# cap is a file write, never a graph record.
+DISPATCH_CI_PENDING_STRIKE_CAP=8
+
+# ci_pending_strike_bump <main-root> <node-id> <head-sha> — count ONE consecutive
+# `pending` CI observation for <node-id> on <head-sha>, and print the new count.
+#
+# The counter is a sidecar file at
+# <main-root>/.claude/worktrees/<node-id>.ci-pending-strikes, holding a single
+# line `<sha> <count>`. The sidecar lives OUTSIDE every checkout — NEXT TO the
+# node's worktree, not inside it — the same convention as `.conflict-strikes`
+# (dispatch-graph-execute:289) and `.scope-fingerprint` (provision-node-worktree,
+# see dispatch-graph-scope-sweep:42). That is load-bearing: a file inside a
+# checkout would dirty that tree and trip graph-commit's assert_clean_outside_ids.
+# This helper makes NO graph write of any kind.
+#
+# Reset semantics: an absent, unreadable, or unparseable sidecar, or a recorded
+# SHA that differs from <head-sha>, resets the count to 1 — the count always
+# means "consecutive pending observations of THIS head SHA". Losing the sidecar
+# (daemon restart, reaped worktree) is deliberately fail-open: it just grants
+# more free observations before the cap.
+#
+# Returns 1 WITHOUT writing when <head-sha> is empty — an unreadable PR must
+# never burn a strike.
+ci_pending_strike_bump() { # <main-root> <node-id> <head-sha>
+  local main_root="$1" node_id="$2" head_sha="$3"
+  [[ -n "$head_sha" ]] || return 1
+  local file="$main_root/.claude/worktrees/$node_id.ci-pending-strikes"
+  mkdir -p "$main_root/.claude/worktrees" 2>/dev/null || true
+  local prev_sha="" c=0
+  read -r prev_sha c < "$file" 2>/dev/null || true
+  # Validate as a LITERAL integer before any (( )) context: bash arithmetic
+  # evaluates array-index command substitution, so an untrusted file value must
+  # never reach it unchecked (same defensive shape as dispatch-graph-execute:330
+  # and reconcile-graph-review-stall:91-95).
+  [[ "$c" =~ ^[0-9]+$ ]] || c=0
+  if [[ "$prev_sha" != "$head_sha" ]]; then
+    c=1
+  else
+    c=$(( c + 1 ))
+  fi
+  printf '%s %s\n' "$head_sha" "$c" > "$file" 2>/dev/null || true
+  printf '%s\n' "$c"
+}
+
+# ci_pending_strike_clear <main-root> <node-id> — drop the ci-pending sidecar
+# (CI concluded, or the hold landed). Always returns 0. Same
+# outside-every-checkout sidecar location as ci_pending_strike_bump above.
+ci_pending_strike_clear() { # <main-root> <node-id>
+  rm -f "$1/.claude/worktrees/$2.ci-pending-strikes" 2>/dev/null || true
+  return 0
+}
+
 # REST-backed drop-in for `gh issue view <N> --json
 # number,title,body,state,stateReason,createdAt,labels,assignees` (#2255). The
 # dispatch fleet exhausts GitHub's shared GraphQL rate-limit bucket while the

--- a/.claude/skills/dispatch-propagate/scripts/reconcile-graph-review-stall
+++ b/.claude/skills/dispatch-propagate/scripts/reconcile-graph-review-stall
@@ -30,6 +30,23 @@
 #              hold (hold-node): a born-parked hold tactic plus a blocked_by
 #              edge on the source, whose id is a valid /dispatch-conflict
 #              Lane 3 entry point. The `reviewed` marker is preserved.
+#   ci-stall — CI never CONCLUDES (tactic-autonomous-ci-pending-liveness-bound).
+#              A `pending` verdict is not a regression and routes nowhere
+#              (reviewStallRoute returns null for it, correctly — pending is a
+#              liveness observation, not a lane), so an armed auto-merge whose
+#              checks never started, or started and never finished, would sit
+#              here forever with no observer: the selector's reviewed-marker
+#              exclusion means graph-select-target's own CI-pending strike
+#              ladder never sees this node. This sweep therefore runs the SAME
+#              bound at its own observation point, reusing lib.sh's
+#              ci_pending_strike_bump / ci_pending_strike_clear sidecar (the
+#              counter lives outside every checkout, so below the cap it is not
+#              a graph write at all). At DISPATCH_CI_PENDING_STRIKE_CAP
+#              consecutive `pending` observations of the SAME head SHA, land a
+#              tracked `ci-pending-stalled` hold via the same hold-node
+#              primitive. NOT the CI-fix interrupt — that strips the `reviewed`
+#              marker and re-drafts the PR, discarding a completed review
+#              verdict, for the same reason the conflict route avoids it.
 #
 # A still-OPEN PR with no regression, or one whose mergeability is still
 # UNKNOWN (GitHub computes it asynchronously and self-heals), is a no-op —
@@ -46,6 +63,7 @@
 # Stdout protocol, one line per tactic acted on; NOTHING for a skip:
 #   recovered <id> -> fix (ci=<verdict> merge=<state>)
 #   held <id> -> conflict via <hold-id> (ci=<verdict> merge=<state>)
+#   held <id> -> ci-stalled via <hold-id> (sha=<sha> strikes=<n>)
 #
 # Exit codes: 0 always (including a no-op sweep and any per-node error —
 # best-effort, matching reconcile-graph-merged's doctrine); 1 only for a hard
@@ -66,8 +84,13 @@
 # LOCK_WAIT_SECONDS, default 1050s), so this sweep runs AT MOST TWO
 # graph-commits per tick: every `fix`-routed node's `--set-fix` write is
 # batched into ONE commit (exactly as reconcile-graph-merged batches its plan),
-# and at most ONE `conflict`-routed node is held per sweep (hold-node lands its
-# own commit and cannot be batched into that one). Per-tick actions are
+# and at most ONE hold is landed per sweep (hold-node lands its own commit and
+# cannot be batched into that one). That single hold slot is SHARED between the
+# `conflict` and `ci-stall` routes — whichever route records first takes it, and
+# the other is skipped this tick rather than raising the budget to three
+# commits. A skipped node still matches the enumeration next tick (and its
+# ci-stall strike count is already at the cap), so it is held on a following
+# sweep. Per-tick actions are
 # additionally capped (GRAPH_REVIEW_STALL_CAP), and the lock heartbeat is
 # refreshed between candidates so the per-PR polling loop cannot age the lock
 # out on its own.
@@ -81,7 +104,16 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
+source "$SCRIPT_DIR/lib-graph-worktree.sh"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+# The CI-pending strike sidecars live NEXT TO the node worktrees under the MAIN
+# checkout (<main-root>/.claude/worktrees/<id>.ci-pending-strikes), so both
+# observation surfaces — this sweep and graph-select-target's own ladder
+# (graph-select-target:445-446, whose NATIVE_ROOT is resolved identically) —
+# read and write ONE file per node. Falling back to REPO_ROOT keeps a fixture or
+# a non-worktree checkout working.
+MAIN_ROOT=$(resolve_main_worktree "$REPO_ROOT")
+MAIN_ROOT="${MAIN_ROOT:-$REPO_ROOT}"
 UTIL_SCRIPTS="$REPO_ROOT/packages/intentionsutil/scripts"
 GRAPH_COMMIT="$UTIL_SCRIPTS/graph-commit"
 
@@ -174,6 +206,9 @@ RECOVERED_IDS=()
 RECOVERED_MSGS=()
 CONFLICT_IDS=()
 CONFLICT_NOTES=()
+CI_STALL_IDS=()
+CI_STALL_SHAS=()
+CI_STALL_STRIKES=()
 ACTED=0
 while IFS=$'\t' read -r id pr; do
   [[ -n "$id" && -n "$pr" ]] || continue
@@ -255,18 +290,53 @@ while IFS=$'\t' read -r id pr; do
       # lock budget above allows one batched commit; this adds at most one
       # more). A second conflicting node is picked up on the next tick, whose
       # enumeration still matches it.
-      [[ "${#CONFLICT_IDS[@]}" -ge 1 ]] && continue
+      #
+      # The one hold slot is SHARED with the ci-stall route below (see the lock
+      # budget header): if that route already recorded a hold this sweep, this
+      # conflict waits for the next tick rather than adding a third commit.
+      [[ "${#CONFLICT_IDS[@]}" -ge 1 || "${#CI_STALL_IDS[@]}" -ge 1 ]] && continue
       CONFLICT_IDS+=("$id")
       CONFLICT_NOTES+=("ci=$VERDICT merge=$MERGEABLE")
       ACTED=$(( ACTED + 1 ))
       ;;
     *)
-      continue   # null — no regression; nothing to route
+      # null — no regression, so nothing to ROUTE. But this is also exactly
+      # where a node whose CI never concludes lands on every single sweep
+      # (`pending` folds to VERDICT=unknown above, which routes nowhere), so the
+      # CI-pending liveness bound observes RAW_VERDICT directly here rather than
+      # widening reviewStallRoute's closed union with a non-route.
+      if [[ -z "$RAW_VERDICT" ]]; then
+        # The verdict call FAILED (line ~214 leaves it empty). An unreadable CI
+        # state is not an observation: never count it, and never clear a real
+        # count that earlier sweeps accumulated. Fail open.
+        continue
+      fi
+      if [[ "$RAW_VERDICT" != "pending" ]]; then
+        # CI concluded (and did not route) — the ladder means CONSECUTIVE
+        # pending observations, so reset it (mirrors graph-select-target's own
+        # concluded-CI reset).
+        ci_pending_strike_clear "$MAIN_ROOT" "$id"
+        continue
+      fi
+      # Pending. Count one observation. A sidecar write is FREE — it holds no
+      # lock and makes no graph write — so a below-cap observation must not
+      # consume the ACTED budget, which exists to bound lock-holding work.
+      strikes=$(ci_pending_strike_bump "$MAIN_ROOT" "$id" "$HEAD_SHA") || continue
+      [[ "$strikes" -lt "$DISPATCH_CI_PENDING_STRIKE_CAP" ]] && continue
+      # At the cap. Recorded, not landed — same reason as the conflict route
+      # (hold-node lands its own graph-commit, whose assert_clean_outside_ids
+      # guard would trip on this loop's still-uncommitted --set-fix writes), and
+      # sharing that route's single hold slot.
+      [[ "${#CONFLICT_IDS[@]}" -ge 1 || "${#CI_STALL_IDS[@]}" -ge 1 ]] && continue
+      CI_STALL_IDS+=("$id")
+      CI_STALL_SHAS+=("$HEAD_SHA")
+      CI_STALL_STRIKES+=("$strikes")
+      ACTED=$(( ACTED + 1 ))   # a hold IS lock-holding work
       ;;
   esac
 done <<<"$CANDIDATES"
 
-[[ "${#RECOVERED_IDS[@]}" -eq 0 && "${#CONFLICT_IDS[@]}" -eq 0 ]] && exit 0
+[[ "${#RECOVERED_IDS[@]}" -eq 0 && "${#CONFLICT_IDS[@]}" -eq 0 && "${#CI_STALL_IDS[@]}" -eq 0 ]] && exit 0
 
 # --- Land every staged fix-state write as ONE graph-commit -------------------
 # `-C "$REPO_ROOT"` is mandatory: graph-commit resolves the repo to commit from
@@ -284,9 +354,9 @@ if [[ "${#RECOVERED_IDS[@]}" -gt 0 ]]; then
   if ! "$GRAPH_COMMIT" "${GC_ARGS[@]}"; then
     echo "reconcile-graph-review-stall: graph-commit failed for ${RECOVERED_IDS[*]} (write rolled back, nothing landed)" >&2
     # The EXIT trap restores every staged write, so intentions/ is left clean
-    # for the next graph writer. The conflict route is skipped this tick (a
-    # failing land means the landing path itself is unhealthy); the next tick
-    # re-detects it — the enumeration still matches.
+    # for the next graph writer. Both hold routes (conflict and ci-stall) are
+    # skipped this tick (a failing land means the landing path itself is
+    # unhealthy); the next tick re-detects them — the enumeration still matches.
     exit 0
   fi
   # Landed — disarm the rollback so the clean exit keeps the committed state.
@@ -324,6 +394,50 @@ if [[ "${#CONFLICT_IDS[@]}" -gt 0 ]]; then
     }
     HOLD_ID=$(awk '{print $2}' <<<"$HELD_LINE")
     echo "held $id -> conflict via ${HOLD_ID:-unknown} (${CONFLICT_NOTES[$i]})"
+    refresh_lock
+  done
+fi
+
+# --- Land the ci-stall route as a tracked ci-pending-stalled hold ------------
+# The CI-pending liveness bound's hold producer at THIS observation surface
+# (tactic-autonomous-ci-pending-liveness-bound). Structurally identical to the
+# conflict block above — the shared hold slot guarantees at most one of the two
+# blocks actually runs per sweep, so the two-graph-commit budget holds.
+#
+# NOT execution.fix, for the same reason the conflict route avoids it (see the
+# header and transitions.ts:272-283): the fix interrupt's `--clear-fix` strips
+# the `reviewed` marker and `gh pr ready --undo` re-drafts the PR, discarding a
+# completed review verdict and re-running the whole review pass — while the
+# stuck/never-started CI run itself stays exactly as stuck. hold-node instead
+# births a born-parked hold tactic plus a blocked_by edge on the source; the
+# source's own office_hours is never written and its `reviewed` marker survives.
+if [[ "${#CI_STALL_IDS[@]}" -gt 0 ]]; then
+  refresh_lock
+  # Reuse the scratch dir the conflict block may already have created; the
+  # single EXIT trap installed above removes it either way (never a second trap).
+  [[ -n "$TMPDIR_HOLD" ]] || TMPDIR_HOLD=$(mktemp -d) \
+    || { echo "reconcile-graph-review-stall: mktemp -d failed" >&2; exit 0; }
+  REASON_FILE="$TMPDIR_HOLD/reason"
+  RECOMMENDATION_FILE="$TMPDIR_HOLD/recommendation"
+
+  for i in "${!CI_STALL_IDS[@]}"; do
+    id="${CI_STALL_IDS[$i]}"
+    sha="${CI_STALL_SHAS[$i]}"
+    strikes="${CI_STALL_STRIKES[$i]}"
+    printf '%s\n' "This tactic completed review and its auto-merge is ARMED, so the selector's reviewed-marker exclusion means no worker lane observes it — this recovery sweep is its only observer. Its PR's CI has reported a \`pending\` verdict on head SHA $sha for $strikes consecutive sweeps: the checks either never started (an empty status-check rollup) or started and never concluded. No verdict can arrive on its own, so the armed merge can never fire and the node is stranded." > "$REASON_FILE"
+    printf '%s\n' "Inspect the PR's Checks tab. If no workflow run exists, re-trigger it (close/reopen the PR, or push an empty commit to the node's branch) — a new head SHA also resets the strike counter. If a run is stuck or was cancelled by a queue/runner problem, re-run it. Do NOT route this through the CI-fix interrupt: \`apply-fix-state --clear-fix\` strips the \`reviewed\` marker and \`gh pr ready --undo\` re-drafts the PR, discarding a completed review verdict and re-running the whole review pass while the stuck CI run stays untouched (the same reason the conflict route avoids it). Then resolve THIS HOLD TACTIC to \`phase: done\` and prune it — clearing \`office_hours\` alone does not unblock the source." > "$RECOMMENDATION_FILE"
+
+    HELD_LINE=$( (cd "$REPO_ROOT" && "$UTIL_SCRIPTS/hold-node" "$id" --kind ci-pending-stalled \
+                  --reason-file "$REASON_FILE" --recommendation-file "$RECOMMENDATION_FILE") ) || {
+      # Hold failed — LEAVE the sidecar in place (it is already at the cap) so
+      # the next sweep retries the hold, matching graph-select-target's own
+      # hold-failed posture.
+      echo "reconcile-graph-review-stall: hold-node --kind ci-pending-stalled failed for $id" >&2
+      continue
+    }
+    HOLD_ID=$(awk '{print $2}' <<<"$HELD_LINE")
+    ci_pending_strike_clear "$MAIN_ROOT" "$id"
+    echo "held $id -> ci-stalled via ${HOLD_ID:-unknown} (sha=$sha strikes=$strikes)"
     refresh_lock
   done
 fi

--- a/.claude/skills/dispatch-propagate/scripts/test-graph-select-target.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-graph-select-target.sh
@@ -648,4 +648,207 @@ gsc_standalone_teardown
 
 # <<< END MOVED <<<
 
+# ============================================================================
+# Test: graph-select-target — the CI-pending liveness bound
+# (tactic-autonomous-ci-pending-liveness-bound Unit 2)
+# ============================================================================
+# A draft PR whose CI verdict never resolves used to stall the node forever:
+# every tick the qa/review gate skipped it as `ci-pending` with no counter and
+# no bound. The gate now counts CONSECUTIVE pending observations of the SAME
+# head SHA in a sidecar OUTSIDE every checkout
+# (<root>/.claude/worktrees/<id>.ci-pending-strikes, `<sha> <count>`), and at
+# DISPATCH_CI_PENDING_STRIKE_CAP (8) lands a `ci-pending-stalled` hold via
+# hold-node. Below the cap it makes NO graph write at all.
+#
+# Fixture shape follows the two harnesses above (real git repo + physically
+# copied script/libs — graph-select-target derives REPO_ROOT from its own
+# on-disk location, so symlinks break it). What is new:
+#   - the fake npx emits a `qa`-phase candidate WITH a pr, so sensor_gate takes
+#     the qa|review arm rather than the gh-free implement arm;
+#   - a fake `gh` on PATH answers both REST reads that arm makes — the PR
+#     object (gh_pr_view_rest) and the commit check-runs list
+#     (dispatch_ci_verdict_rest, via _gate_maybe_interrupt). The empty
+#     check-runs list classifies as `pending`, so the interrupt never fires and
+#     the gate falls through to dispatch-ci-ready;
+#   - `dispatch-ci-ready` is stubbed as a sibling in the fixture's scripts dir
+#     (graph-select-target resolves it via $SCRIPT_DIR), rc driven by
+#     CIP_CI_READY_RC;
+#   - `packages/intentionsutil/scripts/hold-node` is stubbed INSIDE the fixture
+#     repo (the producer invokes it as a path relative to NATIVE_ROOT) and
+#     records its argv to $CIP_ROOT/hold-node-argv, which is what makes
+#     "held / not held" observable.
+CIP_SHA="1111111111111111111111111111111111111111"
+CIP_OTHER_SHA="2222222222222222222222222222222222222222"
+CIP_SIDECAR_REL=".claude/worktrees/tactic-cip-fixture.ci-pending-strikes"
+
+cip_setup() {
+  CIP_ROOT=$(mktemp -d)
+  CIP_BARE=$(mktemp -d)
+  CIP_SCRIPTS="$CIP_ROOT/.claude/skills/dispatch-propagate/scripts"
+  mkdir -p "$CIP_SCRIPTS" "$CIP_ROOT/bin" "$CIP_ROOT/.claude/worktrees" \
+           "$CIP_ROOT/packages/intentionsutil/scripts"
+  cp "$SCRIPT_DIR"/graph-select-target "$SCRIPT_DIR"/lib.sh "$SCRIPT_DIR"/lib-*.sh \
+     "$CIP_SCRIPTS/"
+  chmod +x "$CIP_SCRIPTS/graph-select-target"
+  # One qa-phase candidate carrying a PR number.
+  cat > "$CIP_ROOT/bin/npx" <<'CIPNPX'
+#!/usr/bin/env bash
+echo '{"candidates":[{"id":"tactic-cip-fixture","kind":"tactic","phase":"qa","pr":"555","pace_exempt":false}],"events":[]}'
+exit 0
+CIPNPX
+  chmod +x "$CIP_ROOT/bin/npx"
+  # Fake gh: check-runs -> empty (classifies `pending`); anything else -> the
+  # raw REST pull object gh_pr_view_rest projects. `state` must be non-null
+  # (that projection ascii_upcases it). The head sha is driven by CIP_HEAD_SHA
+  # so a case can simulate a new push.
+  cat > "$CIP_ROOT/bin/gh" <<'CIPGH'
+#!/usr/bin/env bash
+for _a in "$@"; do
+  case "$_a" in
+    *check-runs*) echo '{"check_runs":[]}'; exit 0 ;;
+  esac
+done
+printf '{"number":555,"title":"t","body":"","state":"open","merged_at":null,"merge_commit_sha":null,"mergeable":null,"mergeable_state":"unknown","head":{"ref":"tactic-cip-fixture","sha":"%s"},"labels":[]}\n' "${CIP_HEAD_SHA:-unset}"
+exit 0
+CIPGH
+  chmod +x "$CIP_ROOT/bin/gh"
+  # dispatch-ci-ready: 1 = verdict pending (the bounded arm), 0 = concluded.
+  cat > "$CIP_SCRIPTS/dispatch-ci-ready" <<'CIPCIR'
+#!/usr/bin/env bash
+exit "${CIP_CI_READY_RC:-1}"
+CIPCIR
+  chmod +x "$CIP_SCRIPTS/dispatch-ci-ready"
+  # hold-node: record argv, succeed.
+  cat > "$CIP_ROOT/packages/intentionsutil/scripts/hold-node" <<'CIPHOLD'
+#!/usr/bin/env bash
+_root="$(cd "$(dirname "$0")/../../.." && pwd)"
+printf '%s\n' "$@" > "$_root/hold-node-argv"
+exit 0
+CIPHOLD
+  chmod +x "$CIP_ROOT/packages/intentionsutil/scripts/hold-node"
+  git init -q -b main "$CIP_ROOT"
+  git -C "$CIP_ROOT" config user.email t@t
+  git -C "$CIP_ROOT" config user.name t
+  mkdir -p "$CIP_ROOT/intentions"
+  echo '# placeholder' > "$CIP_ROOT/intentions/placeholder.md"
+  git -C "$CIP_ROOT" add -A
+  git -C "$CIP_ROOT" commit -q -m seed
+  git init -q --bare -b main "$CIP_BARE"
+  git -C "$CIP_ROOT" remote add origin "$CIP_BARE"
+  git -C "$CIP_ROOT" push -q origin main
+  git -C "$CIP_ROOT" fetch -q origin
+  cat > "$CIP_ROOT/bin/claude" <<'CIPCLAUDE'
+#!/usr/bin/env bash
+_root="$(cd "$(dirname "$0")/.." && pwd)"
+cat "$_root/claude-payload.json"
+exit 0
+CIPCLAUDE
+  chmod +x "$CIP_ROOT/bin/claude"
+  printf '%s' '[]' > "$CIP_ROOT/claude-payload.json"
+  CIP_GST="$CIP_SCRIPTS/graph-select-target"
+  CIP_SIDECAR="$CIP_ROOT/$CIP_SIDECAR_REL"
+}
+
+cip_teardown() {
+  rm -rf "$CIP_ROOT" "$CIP_BARE"
+  CIP_ROOT="" ; CIP_BARE="" ; CIP_SCRIPTS="" ; CIP_GST="" ; CIP_SIDECAR=""
+}
+
+# cip_run <extra args...> — one selector invocation with the fixture env.
+cip_run() {
+  PATH="$CIP_ROOT/bin:$SAVED_PATH" \
+    CLAUDE_AGENTS_CMD="$CIP_ROOT/bin/claude" \
+    DISPATCH_RESERVATION_DIR="$CIP_ROOT/reservations" \
+    DISPATCH_SELECTION_LOG_DIR="$CIP_ROOT/seldir" \
+    CIP_HEAD_SHA="$CIP_SHA" CIP_CI_READY_RC="${CIP_CI_READY_RC:-1}" \
+    "$CIP_GST" "$@" 2>/dev/null
+}
+
+cip_held() { [ -f "$CIP_ROOT/hold-node-argv" ] && echo 1 || echo 0; }
+cip_sidecar() { cat "$CIP_SIDECAR" 2>/dev/null || echo "ABSENT"; }
+
+# --- Case 1: first pending observation -> strike 1, no hold -----------------
+echo "Test: graph-select-target — a first pending-CI observation writes strike 1 and never holds"
+cip_setup
+cip1_out=$(cip_run)
+assert_eq "graph-select-target ci-pending: below the cap the node is simply skipped" \
+  "empty" "$cip1_out"
+assert_eq "graph-select-target ci-pending: the sidecar records <sha> 1" \
+  "$CIP_SHA 1" "$(cip_sidecar)"
+assert_eq "graph-select-target ci-pending: no hold is landed below the cap" "0" "$(cip_held)"
+cip_teardown
+
+# --- Case 2: same head SHA accumulates --------------------------------------
+echo "Test: graph-select-target — a pending observation on the SAME head SHA increments the strike count"
+cip_setup
+printf '%s 3\n' "$CIP_SHA" > "$CIP_SIDECAR"
+cip2_out=$(cip_run)
+assert_eq "graph-select-target ci-pending: same-SHA observation still skips" "empty" "$cip2_out"
+assert_eq "graph-select-target ci-pending: same-SHA observation bumps 3 -> 4" \
+  "$CIP_SHA 4" "$(cip_sidecar)"
+assert_eq "graph-select-target ci-pending: no hold at strike 4 of 8" "0" "$(cip_held)"
+cip_teardown
+
+# --- Case 3: a new head SHA resets the ladder -------------------------------
+# The count means "consecutive pending observations of THIS head SHA". A push
+# (new SHA) starts a fresh CI run, so the accumulated strikes must not carry
+# over — otherwise a healthy node that pushed after a stall would hold on its
+# first pending tick.
+echo "Test: graph-select-target — a changed head SHA resets the pending-CI strike ladder to 1"
+cip_setup
+printf '%s 7\n' "$CIP_OTHER_SHA" > "$CIP_SIDECAR"
+cip3_out=$(cip_run)
+assert_eq "graph-select-target ci-pending: changed-SHA observation still skips" "empty" "$cip3_out"
+assert_eq "graph-select-target ci-pending: changed SHA resets the count to 1" \
+  "$CIP_SHA 1" "$(cip_sidecar)"
+assert_eq "graph-select-target ci-pending: a reset never holds" "0" "$(cip_held)"
+cip_teardown
+
+# --- Case 4: at the cap -> tracked hold, sidecar cleared --------------------
+echo "Test: graph-select-target — the DISPATCH_CI_PENDING_STRIKE_CAP-th consecutive pending observation lands a ci-pending-stalled hold"
+cip_setup
+printf '%s 7\n' "$CIP_SHA" > "$CIP_SIDECAR"
+cip4_out=$(cip_run)
+assert_eq "graph-select-target ci-pending: the capped tick still prints empty" "empty" "$cip4_out"
+assert_eq "graph-select-target ci-pending: the cap invokes hold-node" "1" "$(cip_held)"
+assert_eq "graph-select-target ci-pending: the hold names the source node id" \
+  "1" "$(grep -qx 'tactic-cip-fixture' "$CIP_ROOT/hold-node-argv" && echo 1 || echo 0)"
+assert_eq "graph-select-target ci-pending: the hold uses --kind ci-pending-stalled" \
+  "1" "$(grep -qx 'ci-pending-stalled' "$CIP_ROOT/hold-node-argv" && echo 1 || echo 0)"
+# No --reset-fix-attempt: this hold is unrelated to the fix ladder.
+assert_eq "graph-select-target ci-pending: the hold does NOT reset the fix-attempt ladder" \
+  "0" "$(grep -qx -- '--reset-fix-attempt' "$CIP_ROOT/hold-node-argv" && echo 1 || echo 0)"
+assert_eq "graph-select-target ci-pending: a landed hold clears the sidecar" \
+  "ABSENT" "$(cip_sidecar)"
+cip_teardown
+
+# --- Case 5: the explicit --node lane is exempt -----------------------------
+# `dispatch <node-id>` is the human lane; repeated human invocations must not
+# burn the AUTONOMOUS strike budget. The sidecar must be left exactly as found
+# and no hold landed, however close to the cap it already is.
+echo "Test: graph-select-target — the explicit --node lane neither counts pending-CI strikes nor holds"
+cip_setup
+printf '%s 7\n' "$CIP_SHA" > "$CIP_SIDECAR"
+cip5_out=$(cip_run --node tactic-cip-fixture)
+assert_eq "graph-select-target ci-pending: --node still skips on a pending verdict" "empty" "$cip5_out"
+assert_eq "graph-select-target ci-pending: --node leaves the sidecar untouched" \
+  "$CIP_SHA 7" "$(cip_sidecar)"
+assert_eq "graph-select-target ci-pending: --node never lands a hold" "0" "$(cip_held)"
+cip_teardown
+
+# --- Case 6: a concluded verdict clears the ladder --------------------------
+# The count must mean CONSECUTIVE observations, so a tick whose CI verdict
+# concluded has to drop the sidecar — otherwise strikes scattered across weeks
+# and separated by healthy runs would accumulate into a false hold.
+echo "Test: graph-select-target — a concluded CI verdict selects the node and clears the pending-CI ladder"
+cip_setup
+printf '%s 4\n' "$CIP_SHA" > "$CIP_SIDECAR"
+cip6_out=$(CIP_CI_READY_RC=0 cip_run)
+assert_eq "graph-select-target ci-pending: a concluded verdict selects the candidate" \
+  "node tactic-cip-fixture tactic qa" "$cip6_out"
+assert_eq "graph-select-target ci-pending: a concluded verdict clears the sidecar" \
+  "ABSENT" "$(cip_sidecar)"
+assert_eq "graph-select-target ci-pending: a concluded verdict never holds" "0" "$(cip_held)"
+cip_teardown
+
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-reconcile-graph-review-stall.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-reconcile-graph-review-stall.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# Tests for reconcile-graph-review-stall's CI-pending liveness bound
+# (tactic-autonomous-ci-pending-liveness-bound Unit 3).
+#
+# The sweep is the ONLY observer of a tactic at phase:review carrying the
+# `reviewed` marker (the selector excludes it entirely), so a PR whose CI never
+# concludes would sit there forever with an armed auto-merge that can never
+# fire. These cases pin the strike ladder this sweep runs at that second
+# observation surface: below the cap it is a free sidecar write, at the cap it
+# lands a tracked `ci-pending-stalled` hold — and the single hold slot is SHARED
+# with the pre-existing conflict route, so one sweep never lands two holds.
+#
+# Harness (same idiom as test-graph-select-target.sh / test-dispatch-graph-
+# execute.sh): a real git repo with an `origin` bare remote, the SUT plus lib.sh
+# and every lib-*.sh PHYSICALLY copied in (the SUT derives REPO_ROOT from its own
+# on-disk location, so a symlink would resolve back out of the fixture), and
+# stubs on PATH / under packages/intentionsutil/scripts for the three external
+# dependencies: `node` (the two `node --import tsx/esm -e` one-liners), `gh` (the
+# REST PR read + the check-runs verdict), and `hold-node` / `graph-commit`.
+# MAIN_ROOT is resolved for real via `git worktree list` — main is checked out at
+# the fixture root, so the sidecars land at
+# <root>/.claude/worktrees/<id>.ci-pending-strikes, the same file the selection
+# surface would use.
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=dispatch-test-fixture.sh
+source "$FIXTURE_DIR/dispatch-test-fixture.sh"
+
+# dispatch-test-fixture.sh carries assert_eq/report_results but not a substring
+# assert (test-dispatch-graph-execute.sh defines its own assert_not_contains for
+# the same reason).
+assert_contains() {  # $1 = label, $2 = needle, $3 = haystack
+  TOTAL=$((TOTAL + 1))
+  if printf '%s' "$3" | grep -qF -- "$2"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $1"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $1"
+    echo "    expected to contain: $2"
+    echo "    actual: $3"
+  fi
+}
+
+RGRS_CAP=8   # DISPATCH_CI_PENDING_STRIKE_CAP (lib.sh)
+RGRS_SHA="deadbeefcafe0000000000000000000000000001"
+
+# --- fixture ----------------------------------------------------------------
+# rgrs_setup — a fresh sandbox per case so one case cannot leak into the next.
+rgrs_setup() {
+  # pwd -P: `git worktree list` reports the resolved path, and the sidecar
+  # assertions compare against $RGRS_ROOT, so both must be symlink-free.
+  RGRS_ROOT=$(cd "$(mktemp -d)" && pwd -P)
+  RGRS_BARE=$(cd "$(mktemp -d)" && pwd -P)
+  RGRS_SCRIPTS="$RGRS_ROOT/.claude/skills/dispatch-propagate/scripts"
+  RGRS_PKG="$RGRS_ROOT/packages/intentionsutil/scripts"
+  mkdir -p "$RGRS_SCRIPTS" "$RGRS_PKG" "$RGRS_ROOT/bin" "$RGRS_ROOT/intentions" \
+           "$RGRS_ROOT/.claude/worktrees" "$RGRS_ROOT/cicache"
+  cp "$SCRIPT_DIR"/reconcile-graph-review-stall "$SCRIPT_DIR"/lib.sh \
+     "$SCRIPT_DIR"/lib-*.sh "$RGRS_SCRIPTS/"
+  chmod +x "$RGRS_SCRIPTS/reconcile-graph-review-stall"
+
+  RGRS_HOLD_LOG="$RGRS_ROOT/hold.log"
+  RGRS_GC_LOG="$RGRS_ROOT/graph-commit.log"
+  : >"$RGRS_HOLD_LOG"
+  : >"$RGRS_GC_LOG"
+
+  # `node` stub: the SUT makes exactly two `node --import tsx/esm -e <script>`
+  # calls. The enumeration one-liner is answered by reading the fixture's own
+  # intentions/*.md (so a case controls candidacy by writing node files, as the
+  # real listNodes pass would); the reviewStallRoute one-liner reimplements that
+  # pure function's three-line body over its two argv values.
+  cat > "$RGRS_ROOT/bin/node" <<'RGRSNODE'
+#!/usr/bin/env bash
+script=""
+args=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --import) shift 2 ;;
+    -e) script="$2"; shift 2 ;;
+    *) args+=("$1"); shift ;;
+  esac
+done
+if [[ "$script" == *listNodes* ]]; then
+  for f in ./intentions/*.md; do
+    [[ -e "$f" ]] || continue
+    grep -q '^    - reviewed$' "$f" || continue
+    grep -q '^phase: review$' "$f" || continue
+    grep -q '^office_hours: null$' "$f" || continue
+    grep -q '^  fix: null$' "$f" || continue
+    grep -q '^blocked_by: \[\]$' "$f" || continue
+    id=$(grep '^id: ' "$f" | head -1 | cut -d' ' -f2)
+    pr=$(grep '^  pr: ' "$f" | head -1 | cut -d' ' -f4)
+    [[ -n "$id" && -n "$pr" && "$pr" != "null" ]] || continue
+    printf '%s\t%s\n' "$id" "$pr"
+  done
+  exit 0
+fi
+if [[ "$script" == *reviewStallRoute* ]]; then
+  ci="${args[0]-}"
+  mergeable="${args[1]-}"
+  if [[ "$mergeable" == "CONFLICTING" ]]; then printf 'conflict'
+  elif [[ "$ci" == "failing" ]]; then printf 'fix'
+  else printf 'null'; fi
+  exit 0
+fi
+exit 0
+RGRSNODE
+  chmod +x "$RGRS_ROOT/bin/node"
+
+  # `gh` stub: `gh api repos/{owner}/{repo}/pulls/<n>` returns the RAW REST PR
+  # object gh_pr_view_rest projects (mergeable driven by a per-PR file so a case
+  # can make one node CONFLICTING); the check-runs endpoint is only reached when
+  # no verdict is memoised, and fails on purpose — the memo cache below is how a
+  # case pins a verdict, and the failure is what Case 4 exercises.
+  cat > "$RGRS_ROOT/bin/gh" <<'RGRSGH'
+#!/usr/bin/env bash
+_root="$(cd "$(dirname "$0")/.." && pwd)"
+path="$*"
+case "$path" in
+  *pulls/*)
+    num="${path##*pulls/}"
+    mergeable="true"
+    [[ -f "$_root/pr-$num.conflicting" ]] && mergeable="false"
+    sha=$(cat "$_root/pr-$num.sha")
+    printf '{"number":%s,"title":"t","body":"","state":"open","merged_at":null,' "$num"
+    printf '"merge_commit_sha":null,"mergeable":%s,"mergeable_state":"clean",' "$mergeable"
+    printf '"head":{"ref":"b","sha":"%s"},"labels":[]}\n' "$sha"
+    exit 0 ;;
+  *check-runs*)
+    echo "check-runs unavailable" >&2
+    exit 1 ;;
+esac
+exit 1
+RGRSGH
+  chmod +x "$RGRS_ROOT/bin/gh"
+
+  # hold-node stub: log the argv plus the reason/recommendation bodies, print
+  # the `held <hold-id>` line the SUT parses with awk '{print $2}'.
+  cat > "$RGRS_PKG/hold-node" <<'RGRSHOLD'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$HOLD_LOG"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --reason-file|--recommendation-file) cat "$2" >> "$HOLD_LOG"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+echo "held tactic-hold-fixture"
+exit "${HOLD_RC:-0}"
+RGRSHOLD
+  # graph-commit stub: nothing in these cases takes the fix route, so a call
+  # here would itself be a finding.
+  cat > "$RGRS_PKG/graph-commit" <<'RGRSGC'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GC_LOG"
+exit 0
+RGRSGC
+  chmod +x "$RGRS_PKG/hold-node" "$RGRS_PKG/graph-commit"
+
+  git init -q -b main "$RGRS_ROOT"
+  git -C "$RGRS_ROOT" config user.email t@t
+  git -C "$RGRS_ROOT" config user.name t
+}
+
+rgrs_seed_git() {
+  git -C "$RGRS_ROOT" add -A
+  git -C "$RGRS_ROOT" commit -q -m seed
+  git init -q --bare -b main "$RGRS_BARE"
+  git -C "$RGRS_ROOT" remote add origin "$RGRS_BARE"
+  git -C "$RGRS_ROOT" push -q origin main
+  git -C "$RGRS_ROOT" fetch -q origin
+}
+
+rgrs_teardown() {
+  rm -rf "$RGRS_ROOT" "$RGRS_BARE"
+}
+
+# rgrs_node <id> <pr> — write a phase:review + `reviewed` tactic fixture.
+rgrs_node() {
+  cat > "$RGRS_ROOT/intentions/$1.md" <<RGRSNODEFILE
+---
+id: $1
+kind: tactic
+statement: fixture
+owner: ai
+status: raw
+parent: null
+serves: []
+phase: review
+execution:
+  branch: $1
+  pr: $2
+  attempts: {}
+  markers:
+    - planned
+    - reviewed
+  fix: null
+blocked_by: []
+office_hours: null
+---
+# fixture
+RGRSNODEFILE
+  printf '%s\n' "$RGRS_SHA" > "$RGRS_ROOT/pr-$2.sha"
+}
+
+# rgrs_sidecar_set <id> <count> / rgrs_sidecar <id>
+rgrs_sidecar_set() {
+  printf '%s %s\n' "$RGRS_SHA" "$2" > "$RGRS_ROOT/.claude/worktrees/$1.ci-pending-strikes"
+}
+rgrs_sidecar() {
+  cat "$RGRS_ROOT/.claude/worktrees/$1.ci-pending-strikes" 2>/dev/null || echo "gone"
+}
+
+# rgrs_verdict <verdict> — memoise the CI verdict for the fixture SHA, so
+# dispatch_ci_verdict_rest returns it without a check-runs call. Omit to leave
+# the cache empty and drive the call FAILURE path instead.
+rgrs_verdict() {
+  printf '%s\n' "$1" > "$RGRS_ROOT/cicache/$RGRS_SHA"
+}
+
+# rgrs_run — run the sweep against the sandbox; stdout in RGRS_OUT, rc in RGRS_RC.
+RGRS_OUT=""
+RGRS_RC=0
+rgrs_run() {
+  set +e
+  RGRS_OUT=$(
+    export PATH="$RGRS_ROOT/bin:$SAVED_PATH"
+    export DISPATCH_CI_VERDICT_CACHE="$RGRS_ROOT/cicache"
+    export HOLD_LOG="$RGRS_HOLD_LOG" GC_LOG="$RGRS_GC_LOG"
+    export GH_RETRY_ATTEMPTS=1
+    "$RGRS_SCRIPTS/reconcile-graph-review-stall" 2>/dev/null
+  )
+  RGRS_RC=$?
+  set -e
+}
+
+# ============================================================================
+# Case 1: a `pending` verdict BELOW the cap counts and does nothing else
+# ============================================================================
+echo "Case 1: pending below the cap bumps the sidecar, lands no hold"
+rgrs_setup
+rgrs_node tactic-pend 101
+rgrs_seed_git
+rgrs_verdict pending
+rgrs_sidecar_set tactic-pend 3
+rgrs_run
+assert_eq "below-cap prints nothing" "" "$RGRS_OUT"
+assert_eq "below-cap exits 0" "0" "$RGRS_RC"
+assert_eq "below-cap bumps the sidecar to 4" "$RGRS_SHA 4" "$(rgrs_sidecar tactic-pend)"
+assert_eq "below-cap calls no hold-node" "" "$(cat "$RGRS_HOLD_LOG")"
+assert_eq "below-cap calls no graph-commit" "" "$(cat "$RGRS_GC_LOG")"
+rgrs_teardown
+
+# ============================================================================
+# Case 2: at the cap -> a tracked ci-pending-stalled hold, sidecar cleared
+# ============================================================================
+echo "Case 2: pending at the cap lands a ci-pending-stalled hold"
+rgrs_setup
+rgrs_node tactic-stalled 202
+rgrs_seed_git
+rgrs_verdict pending
+rgrs_sidecar_set tactic-stalled $(( RGRS_CAP - 1 ))
+rgrs_run
+RGRS_HOLD=$(cat "$RGRS_HOLD_LOG")
+assert_eq "at-cap prints the ci-stalled hold line" \
+  "held tactic-stalled -> ci-stalled via tactic-hold-fixture (sha=$RGRS_SHA strikes=$RGRS_CAP)" \
+  "$RGRS_OUT"
+assert_eq "at-cap exits 0" "0" "$RGRS_RC"
+assert_contains "at-cap calls hold-node with --kind ci-pending-stalled" \
+  "tactic-stalled --kind ci-pending-stalled" "$RGRS_HOLD"
+assert_eq "at-cap clears the sidecar" "gone" "$(rgrs_sidecar tactic-stalled)"
+# The reason must name what is specific to THIS surface (the armed merge nobody
+# observes), and the recommendation must forbid the CI-fix interrupt.
+assert_contains "at-cap reason names the armed, unobserved merge" \
+  "auto-merge is ARMED" "$RGRS_HOLD"
+assert_contains "at-cap reason names the head SHA" "$RGRS_SHA" "$RGRS_HOLD"
+assert_contains "at-cap recommendation forbids the CI-fix interrupt" \
+  "Do NOT route this through the CI-fix interrupt" "$RGRS_HOLD"
+assert_contains "at-cap recommendation demands the hold be resolved to done" \
+  "phase: done" "$RGRS_HOLD"
+rgrs_teardown
+
+# ============================================================================
+# Case 3: a CONCLUDED (passing) verdict clears an accumulated sidecar
+# ============================================================================
+echo "Case 3: a passing verdict clears the sidecar and lands no hold"
+rgrs_setup
+rgrs_node tactic-green 303
+rgrs_seed_git
+rgrs_verdict passing
+rgrs_sidecar_set tactic-green 5
+rgrs_run
+assert_eq "passing prints nothing" "" "$RGRS_OUT"
+assert_eq "passing clears the sidecar" "gone" "$(rgrs_sidecar tactic-green)"
+assert_eq "passing calls no hold-node" "" "$(cat "$RGRS_HOLD_LOG")"
+rgrs_teardown
+
+# ============================================================================
+# Case 4: an unreadable CI verdict neither counts nor clears (fail open)
+# ============================================================================
+echo "Case 4: a failed CI verdict call leaves the sidecar untouched"
+rgrs_setup
+rgrs_node tactic-ghfail 404
+rgrs_seed_git
+# No memoised verdict -> the check-runs call runs and the gh stub fails it, so
+# RAW_VERDICT is empty. That must NOT burn a strike and must NOT reset one.
+rgrs_sidecar_set tactic-ghfail 5
+rgrs_run
+assert_eq "verdict-failure prints nothing" "" "$RGRS_OUT"
+assert_eq "verdict-failure leaves the sidecar at 5" "$RGRS_SHA 5" "$(rgrs_sidecar tactic-ghfail)"
+assert_eq "verdict-failure calls no hold-node" "" "$(cat "$RGRS_HOLD_LOG")"
+rgrs_teardown
+
+# ============================================================================
+# Case 5: the two hold routes SHARE one slot — a conflicting node and an at-cap
+# pending node in the same sweep produce exactly ONE hold-node call
+# ============================================================================
+echo "Case 5: a conflict and an at-cap ci-stall in one sweep land exactly one hold"
+rgrs_setup
+rgrs_node tactic-aconflict 505
+rgrs_node tactic-bstalled 506
+rgrs_seed_git
+touch "$RGRS_ROOT/pr-505.conflicting"
+rgrs_verdict pending
+rgrs_sidecar_set tactic-bstalled $(( RGRS_CAP - 1 ))
+rgrs_run
+assert_eq "shared slot: exactly one hold-node invocation" "1" \
+  "$(grep -c -e '--kind' "$RGRS_HOLD_LOG")"
+assert_eq "shared slot: exactly one held line on stdout" "1" \
+  "$(printf '%s\n' "$RGRS_OUT" | grep -c '^held ')"
+assert_eq "shared slot: exits 0" "0" "$RGRS_RC"
+# The skipped route is not lost: its node still matches the enumeration next
+# tick, and the ci-stall strike count stays at the cap so it holds immediately.
+assert_eq "shared slot: the pending node's strike count is at the cap" \
+  "$RGRS_SHA $RGRS_CAP" "$(rgrs_sidecar tactic-bstalled)"
+rgrs_teardown
+
+report_results

--- a/packages/intentionsutil/scripts/hold-node
+++ b/packages/intentionsutil/scripts/hold-node
@@ -32,7 +32,7 @@
 #
 # Usage:
 #   hold-node <source-node-id>
-#             --kind <provision-conflict|fix-attempt-cap|worktree-residue>
+#             --kind <provision-conflict|fix-attempt-cap|worktree-residue|ci-pending-stalled>
 #             --reason-file <f> --recommendation-file <f>
 #             [--body-file <f>] [--reset-fix-attempt]
 #
@@ -61,7 +61,7 @@ DUMP_NODE_TS="$SCRIPT_DIR/dump-node.ts"
 APPLY_FIX_TS="$SCRIPT_DIR/apply-fix-state.ts"
 GRAPH_COMMIT="$SCRIPT_DIR/graph-commit"
 
-USAGE="usage: hold-node <source-node-id> --kind <provision-conflict|fix-attempt-cap|worktree-residue> --reason-file <f> --recommendation-file <f> [--body-file <f>] [--reset-fix-attempt]"
+USAGE="usage: hold-node <source-node-id> --kind <provision-conflict|fix-attempt-cap|worktree-residue|ci-pending-stalled> --reason-file <f> --recommendation-file <f> [--body-file <f>] [--reset-fix-attempt]"
 
 SOURCE_ID=""
 KIND=""

--- a/packages/intentionsutil/scripts/hold-node-decide.ts
+++ b/packages/intentionsutil/scripts/hold-node-decide.ts
@@ -18,7 +18,7 @@
 //
 // Usage:
 //   node --import tsx/esm hold-node-decide.ts --source <id>
-//     --kind <provision-conflict|fix-attempt-cap|worktree-residue>
+//     --kind <provision-conflict|fix-attempt-cap|worktree-residue|ci-pending-stalled>
 //     --reason-file <f> --recommendation-file <f>
 //     [--body-file <f>] [--now <YYYY-MM-DD>] [--intentions <dir>]
 //
@@ -58,12 +58,30 @@ import type { IntentionNode } from "../src/schema.js";
  *                    no-progress fuse. Deliberately NOT wired to a producer
  *                    kind or a CLI case here; the name is reserved so the id
  *                    scheme (`tactic-hold-no-progress-<source>`) is documented
- *                    and cannot be claimed for something else.
+ *                    and cannot be claimed for something else. `ci-stalled`
+ *                    below was minted separately rather than claiming this
+ *                    slug: `no-progress` is reserved for a general any-phase
+ *                    no-progress fuse (a different future tactic), while
+ *                    `ci-stalled` is a specific single-cause bound on one
+ *                    sensor's verdict (the CI-pending observation). Claiming
+ *                    the general slug for a specific cause would make the
+ *                    eventual general fuse unnameable, and would make
+ *                    `tactic-hold-no-progress-<source>` ambiguous between two
+ *                    producers.
+ *  - `ci-stalled`  — ci-pending-stalled: the autonomous tick observed the
+ *                    node's draft-PR CI verdict as `pending` on the SAME head
+ *                    SHA for DISPATCH_CI_PENDING_STRIKE_CAP consecutive
+ *                    observations (checks never started, or a run that never
+ *                    concluded). Unlike `worktree-residue` this DOES have a
+ *                    plausible self-heal (checks may still start), so it sits
+ *                    behind a strike ladder rather than escalating on first
+ *                    occurrence. IMPLEMENTED.
  */
 export const HOLD_KINDS = [
   "provision-conflict",
   "fix-attempt-cap",
   "worktree-residue",
+  "ci-pending-stalled",
 ] as const;
 
 export type HoldKind = (typeof HOLD_KINDS)[number];
@@ -72,6 +90,7 @@ const KIND_SLUGS: Record<HoldKind, string> = {
   "provision-conflict": "conflict",
   "fix-attempt-cap": "fix-cap",
   "worktree-residue": "residue",
+  "ci-pending-stalled": "ci-stalled",
 };
 
 /**
@@ -308,7 +327,7 @@ function parseArgs(argv: string[]): Args {
 
   if (sourceId === null || sourceId === "") fail("--source <node-id> is required");
   if (kind === null) {
-    fail("--kind <provision-conflict|fix-attempt-cap|worktree-residue> is required");
+    fail(`--kind <${HOLD_KINDS.join("|")}> is required`);
   }
   if (!isHoldKind(kind)) {
     fail(`--kind must be one of ${HOLD_KINDS.join("|")}, got "${kind}"`);

--- a/packages/intentionsutil/scripts/resolve-hold
+++ b/packages/intentionsutil/scripts/resolve-hold
@@ -75,7 +75,7 @@
 # `blocked_by` still names the hold is rejected by validate-graph, so prune
 # ordering is a separate concern (the owed-prune census), not this script's.
 #
-# Usage: resolve-hold <source-node-id> [--kind <provision-conflict|fix-attempt-cap|worktree-residue>]
+# Usage: resolve-hold <source-node-id> [--kind <provision-conflict|fix-attempt-cap|worktree-residue|ci-pending-stalled>]
 #
 # --kind defaults to `provision-conflict` (the Lane-3 case). It selects which
 #   hold id is resolved, since a source can in principle carry one hold per kind.
@@ -106,7 +106,7 @@ DUMP_NODE_TS="$SCRIPT_DIR/dump-node.ts"
 WRITE_NODE_TS="$SCRIPT_DIR/write-node.ts"
 GRAPH_COMMIT="$SCRIPT_DIR/graph-commit"
 
-USAGE="usage: resolve-hold <source-node-id> [--kind <provision-conflict|fix-attempt-cap|worktree-residue>]"
+USAGE="usage: resolve-hold <source-node-id> [--kind <provision-conflict|fix-attempt-cap|worktree-residue|ci-pending-stalled>]"
 
 SOURCE_ID=""
 KIND="provision-conflict"

--- a/packages/intentionsutil/test/hold-node-decide.test.ts
+++ b/packages/intentionsutil/test/hold-node-decide.test.ts
@@ -3,6 +3,7 @@ import { validateNode, type IntentionNode } from "../src/schema.js";
 import {
   decideHold,
   holdIdFor,
+  RESERVED_KIND_SLUGS,
   RESOLUTION_SENTENCE,
   type HoldInput,
 } from "../scripts/hold-node-decide.js";
@@ -72,6 +73,12 @@ describe("holdIdFor", () => {
   it("derives the residue slug id for worktree-residue", () => {
     expect(holdIdFor("worktree-residue", "tactic-some-work")).toBe(
       "tactic-hold-residue-some-work",
+    );
+  });
+
+  it("derives the ci-stalled slug id for ci-pending-stalled", () => {
+    expect(holdIdFor("ci-pending-stalled", "tactic-foo")).toBe(
+      "tactic-hold-ci-stalled-foo",
     );
   });
 
@@ -163,8 +170,44 @@ describe("decideHold dispositions", () => {
     });
   });
 
+  it("uses the ci-stalled hold id when the kind is ci-pending-stalled", () => {
+    const d = decideHold([source()], input({ kind: "ci-pending-stalled" }));
+    expect(d.disposition).toBe("NONE");
+    expect(d.hold_id).toBe("tactic-hold-ci-stalled-some-work");
+    expect(d.source_edge_needed).toBe(true);
+    expect(d.node?.attributes).toEqual({
+      hold_for: SOURCE,
+      hold_kind: "ci-pending-stalled",
+    });
+    expect(d.node_body).toContain(RESOLUTION_SENTENCE);
+  });
+
   it("throws when the source node is not in the store", () => {
     expect(() => decideHold([], input())).toThrow(/is not in the store/);
+  });
+});
+
+describe("reserved kind slugs", () => {
+  it("keeps no-progress reserved and unclaimed by any implemented kind", () => {
+    expect(RESERVED_KIND_SLUGS).toContain("no-progress");
+    for (const [kind, d] of [
+      ["provision-conflict", decideHold([source()], input())],
+      [
+        "fix-attempt-cap",
+        decideHold([source()], input({ kind: "fix-attempt-cap" })),
+      ],
+      [
+        "worktree-residue",
+        decideHold([source()], input({ kind: "worktree-residue" })),
+      ],
+      [
+        "ci-pending-stalled",
+        decideHold([source()], input({ kind: "ci-pending-stalled" })),
+      ],
+    ] as const) {
+      expect(holdIdFor(kind, SOURCE)).not.toContain("no-progress");
+      expect(d.hold_id).not.toContain("no-progress");
+    }
   });
 });
 


### PR DESCRIPTION
## Context

The autonomous dispatch tick has a cap-and-escalate convention for every mechanical stuck state except one: a graph-native tactic whose draft PR's CI never reaches a verdict. Two independent surfaces observe pending CI every tick and do nothing but skip forever — `graph-select-target`'s `qa|review` selection gate, and `reconcile-graph-review-stall`'s sweep over reviewed-marker-excluded nodes (whose armed auto-merge can never fire). Neither has a counter, a hold, a park, or an operator surface.

Implements node `tactic-autonomous-ci-pending-liveness-bound` (2026-07-31 `/align-tactics` round).

## What this adds

- **Unit 1** — a fourth hold kind, `ci-pending-stalled` (slug `ci-stalled`), registered in `packages/intentionsutil/scripts/hold-node-decide.ts`'s `HOLD_KINDS`/`KIND_SLUGS`, with matching usage-string updates in `hold-node` and `resolve-hold`, and new `hold-node-decide.test.ts` cases.
- **Unit 2** — a SHA-keyed strike sidecar (`ci_pending_strike_bump`/`ci_pending_strike_clear` in `lib.sh`, `DISPATCH_CI_PENDING_STRIKE_CAP=8`) and the selection-surface producer in `graph-select-target`: below cap it emits a `ci-pending (strike n/8)` skip reason; at cap it lands a `ci-pending-stalled` hold via `hold-node`. The explicit `--node` lane and an unreadable PR are exempt. `dispatch-graph-execute`'s exit-10 intra-tick race is documented as deliberately uncounted (the sustained form is caught here).
- **Unit 3** — the same bound at `reconcile-graph-review-stall`'s independent observation point (reviewed-marker-excluded nodes never revisit the selector), sharing the sidecar and a hold slot budget shared 1-per-sweep with the existing conflict-hold route.

## Test plan

- [x] `.claude/skills/dispatch-propagate/scripts/run-unit-tests.sh --pr-scripts` — all suites pass
- [x] `npx vitest run --project packages/intentionsutil --root .` — 722/722 pass
- [x] `.claude/skills/dispatch-propagate/scripts/run-typecheck.sh --app packages/intentionsutil` — clean
- [x] `.claude/skills/dispatch-propagate/scripts/run-lint.sh --prose` — clean
- [x] Hold-kind round trip via `hold-node-decide.ts` — confirmed `ci-pending-stalled` produces `hold_id: tactic-hold-ci-stalled-autonomous-ci-pending-liveness-bound`, `disposition: NONE`; confirmed `no-progress` is still rejected
- [x] No graph write below cap — `intentions/` clean after all fixture test runs
- [ ] Manual/production: watch the tick journal for `ci-pending (strike n/8)` skip reasons on a genuinely-waiting node and confirm the count resets to 1 once CI concludes or a new push lands
