### PR TITLE
assert-node-fresh: refuse a stale-based wholesale body write in /align-tactics instead of silently clobbering it

### DIFF
--- a/.claude/skills/align-tactics/SKILL.md
+++ b/.claude/skills/align-tactics/SKILL.md
@@ -43,7 +43,8 @@ It inherits along two axes, each with a part it deliberately does **not** take:
   target is the `<strategy-node-id>` argument; sequencing is `blocked_by`
   frontmatter edges, not a PR-precondition scan.
 - **From `/align-strategy` (`.claude/skills/align-strategy/SKILL.md`)** — take
-  the write path (`write-node.ts` → body `Edit` → `graph-commit`), the
+  the write path (`write-node.ts` → `assert-node-fresh` → body `Edit` →
+  `graph-commit`), the
   citation of `validateGraph` rules by number, and the register. Invert the
   interaction model: `/align-strategy` is interview-driven; **`/align-tactics`
   is autonomous and never calls `AskUserQuestion`**. This inversion is the
@@ -193,6 +194,9 @@ and its existing non-draft children — the Idempotency section's census script
 finds both, and its `classification` field tells a draft (`phase` absent **and**
 `office_hours` unset) from a born-parked child (`phase` absent **with** `office_hours` set,
 which is decided human-owned work, **not** a draft — leave it out of the input).
+Dump the base manifest for every pre-existing node this round will edit
+**here**, at this read, before any write — see `references/write-path.md`'s
+"Capture a base manifest" section for the recipe.
 
 **Build `args`.**
 
@@ -290,8 +294,10 @@ The Workflow authored no files; this session lands every graph write. The
 shape of the work, in order: **mint** real node ids for the Workflow's
 `temp_ref`s and rewrite edges, **dump** a base manifest for every
 pre-existing node this round touches (`dump-node.ts`), write each node's
-**frontmatter** (`write-node.ts`), `Edit` in each planned tactic's **body**
-(the Workflow's `body_markdown`), **land** the whole round in one or a few
+**frontmatter** (`write-node.ts`), **assert** freshness against
+`origin/main` for every id about to receive a body write
+(`assert-node-fresh`), `Edit` in each planned tactic's **body** (the
+Workflow's `body_markdown`), **land** the whole round in one or a few
 `graph-commit --base` calls, then **validate**
 (`validate-graph.ts`). Parks (`result.parks`) are written the same way, as
 `office_hours: {reason, since}` on the target node. `graph-commit` has two
@@ -299,10 +305,11 @@ distinct exit-1 cases — a parking message (a concurrent writer landed first;
 this session's content is unlanded but preserved on disk) versus a
 busy-main-exhaustion error (nothing landed, no park) — either way, report and
 stop rather than retry automatically. See `references/write-path.md` for the
-full write-node.ts/dump-node.ts/graph-commit mechanics, exit-1 discrimination,
-park-writing, and the fingerprint/round-accounting details (per-strategy
-`execution.strategy_fingerprint` map via `strategy-fingerprint.ts`, and the
-strategy's `rounds.count`/`last_completed`/`last_aligned` bookkeeping).
+full write-node.ts/dump-node.ts/assert-node-fresh/graph-commit mechanics,
+exit-1 discrimination, park-writing, and the fingerprint/round-accounting
+details (per-strategy `execution.strategy_fingerprint` map via
+`strategy-fingerprint.ts`, and the strategy's
+`rounds.count`/`last_completed`/`last_aligned` bookkeeping).
 
 Once the round has landed and `validate-graph.ts` is clean, record the
 terminal disposition:

--- a/.claude/skills/align-tactics/references/tactic-target.md
+++ b/.claude/skills/align-tactics/references/tactic-target.md
@@ -33,7 +33,10 @@ single-node graph write it returns (via the write path in
 
 **Read the node and decide draft/raw vs soft-frozen.** A frozen tactic
 target is either draft/raw or soft-frozen; read its frontmatter to tell
-which. This session picks the `phase` value it will land, but the
+which. Capture the single-node base manifest here, at this read, before any
+write — see `references/write-path.md`'s "Capture a base manifest" section
+for the recipe; do not restate it here. This session picks the `phase` value
+it will land, but the
 finalize-vs-re-plan *judgment* (what the reconciled body should say) is the
 Workflow's tactic-mode job, not this thread's:
 
@@ -108,7 +111,8 @@ mode.
 single-node result lands through the **same** apply-result writer as the
 strategy-target flow, with one node (not a subtree) to write: `dump-node.ts`
 (base manifest) → `write-node.ts` (frontmatter, with the `phase` decided
-above) → body `Edit` (the Workflow's `body_markdown`) → `graph-commit
+above) → `assert-node-fresh` (freshness assertion against `origin/main`) →
+body `Edit` (the Workflow's `body_markdown`) → `graph-commit
 --base`. Do **not** duplicate that writer here; the only tactic-mode
 specializations are the `phase` choice above (`implement` for a finalize,
 the preserved in-flight phase for a re-plan) and the single-strategy

--- a/.claude/skills/align-tactics/references/write-path.md
+++ b/.claude/skills/align-tactics/references/write-path.md
@@ -65,6 +65,22 @@ BASE=$(npx tsx packages/intentionsutil/scripts/dump-node.ts \
 packages/intentionsutil/scripts/graph-commit --base "$BASE" <tactic-id>
 ```
 
+**Capture the manifest at the read, before any write, and never re-dump over
+an edited worktree.** The manifest's claim is "this is the content that was
+read" — so it must be taken at the session's **read** step (the
+strategy-target flow's "Gather the input", or the tactic-target flow's node
+read), before `write-node.ts` or the body `Edit` touches anything, not later
+in Step 2. Do **not** re-run `dump-node.ts` in a worktree that already holds
+an edit, including during a `graph-commit` timeout/`git reset --mixed`
+recovery — a dump taken after the writer's own edit records that in-flight
+content as the base, defeating the compare-and-swap entirely. If the original
+manifest is lost, recompute the base directly with `git rev-parse
+origin/main:intentions/<id>.md` rather than re-dumping. This is not
+theoretical: on 2026-07-31 a re-dump after the edit made `base == ours`, so
+`check_base_freshness()`'s three-way merge resolved cleanly to `theirs` and
+silently reverted a 310-line finalized plan body to a 2-line draft stub,
+reporting nothing.
+
 ## Artifact-owner placement (strategy clarification 27)
 
 `serves` names the strategy that actually owns the artifact the tactic
@@ -101,7 +117,37 @@ author) instead of assigning ownership by proximity.
    npx tsx packages/intentionsutil/scripts/write-node.ts --file "$TMPDIR/tactic.json"
    ```
 
-2. **Plan body via `Edit`.** `write-node.ts` lands only frontmatter;
+2. **Freshness assertion before the body write.** The body write is a
+   *wholesale replacement* — `body_markdown` is not merged into the existing
+   body — so it must be preceded by a freshness assertion against the same ref
+   the write will land on. Run, from the worktree:
+
+   ```bash
+   .claude/skills/dispatch-propagate/scripts/assert-node-fresh \
+     --base "$BASE" <id> [<id> ...]
+   ```
+
+   naming **every** id this round will write a body for. Exit 0 means no
+   named node moved on `origin/main` since the base was captured — proceed.
+   A non-zero exit means the node moved (or the fetch failed, or a
+   pre-existing id is missing from `$BASE`): **do not write the body.** The
+   guard compares the recorded base blob against `origin/main`, never the
+   on-disk file, so the frontmatter `write-node.ts` just landed does not
+   trip it.
+
+   On a refusal naming a moved node, take **one** bounded retry: re-read that
+   node from `origin/main` (`git show origin/main:intentions/<id>.md`),
+   rebuild `args` from the fresh body, re-invoke the Workflow once, capture a
+   **new** base manifest into a **fresh `--out-dir`** (never a second dump
+   into the old one, and never a dump over an edited file), and re-run
+   `assert-node-fresh`. If the second check also refuses, or the refusal is a
+   fetch failure or a missing `--base` entry, **park** the node —
+   `office_hours: {reason, since}` per the Parks section below — with a
+   reason naming the intervening commit and recommending a fresh
+   `/align-tactics <node-id>` round. Never overwrite, and never end the pass
+   without one of these two dispositions.
+
+3. **Plan body via `Edit`.** `write-node.ts` lands only frontmatter;
    `writeNode` preserves an existing tactic body verbatim across
    frontmatter-only rewrites. For each tactic with a non-null
    `body_markdown` (the Workflow merged the authored plan onto the tactic
@@ -112,7 +158,7 @@ author) instead of assigning ownership by proximity.
    implement-phase body — only its statement and the reason it needs a
    human.
 
-3. **Land via `graph-commit`.** One `graph-commit` per tactic, or a small
+4. **Land via `graph-commit`.** One `graph-commit` per tactic, or a small
    batch (e.g. a parent plus its immediate children, the drift-clarified
    strategy alongside the round's tactics, or a split-parent tactic
    alongside its new born-parked sibling) in one call:

--- a/.claude/skills/align-tactics/references/write-path.md
+++ b/.claude/skills/align-tactics/references/write-path.md
@@ -73,10 +73,26 @@ read), before `write-node.ts` or the body `Edit` touches anything, not later
 in Step 2. Do **not** re-run `dump-node.ts` in a worktree that already holds
 an edit, including during a `graph-commit` timeout/`git reset --mixed`
 recovery — a dump taken after the writer's own edit records that in-flight
-content as the base, defeating the compare-and-swap entirely. If the original
-manifest is lost, recompute the base directly with `git rev-parse
-origin/main:intentions/<id>.md` rather than re-dumping. This is not
-theoretical: on 2026-07-31 a re-dump after the edit made `base == ours`, so
+content as the base, defeating the compare-and-swap entirely.
+
+**A lost manifest is an unverifiable state — park, do not recompute.** Never
+manufacture a base from the *current* remote tip (`git rev-parse
+origin/main:intentions/<id>.md`): that records content the session never read,
+so `assert-node-fresh` compares the recorded blob against an identical
+`FETCH_HEAD` blob and always exits 0, and `graph-commit`'s
+`check_base_freshness()` sees `base == theirs` and resolves the three-way
+merge wholesale to `ours` — silently discarding anything a concurrent writer
+landed between the read and the recompute. It is the same silent revert as the
+2026-07-31 incident with the operands swapped. When the manifest is gone, park
+the node — `office_hours: {reason, since}` per the Parks section below — with
+a reason naming the lost manifest and recommending a fresh `/align-tactics
+<node-id>` round. The only admissible reconstruction is one that names the
+blob the session actually read — the provision-time sha (`git rev-parse
+<provision-time-sha>:intentions/<id>.md`) or the sha recorded in the worker's
+provisioning record — never the current tip.
+
+This is not theoretical: on 2026-07-31 a re-dump after the edit made
+`base == ours`, so
 `check_base_freshness()`'s three-way merge resolved cleanly to `theirs` and
 silently reverted a 310-line finalized plan body to a 2-line draft stub,
 reporting nothing.
@@ -135,11 +151,22 @@ author) instead of assigning ownership by proximity.
    on-disk file, so the frontmatter `write-node.ts` just landed does not
    trip it.
 
-   On a refusal naming a moved node, take **one** bounded retry: re-read that
-   node from `origin/main` (`git show origin/main:intentions/<id>.md`),
-   rebuild `args` from the fresh body, re-invoke the Workflow once, capture a
-   **new** base manifest into a **fresh `--out-dir`** (never a second dump
-   into the old one, and never a dump over an edited file), and re-run
+   On a refusal naming a moved node, take **one** bounded retry. Step 1 above
+   already rewrote the node's frontmatter on disk, and `dump-node.ts` hashes
+   the **on-disk** file — so the retry must first restore the worktree copy to
+   the remote content, or the new manifest would record this writer's own
+   in-flight frontmatter as the base. In order:
+
+   ```bash
+   git fetch origin main
+   git checkout origin/main -- intentions/<id>.md
+   ```
+
+   Then re-read that node from `origin/main`
+   (`git show origin/main:intentions/<id>.md`), rebuild `args` from the fresh
+   body, re-invoke the Workflow once, capture a **new** base manifest into a
+   **fresh `--out-dir`** (never a second dump into the old one, and never a
+   dump over an edited file), re-run `write-node.ts`, and re-run
    `assert-node-fresh`. If the second check also refuses, or the refusal is a
    fetch failure or a missing `--base` entry, **park** the node —
    `office_hours: {reason, since}` per the Parks section below — with a

--- a/.claude/skills/dispatch-propagate/scripts/assert-node-fresh
+++ b/.claude/skills/dispatch-propagate/scripts/assert-node-fresh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# assert-node-fresh --base <manifest-or-id=blobsha> [--worktree <path>] <node-id>... —
+# per-node, PRE-WRITE freshness guard for wholesale intention-node body writes.
+# It refuses to let a session overwrite `intentions/<id>.md` when that node has
+# MOVED on origin/main since the session read it.
+#
+# WHY it exists, and why assert-worktree-fresh does not cover it. A worker's
+# worktree is a snapshot of `intentions/` taken at provision time and nothing
+# re-syncs it mid-session, so the worker's view of its OWN node is frozen at
+# spawn. `assert-worktree-fresh` is whole-tree and once-per-session (a
+# `rev-list --count HEAD..origin/main` at entry), and is skipped outright when
+# the worktree was cut fresh from origin/main by provision-node-worktree —
+# either way it cannot see an edit that lands twenty minutes later. And the
+# `/align-tactics` body write is a WHOLESALE replacement: `body_markdown` is not
+# merged into the existing body, it replaces it, so a stale-based write does not
+# conflict, does not flag and does not preserve — it silently discards a landed
+# edit. This script is the check at the point of loss: run it immediately before
+# the body write, against the same ref the write will land on.
+#
+# THE ONE SEMANTIC THAT MUST NOT BE GOT WRONG: this compares the RECORDED BASE
+# BLOB (from --base, produced by dump-node.ts at the session's READ step)
+# against origin/main. It NEVER hashes the on-disk file. By the time this runs,
+# the on-disk node has already been rewritten by write-node.ts (frontmatter), so
+# an on-disk hash would differ for a completely benign reason and the guard
+# would refuse every round. Hashing on-disk content here would also be precisely
+# the `align-tactics-dump-node-after-edit-wipes-content` mistake — a base
+# captured from the writer's own in-flight content — one layer earlier.
+#
+# This is a DETECT-ONLY primitive: it NEVER merges, NEVER writes, and NEVER runs
+# a tree-updating git op — reconciling a moved node (re-plan once, or park) is
+# the caller's job. It also does NOT disable any sandbox: the read-only
+# `git fetch origin main` to github.com is sandbox-allowlisted and every other
+# git call here is a read (`cat-file`, `rev-parse`, `log`), so sandbox handling
+# is purely a caller concern.
+#
+# Exit-code contract:
+#   0 — every named node's recorded base still matches origin/main (fresh).
+#   2 — usage error (flag-shaped positional, un-cd-able --worktree, missing
+#       --base, no node ids, or a malformed <id>=<blobsha> pair).
+#   1 — not a git repo, fetch failure, a named node MOVED on origin/main, or a
+#       pre-existing node named with no --base entry (no compare-and-swap at all).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+usage_error() {
+  echo "assert-node-fresh: $1" >&2
+  exit 2
+}
+
+declare -A BASE=()
+BASE_GIVEN=0
+WORKTREE=""
+IDS=()
+
+# --- --base parsing ---------------------------------------------------------
+# The <id>=<blobsha>-or-manifest-path convention's home is graph-commit:369-395
+# (add_blob_pair / parse_blob_arg). Copied, not sourced: graph-commit is an
+# executable with a main() and a process-wide EXIT trap, so sourcing it would
+# run the landing machinery.
+add_blob_pair() { # <pair>
+  local pair="$1" id sha
+  id="${pair%%=*}"
+  sha="${pair#*=}"
+  if [[ -z "$id" || "$id" == "$pair" || -z "$sha" ]]; then
+    usage_error "invalid --base entry '$pair' (expected <id>=<blobsha>)"
+  fi
+  BASE["$id"]="$sha"
+}
+
+parse_blob_arg() { # <arg>
+  local arg="$1"
+  if [[ -f "$arg" ]]; then
+    local line
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      [[ -z "$line" ]] && continue
+      add_blob_pair "$line"
+    done <"$arg"
+  else
+    add_blob_pair "$arg"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      [[ $# -ge 2 ]] || usage_error "--base requires a <manifest-path> or <id>=<blobsha> argument"
+      parse_blob_arg "$2"
+      BASE_GIVEN=1
+      shift 2
+      ;;
+    --worktree)
+      [[ $# -ge 2 ]] || usage_error "--worktree requires a path argument"
+      WORKTREE="$2"
+      shift 2
+      ;;
+    -*)
+      usage_error "flag-shaped argument '$1' is not a node id"
+      ;;
+    *)
+      IDS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "$BASE_GIVEN" -eq 0 ]]; then
+  usage_error "--base <manifest-path-or-id=blobsha> is required"
+fi
+if [[ "${#IDS[@]}" -eq 0 ]]; then
+  usage_error "at least one <node-id> is required"
+fi
+
+# --worktree is optional; default to the current working directory.
+WORKTREE="${WORKTREE:-$PWD}"
+cd "$WORKTREE" || usage_error "cannot cd to '$WORKTREE'"
+
+# Clear error before the network fetch when the target is not inside a git repo.
+if ! resolve_project_root >/dev/null 2>&1; then
+  echo "assert-node-fresh: '$WORKTREE' is not inside a git repository" >&2
+  exit 1
+fi
+
+# One fetch up front, for every named id. A failed fetch is never license to
+# proceed on unverified local state.
+if ! git fetch origin main >&2; then
+  echo "assert-node-fresh: git fetch origin main failed in '$WORKTREE' — cannot verify freshness, refusing to proceed on unverified local state" >&2
+  exit 1
+fi
+
+# Per-id comparison, mirroring check_base_freshness() (graph-commit:467-477).
+# FETCH_HEAD, not origin/main: it is the ref this fetch just wrote, and it does
+# not depend on a remote-tracking ref being configured in this worktree.
+REFUSED=0
+for id in "${IDS[@]}"; do
+  path="intentions/$id.md"
+  if git cat-file -e "FETCH_HEAD:$path" 2>/dev/null; then
+    origin_sha="$(git rev-parse "FETCH_HEAD:$path")"
+  else
+    origin_sha="<absent>"
+  fi
+  recorded="${BASE[$id]:-<unrecorded>}"
+
+  if [[ "$recorded" == "$origin_sha" ]]; then
+    continue                     # fresh — the node has not moved
+  fi
+  if [[ "$recorded" == "<unrecorded>" && "$origin_sha" == "<absent>" ]]; then
+    continue                     # created this round: no origin blob, no --base entry
+  fi
+  if [[ "$recorded" == "<unrecorded>" ]]; then
+    # Pre-existing on origin/main but carrying no --base entry: the write would
+    # land with no compare-and-swap at all.
+    echo "assert-node-fresh: '$id' exists on origin/main (blob $origin_sha) but has no --base entry — the body write would land with no compare-and-swap; capture a base manifest at the read step (dump-node.ts) and pass it via --base" >&2
+    REFUSED=$((REFUSED + 1))
+    continue
+  fi
+
+  # Moved. Name the intervening commit — that is what lets the caller decide
+  # between one bounded re-plan and handing back.
+  moved_by="$(git log -1 --format='%h %ad %s' --date=short FETCH_HEAD -- "$path" 2>/dev/null || true)"
+  echo "assert-node-fresh: '$id' MOVED on origin/main since the base was captured (recorded $recorded, origin now $origin_sha) — intervening commit: ${moved_by:-<unknown>}. Do NOT write the body: re-read the node from origin/main and re-plan once, or park it." >&2
+  REFUSED=$((REFUSED + 1))
+done
+
+# Every named id is checked before exiting, so one call names them all — the
+# same reason check_base_freshness() keeps iterating (graph-commit:520-524).
+if [[ "$REFUSED" -gt 0 ]]; then
+  echo "assert-node-fresh: refusing — $REFUSED of ${#IDS[@]} node(s) are not fresh against origin/main" >&2
+  exit 1
+fi
+
+# stdout stays free for any future machine-readable output; the OK note goes to
+# stderr.
+echo "assert-node-fresh: ${#IDS[@]} node(s) are fresh against origin/main" >&2
+exit 0

--- a/.claude/skills/dispatch-propagate/scripts/test-align-tactics-write-path-freshness.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-align-tactics-write-path-freshness.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Doctrine ratchet for the /align-tactics write path's freshness-assertion
+# mandate (tactic-node-body-stale-in-worker-worktree, Unit 3). A worker's
+# worktree pins intentions/ at provision time; nothing re-syncs it mid-session,
+# so a wholesale body Edit landed against a stale base silently discards a
+# concurrent edit to the same node. Unit 2 mandated assert-node-fresh
+# immediately before that body Edit across three doctrine files
+# (references/write-path.md, references/tactic-target.md, SKILL.md). This
+# suite is the guard that a future edit cannot silently drop that mandate.
+#
+# Modeled on test-fix-checks-cas-guard.sh: a prose/fenced-block guard over
+# skill doctrine, not a functional test harness over a script.
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=dispatch-test-fixture.sh
+source "$FIXTURE_DIR/dispatch-test-fixture.sh"
+
+echo "=== align-tactics: write-path freshness assertion doctrine guard ==="
+#
+# assert-node-fresh (.claude/skills/dispatch-propagate/scripts/assert-node-fresh)
+# is the per-node, pre-write freshness primitive that catches a worker whose
+# worktree-pinned view of its own node went stale. It is only a guard if the
+# doctrine actually calls it, in the right place, with a real disposition on
+# refusal. The assertions below bind to each of those three requirements
+# individually rather than a single pass/fail, so a regression in any one of
+# them is legible on its own.
+#
+# If an expectation below legitimately changes (e.g. the doctrine's wording is
+# reworded, or the step moves), update this row AND confirm every site still
+# carries the step — never drop a row or an assertion just to make this suite
+# green (.claude/rules/test-integrity.md).
+
+GUARD_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+WRITE_PATH="$GUARD_ROOT/.claude/skills/align-tactics/references/write-path.md"
+TACTIC_TARGET="$GUARD_ROOT/.claude/skills/align-tactics/references/tactic-target.md"
+ALIGN_TACTICS_SKILL="$GUARD_ROOT/.claude/skills/align-tactics/SKILL.md"
+ASSERT_NODE_FRESH="$GUARD_ROOT/.claude/skills/dispatch-propagate/scripts/assert-node-fresh"
+
+# --- 1. write-path.md mentions assert-node-fresh at all ---------------------
+
+if [[ ! -f "$WRITE_PATH" ]]; then
+  TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
+  echo "  FAIL: write-path.md mentions assert-node-fresh: file missing: .claude/skills/align-tactics/references/write-path.md"
+else
+  actual=$(grep -cF -- 'assert-node-fresh' "$WRITE_PATH" || true)
+  if [[ "$actual" -gt 0 ]]; then actual="present"; else actual="absent"; fi
+  assert_eq "write-path.md mentions assert-node-fresh" "present" "$actual"
+fi
+
+# --- 2. Ordering within the "Per node (tactic or gate)" section -------------
+#
+# A file-global occurrence count would stay correct even if the step drifted
+# to the wrong position in the sequence — exactly the regression this
+# assertion exists to catch — so this binds to byte ordering within the
+# section, not a count.
+
+if [[ ! -f "$WRITE_PATH" ]]; then
+  TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
+  echo "  FAIL: write-path.md orders assert-node-fresh between write-node.ts and the body Edit: file missing"
+else
+  actual=$(awk '
+    /^## Per node \(tactic or gate\)/ { insec = 1; next }
+    insec && /^## / { insec = 0 }
+    insec { buf = buf $0 "\n" }
+    END {
+      wn = index(buf, "write-node.ts --file")
+      anf = index(buf, "assert-node-fresh")
+      ed = index(buf, "Plan body via `Edit`")
+      if (wn == 0 || anf == 0 || ed == 0) {
+        print "missing-marker: write-node.ts=" wn " assert-node-fresh=" anf " body-edit=" ed
+      } else if (wn < anf && anf < ed) {
+        print "ordered"
+      } else {
+        print "misordered: write-node.ts=" wn " assert-node-fresh=" anf " body-edit=" ed
+      }
+    }
+  ' "$WRITE_PATH")
+  assert_eq "write-path.md orders assert-node-fresh between write-node.ts and the body Edit within 'Per node (tactic or gate)'" \
+    "ordered" "$actual"
+fi
+
+# --- 3. tactic-target.md mentions assert-node-fresh --------------------------
+
+if [[ ! -f "$TACTIC_TARGET" ]]; then
+  TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
+  echo "  FAIL: tactic-target.md mentions assert-node-fresh: file missing: .claude/skills/align-tactics/references/tactic-target.md"
+else
+  actual=$(grep -cF -- 'assert-node-fresh' "$TACTIC_TARGET" || true)
+  if [[ "$actual" -gt 0 ]]; then actual="present"; else actual="absent"; fi
+  assert_eq "tactic-target.md mentions assert-node-fresh" "present" "$actual"
+fi
+
+# --- 4. SKILL.md mentions assert-node-fresh ----------------------------------
+
+if [[ ! -f "$ALIGN_TACTICS_SKILL" ]]; then
+  TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
+  echo "  FAIL: align-tactics SKILL.md mentions assert-node-fresh: file missing: .claude/skills/align-tactics/SKILL.md"
+else
+  actual=$(grep -cF -- 'assert-node-fresh' "$ALIGN_TACTICS_SKILL" || true)
+  if [[ "$actual" -gt 0 ]]; then actual="present"; else actual="absent"; fi
+  assert_eq "align-tactics SKILL.md mentions assert-node-fresh" "present" "$actual"
+fi
+
+# --- 5. write-path.md states the refusal disposition -------------------------
+#
+# A refusal must resolve to exactly one of a bounded retry or an office_hours
+# park — never a silent fourth exit. Bind to both concepts appearing in the
+# same section as assert-node-fresh, not just anywhere in the file.
+
+if [[ ! -f "$WRITE_PATH" ]]; then
+  TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
+  echo "  FAIL: write-path.md states the refusal disposition (bounded retry + office_hours): file missing"
+else
+  actual=$(awk '
+    /^## Per node \(tactic or gate\)/ { insec = 1; next }
+    insec && /^## / { insec = 0 }
+    insec { buf = buf $0 "\n" }
+    END {
+      anf = index(buf, "assert-node-fresh")
+      retry = (index(buf, "bounded retry") > 0)
+      oh = (index(buf, "office_hours") > 0)
+      if (anf > 0 && retry && oh) { print "disposition-present" }
+      else { print "disposition-missing: assert-node-fresh=" (anf>0) " bounded-retry=" retry " office_hours=" oh }
+    }
+  ' "$WRITE_PATH")
+  assert_eq "write-path.md states the refusal disposition (bounded retry + office_hours) alongside assert-node-fresh" \
+    "disposition-present" "$actual"
+fi
+
+# --- 6. assert-node-fresh exists and is executable ---------------------------
+
+if [[ ! -f "$ASSERT_NODE_FRESH" ]]; then
+  TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1))
+  echo "  FAIL: assert-node-fresh exists and is executable: file missing: .claude/skills/dispatch-propagate/scripts/assert-node-fresh"
+elif [[ -x "$ASSERT_NODE_FRESH" ]]; then
+  assert_eq "assert-node-fresh exists and is executable" "executable" "executable"
+else
+  assert_eq "assert-node-fresh exists and is executable" "executable" "not-executable"
+fi
+
+report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-assert-node-fresh.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-assert-node-fresh.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Tests for assert-node-fresh — the per-node, pre-write freshness guard
+# (tactic-node-body-stale-in-worker-worktree Unit 1).
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=dispatch-test-fixture.sh
+source "$FIXTURE_DIR/dispatch-test-fixture.sh"
+
+# ============================================================================
+# Fixture shape, copied from test-assert-worktree-fresh.sh:15-64.
+#
+# assert-node-fresh derives its script location via SCRIPT_DIR and sources
+# lib.sh from there, so the fixture copies the script under test PHYSICALLY
+# (not a symlink) alongside lib.sh. No network is used: `origin` is a local
+# bare repo reached by file path, and a moved node is simulated by pushing an
+# edit from a SECOND local clone, which advances origin/main without the
+# worktree under test ever changing.
+# ============================================================================
+
+ANF_ROOT=$(mktemp -d)
+ANF_BARE=$(mktemp -d)
+ANF_CLONE=$(mktemp -d)
+ANF_OFFLINE=$(mktemp -d)
+ANF_SCRIPTS="$ANF_ROOT/.claude/skills/dispatch-propagate/scripts"
+mkdir -p "$ANF_SCRIPTS"
+cp "$SCRIPT_DIR"/assert-node-fresh "$SCRIPT_DIR"/lib.sh "$ANF_SCRIPTS/"
+chmod +x "$ANF_SCRIPTS/assert-node-fresh"
+ANF_SCRIPT="$ANF_SCRIPTS/assert-node-fresh"
+
+# Bare "origin" remote, reached only via local file path — no network.
+git init -q --bare -b main "$ANF_BARE"
+
+# The worktree under test, carrying two intention nodes.
+git init -q -b main "$ANF_ROOT"
+git -C "$ANF_ROOT" config user.email t@t
+git -C "$ANF_ROOT" config user.name t
+mkdir -p "$ANF_ROOT/intentions"
+printf 'body-alpha\n' > "$ANF_ROOT/intentions/tactic-alpha.md"
+printf 'body-beta\n'  > "$ANF_ROOT/intentions/tactic-beta.md"
+git -C "$ANF_ROOT" add -A
+git -C "$ANF_ROOT" commit -q -m seed
+git -C "$ANF_ROOT" remote add origin "$ANF_BARE"
+git -C "$ANF_ROOT" push -q origin main
+git -C "$ANF_ROOT" fetch -q origin main
+
+# The base manifest, captured at "read" time — <id>=<blobsha>, one per line,
+# the same format dump-node.ts writes.
+ANF_MANIFEST="$ANF_ROOT/base-manifest.txt"
+ALPHA_BASE=$(git -C "$ANF_ROOT" rev-parse HEAD:intentions/tactic-alpha.md)
+BETA_BASE=$(git -C "$ANF_ROOT" rev-parse HEAD:intentions/tactic-beta.md)
+{
+  echo "tactic-alpha=$ALPHA_BASE"
+  echo "tactic-beta=$BETA_BASE"
+} > "$ANF_MANIFEST"
+
+# --- 1. fresh ---------------------------------------------------------------
+echo "Test: assert-node-fresh — recorded base equals origin's blob exits 0"
+anf_out=$(cd "$ANF_ROOT" && "$ANF_SCRIPT" --base "$ANF_MANIFEST" tactic-alpha 2>/dev/null) \
+  && anf_rc=0 || anf_rc=$?
+assert_eq "assert-node-fresh: fresh node exits 0" "0" "$anf_rc"
+
+# --- 3. on-disk edited, origin unmoved --------------------------------------
+# The semantics guard for the "never hash the on-disk file" rule: by the time
+# this runs in production, write-node.ts has already rewritten the frontmatter,
+# so an on-disk hash would refuse every round.
+echo "Test: assert-node-fresh — on-disk edit with origin unmoved still exits 0"
+printf 'body-alpha REWRITTEN BY write-node.ts\n' > "$ANF_ROOT/intentions/tactic-alpha.md"
+anf_disk_out=$(cd "$ANF_ROOT" && "$ANF_SCRIPT" --base "$ANF_MANIFEST" tactic-alpha 2>/dev/null) \
+  && anf_disk_rc=0 || anf_disk_rc=$?
+assert_eq "assert-node-fresh: on-disk edit does not trip the guard" "0" "$anf_disk_rc"
+
+# --- 4. created this round --------------------------------------------------
+echo "Test: assert-node-fresh — node created this round (no manifest entry, absent on origin) exits 0"
+anf_new_out=$(cd "$ANF_ROOT" && "$ANF_SCRIPT" --base "$ANF_MANIFEST" tactic-brand-new 2>/dev/null) \
+  && anf_new_rc=0 || anf_new_rc=$?
+assert_eq "assert-node-fresh: created-this-round node exits 0" "0" "$anf_new_rc"
+
+# --- 5. unguarded pre-existing ----------------------------------------------
+echo "Test: assert-node-fresh — pre-existing node absent from the manifest exits 1"
+ANF_ONLY_ALPHA="$ANF_ROOT/base-alpha-only.txt"
+echo "tactic-alpha=$ALPHA_BASE" > "$ANF_ONLY_ALPHA"
+anf_unguarded_out=$(cd "$ANF_ROOT" && "$ANF_SCRIPT" --base "$ANF_ONLY_ALPHA" tactic-beta 2>&1) \
+  && anf_unguarded_rc=0 || anf_unguarded_rc=$?
+assert_eq "assert-node-fresh: unguarded pre-existing node exits 1" "1" "$anf_unguarded_rc"
+case "$anf_unguarded_out" in
+  *"no --base entry"*) anf_unguarded_match="yes" ;;
+  *) anf_unguarded_match="no" ;;
+esac
+assert_eq "assert-node-fresh: unguarded message names the missing --base entry" \
+  "yes" "$anf_unguarded_match"
+
+# --- 2. moved ---------------------------------------------------------------
+echo "Test: assert-node-fresh — node moved on origin/main exits 1 naming the intervening commit"
+# A second local clone rewrites the node and pushes, advancing origin/main
+# without ANF_ROOT's tree ever changing.
+git clone -q "$ANF_BARE" "$ANF_CLONE"
+git -C "$ANF_CLONE" config user.email t@t
+git -C "$ANF_CLONE" config user.name t
+printf 'body-alpha CORRECTED SCOPE\n' > "$ANF_CLONE/intentions/tactic-alpha.md"
+git -C "$ANF_CLONE" add -A
+git -C "$ANF_CLONE" commit -q -m 'correct alpha scope'
+git -C "$ANF_CLONE" push -q origin main
+ANF_MOVED_SHA=$(git -C "$ANF_CLONE" rev-parse --short HEAD)
+
+anf_moved_out=$(cd "$ANF_ROOT" && "$ANF_SCRIPT" --base "$ANF_MANIFEST" tactic-alpha 2>&1) \
+  && anf_moved_rc=0 || anf_moved_rc=$?
+assert_eq "assert-node-fresh: moved node exits 1" "1" "$anf_moved_rc"
+case "$anf_moved_out" in
+  *"$ANF_MOVED_SHA"*) anf_moved_match="yes" ;;
+  *) anf_moved_match="no" ;;
+esac
+assert_eq "assert-node-fresh: moved message names the intervening commit's short sha" \
+  "yes" "$anf_moved_match"
+
+# --- 8. multi-id ------------------------------------------------------------
+echo "Test: assert-node-fresh — two ids, one moved and one fresh, exits 1 naming the moved id"
+anf_multi_out=$(cd "$ANF_ROOT" && "$ANF_SCRIPT" --base "$ANF_MANIFEST" tactic-alpha tactic-beta 2>&1) \
+  && anf_multi_rc=0 || anf_multi_rc=$?
+assert_eq "assert-node-fresh: multi-id with one moved exits 1" "1" "$anf_multi_rc"
+case "$anf_multi_out" in
+  *"'tactic-alpha' MOVED"*) anf_multi_match="yes" ;;
+  *) anf_multi_match="no" ;;
+esac
+assert_eq "assert-node-fresh: multi-id message names the moved id" "yes" "$anf_multi_match"
+case "$anf_multi_out" in
+  *"tactic-beta"*) anf_multi_clean="named" ;;
+  *) anf_multi_clean="not-named" ;;
+esac
+assert_eq "assert-node-fresh: multi-id message does not flag the fresh id" \
+  "not-named" "$anf_multi_clean"
+
+# --- 6. unreachable origin --------------------------------------------------
+echo "Test: assert-node-fresh — unreachable origin (fetch fails) exits 1"
+git init -q -b main "$ANF_OFFLINE"
+git -C "$ANF_OFFLINE" config user.email t@t
+git -C "$ANF_OFFLINE" config user.name t
+mkdir -p "$ANF_OFFLINE/intentions"
+printf 'body-alpha\n' > "$ANF_OFFLINE/intentions/tactic-alpha.md"
+git -C "$ANF_OFFLINE" add -A
+git -C "$ANF_OFFLINE" commit -q -m seed
+git -C "$ANF_OFFLINE" remote add origin /nonexistent/path/that/does/not/exist.git
+
+anf_offline_out=$(cd "$ANF_OFFLINE" && "$ANF_SCRIPT" --base "$ANF_MANIFEST" tactic-alpha 2>/dev/null) \
+  && anf_offline_rc=0 || anf_offline_rc=$?
+assert_eq "assert-node-fresh: unreachable origin exits 1" "1" "$anf_offline_rc"
+
+# --- 7. usage errors --------------------------------------------------------
+echo "Test: assert-node-fresh — usage errors exit 2"
+anf_noids_out=$(cd "$ANF_ROOT" && "$ANF_SCRIPT" --base "$ANF_MANIFEST" 2>/dev/null) \
+  && anf_noids_rc=0 || anf_noids_rc=$?
+assert_eq "assert-node-fresh: no node ids exits 2" "2" "$anf_noids_rc"
+
+anf_flag_out=$(cd "$ANF_ROOT" && "$ANF_SCRIPT" --base "$ANF_MANIFEST" --bogus 2>/dev/null) \
+  && anf_flag_rc=0 || anf_flag_rc=$?
+assert_eq "assert-node-fresh: flag-shaped positional exits 2" "2" "$anf_flag_rc"
+
+anf_nobase_out=$(cd "$ANF_ROOT" && "$ANF_SCRIPT" tactic-alpha 2>/dev/null) \
+  && anf_nobase_rc=0 || anf_nobase_rc=$?
+assert_eq "assert-node-fresh: missing --base exits 2" "2" "$anf_nobase_rc"
+
+anf_badpair_out=$(cd "$ANF_ROOT" && "$ANF_SCRIPT" --base 'no-equals-sign' tactic-alpha 2>/dev/null) \
+  && anf_badpair_rc=0 || anf_badpair_rc=$?
+assert_eq "assert-node-fresh: malformed <id>=<blobsha> pair exits 2" "2" "$anf_badpair_rc"
+
+rm -rf "$ANF_ROOT" "$ANF_BARE" "$ANF_CLONE" "$ANF_OFFLINE"
+
+report_results

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -214,6 +214,8 @@ jobs:
         run: .claude/skills/dispatch-propagate/scripts/test-dispatch-office-hours-strip-hook.sh
       - name: Run fix-checks node-lane doctrine ratchet
         run: .claude/skills/dispatch-propagate/scripts/test-fix-checks-cas-guard.sh
+      - name: Run align-tactics write-path freshness doctrine ratchet
+        run: .claude/skills/dispatch-propagate/scripts/test-align-tactics-write-path-freshness.sh
       - name: Run dispatch-chain worktree doctrine ratchet
         run: .claude/skills/dispatch-propagate/scripts/test-dispatch-chain-worktree-ratchet.sh
       - name: Run dispatch-conflict Lane 3 cwd doctrine ratchet


### PR DESCRIPTION
## Context

A worker's worktree is a snapshot of `intentions/` taken at provision time —
nothing re-syncs it mid-session. So a worker's view of its own node is frozen
at spawn, and any edit landed afterward is invisible to it. `/align-tactics`
finishes by writing the plan's `body_markdown` wholesale — not merged, a
plain replacement — so a stale-based write silently overwrites a landed edit
with no error at the point of loss. Observed live on 2026-07-31: a node's
scope was corrected on `origin/main` fifteen minutes after a worker's
worktree was provisioned; the worker spent the next several minutes
authoring a plan against the superseded body, and was stopped just before
the wholesale body write would have discarded the correction. Existing
guards don't cover it: `assert-worktree-fresh` is whole-tree/once-per-session
and can't see a later edit; `graph-commit --base`'s freshness check fires
only at land time, after the plan is authored and the body already
overwritten locally, and when the base itself was captured wrongly (a
re-dump after the edit) the merge silently reverts instead of parking.

## What changed

**Unit 1 — `assert-node-fresh`: a per-node, pre-write freshness primitive**

- New `.claude/skills/dispatch-propagate/scripts/assert-node-fresh`, mirrored
  from `assert-worktree-fresh`'s structure but comparing a recorded base
  manifest blob against `origin/main`'s current blob for each named node.
  Reuses `check_base_freshness()`'s git primitives and `graph-commit`'s
  `--base` CLI convention from `graph-commit` (copied, not sourced). Detect
  only: never merges, never writes, never runs a tree-updating git op.
- New `test-assert-node-fresh.sh` covering fresh, moved, on-disk-edited/
  origin-unmoved, created-this-round, unguarded pre-existing, unreachable
  origin, usage errors, and multi-id cases.

**Unit 2 — mandate the guard in the `/align-tactics` write path**

- `references/write-path.md`: added guidance to capture the base manifest at
  the read step (never re-dump over an already-edited worktree — the
  concrete cause of a separate 2026-07-31 silent revert), and inserted a new
  "Freshness assertion before the body write" step between the frontmatter
  write and the body `Edit`, with a disposition paragraph (one bounded
  retry, then `office_hours` park — never overwrite).
- `references/tactic-target.md` and `SKILL.md`: threaded the same
  `assert-node-fresh` step into their narration of the write sequence so the
  shared writer doesn't diverge across flows.

**Unit 3 — doctrine ratchet so the mandate cannot silently regress**

- New `test-align-tactics-write-path-freshness.sh`, a prose/fenced-block
  guard (modeled on `test-fix-checks-cas-guard.sh`) asserting `assert-node-fresh`
  is mentioned in all three doctrine files, and specifically that it's
  ordered between the frontmatter write and the body `Edit` within
  `write-path.md`'s "Per node" section — not just present anywhere in the
  file.
- Wired into `.github/workflows/unit-tests.yml`'s `hook-tests` job, since
  this suite's SUT lives outside `.claude/skills/dispatch-propagate/scripts/`
  and would otherwise never run in CI.

## Out of scope

This is explicitly interim scaffolding — `tactic-graph-ref-split` is the
greenfield fix (one shared graph store instead of per-worktree snapshots).
The mandate is not extended to other wholesale-body writers (`transition-node`,
`qa-fix` needs-main residue, `park-node`/`clear-park`) — those have their own
sibling tactics. No `PreToolUse` hook (considered and rejected: adds a
network fetch to every graph edit and false-fires on legitimate divergent-
content flows).

## Verification

- `bash -n assert-node-fresh` — clean.
- `test-assert-node-fresh.sh` — 16/16 passed.
- `test-align-tactics-write-path-freshness.sh` — 7/7 passed.

Graph node: tactic-node-body-stale-in-worker-worktree
