### PR TITLE
Fail a dispatch lane that cannot invoke its named instrument

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-verify-instrument-invocation
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-verify-instrument-invocation
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# dispatch-verify-instrument-invocation — independent, non-fabricable evidence
+# that a named instrument was actually invoked.
+#
+# The instrument gate in .claude/workflows/review-fix.js checks a receipt the
+# finder agent returns about itself. The honest "it failed" path is trustworthy
+# (an agent narrating its own rejection is not lying in the direction that
+# hurts), but `invoked: true` is fabricable: nothing stops an agent from
+# claiming it invoked the instrument when it did not. This script closes that
+# gap by reading the actual Claude session transcript record — the tool-call
+# history — rather than trusting the self-report.
+#
+# USAGE
+#   dispatch-verify-instrument-invocation --instrument <name> --kind skill|command
+#            [--skill <skill-arg>] [--command-pattern <ERE>]
+#            --since <ISO8601> --cwd <abs-path>
+#            [--wait-secs <N>]
+#
+#     --instrument       the instrument's registry name (e.g. code-review). Used
+#                        in the rejection-message regex and echoed in the output.
+#     --kind             skill   → look for a Skill tool_use whose .input.skill
+#                                  equals --skill
+#                        command → look for a Bash tool_use whose .input.command
+#                                  matches --command-pattern (ERE)
+#     --since            ISO8601 lower bound; only transcript records at or after
+#                        it are considered. Claude transcript timestamps are
+#                        zero-padded ISO8601, so a lexical >= comparison is
+#                        correct — no date parsing is needed or wanted.
+#     --cwd              exact match against each record's own `.cwd` field. This
+#                        is what makes the verdict safe when several concurrent
+#                        sessions/worktrees write into the transcript tree at
+#                        once. The project directory is deliberately NOT derived
+#                        from a path slug.
+#     --wait-secs        bounded poll (default 10) used ONLY when the first pass
+#                        found no evidence either way, since transcripts can lag
+#                        a moment behind real-time writes. This is
+#                        evidence-gathering, not a substitute invocation.
+#
+# WHAT IT SCANS
+#   Projects root: ${DISPATCH_AUDIT_PROJECTS_ROOT:-$HOME/.claude/projects} — the
+#   SAME env-var seam .claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
+#   uses, deliberately reusing the identical name so a caller can point both
+#   tools at one fixture root. A recursive find for *.jsonl picks up top-level
+#   session transcripts (<projectdir>/<sessionid>.jsonl), subagent transcripts
+#   (<projectdir>/<sessionid>/subagents/agent-*.jsonl) and the deeper
+#   workflow-subagent nesting
+#   (<projectdir>/<sessionid>/subagents/workflows/wf_<id>/agent-*.jsonl).
+#
+# WHAT IT COUNTS (over the cwd+since-filtered records)
+#   rejections   `.type == "user"` records carrying a `tool_result` content block
+#                with `.is_error == true` whose stringified `.content` matches
+#                "Skill <instrument> cannot be used with Skill tool". The first
+#                match is reported verbatim (untruncated — the caller truncates)
+#                as failure_text.
+#   invocations  `.type == "assistant"` records carrying a matching `tool_use`
+#                content block (see --kind). Their `.id`s form the pairing set.
+#   succeeded    `tool_result` blocks whose `.tool_use_id` is in that set and
+#                whose `.is_error` is not true. The tool_use and its paired
+#                tool_result always appear in the same transcript file, so
+#                per-file id-pairing is sufficient — no cross-file joins.
+#
+#   verified is true iff succeeded >= 1 AND rejections == 0.
+#
+# OUTPUT / EXIT CONTRACT (mirrors dispatch-recover-session-id's 0/1/2 style)
+#   0  verified; exactly one JSON document on stdout.
+#   1  NOT verified; exactly one JSON document on stdout. This is a normal,
+#      EXPECTED outcome for a genuinely-rejected instrument — not a script bug.
+#      A wait window that expires with no evidence either way lands here with
+#      reason "no invocation record found" (fail-closed).
+#   2  usage error (missing/invalid flag) or environment error (transcript root
+#      absent, --since unparseable). Diagnostic on stderr, NO stdout JSON — per
+#      .claude/rules/code-style.md a missing transcript root is a clear error,
+#      never masqueraded as verified:false.
+#
+#   JSON shape:
+#     {"instrument":..,"kind":..,"invocations":N,"succeeded":N,"rejections":N,
+#      "verified":bool,"failure_text":"..","reason":".."}
+#
+# Pure filesystem — never touches the Claude daemon, so it is sandbox-safe and
+# unit-testable (see test-dispatch-verify-instrument-invocation.sh).
+#
+# .claude/rules/shell-json.md: this file never pipes a captured JSON variable
+# through `echo` into jq. jq reads files directly, or takes a here-string.
+set -euo pipefail
+
+INSTRUMENT=""
+KIND=""
+SKILL_ARG=""
+COMMAND_PATTERN=""
+SINCE=""
+CWD=""
+WAIT_SECS=10
+
+usage() {
+  echo "usage: dispatch-verify-instrument-invocation --instrument <name> --kind skill|command" >&2
+  echo "         [--skill <skill-arg>] [--command-pattern <ERE>]" >&2
+  echo "         --since <ISO8601> --cwd <abs-path> [--wait-secs <N>]" >&2
+}
+
+die_usage() {
+  echo "dispatch-verify-instrument-invocation: $1" >&2
+  usage
+  exit 2
+}
+
+need_value() {
+  # $1 = flag name, $2 = remaining arg count
+  [[ "$2" -ge 2 ]] || die_usage "$1 requires a value"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --instrument)      need_value "$1" "$#"; INSTRUMENT="$2"; shift 2 ;;
+    --kind)            need_value "$1" "$#"; KIND="$2"; shift 2 ;;
+    --skill)           need_value "$1" "$#"; SKILL_ARG="$2"; shift 2 ;;
+    --command-pattern) need_value "$1" "$#"; COMMAND_PATTERN="$2"; shift 2 ;;
+    --since)           need_value "$1" "$#"; SINCE="$2"; shift 2 ;;
+    --cwd)             need_value "$1" "$#"; CWD="$2"; shift 2 ;;
+    --wait-secs)       need_value "$1" "$#"; WAIT_SECS="$2"; shift 2 ;;
+    *)                 die_usage "unexpected argument: $1" ;;
+  esac
+done
+
+[[ -n "$INSTRUMENT" ]] || die_usage "--instrument is required"
+[[ -n "$KIND" ]] || die_usage "--kind is required"
+[[ -n "$SINCE" ]] || die_usage "--since is required"
+[[ -n "$CWD" ]] || die_usage "--cwd is required"
+
+case "$KIND" in
+  skill)
+    [[ -n "$SKILL_ARG" ]] || die_usage "--kind skill requires --skill"
+    ;;
+  command)
+    [[ -n "$COMMAND_PATTERN" ]] || die_usage "--kind command requires --command-pattern"
+    ;;
+  *)
+    die_usage "--kind must be 'skill' or 'command', got: $KIND"
+    ;;
+esac
+
+[[ "$WAIT_SECS" =~ ^[0-9]+$ ]] || die_usage "--wait-secs must be a non-negative integer, got: $WAIT_SECS"
+
+# --since must be a zero-padded ISO8601 instant; the lexical >= comparison below
+# is only correct for that shape, so reject anything else loudly (environment
+# error) rather than silently comparing garbage.
+if [[ ! "$SINCE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2} ]]; then
+  echo "dispatch-verify-instrument-invocation: --since is not a parseable ISO8601 instant: $SINCE" >&2
+  exit 2
+fi
+
+PROJECTS_ROOT="${DISPATCH_AUDIT_PROJECTS_ROOT:-${HOME:-}/.claude/projects}"
+if [[ -z "$PROJECTS_ROOT" || ! -d "$PROJECTS_ROOT" ]]; then
+  echo "dispatch-verify-instrument-invocation: transcript root '$PROJECTS_ROOT' is not a directory" >&2
+  exit 2
+fi
+
+# The rejection signature the substitution incident produced verbatim:
+#   <tool_use_error>Skill code-review cannot be used with Skill tool due to
+#   disable-model-invocation</tool_use_error>
+REJECT_RE="Skill ${INSTRUMENT} cannot be used with Skill tool"
+
+INVOCATIONS=0
+SUCCEEDED=0
+REJECTIONS=0
+FAILURE_TEXT=""
+
+# Per-file jq program. Slurps one transcript's records, filters to this cwd and
+# time window, then emits one compact object. Files are handled independently so
+# a huge tree is never slurped whole, and id-pairing stays within a session.
+JQ_PROG='
+  map(select(((.cwd? // "") == $cwd) and ((.timestamp? // "") >= $since))) as $recs
+  | [ $recs[]
+      | select(.type == "user")
+      | .message.content[]?
+      | select(.type == "tool_result" and .is_error == true)
+      | (.content | tostring)
+      | select(test($rejre))
+    ] as $rej
+  | [ $recs[]
+      | select(.type == "assistant")
+      | .message.content[]?
+      | select(.type == "tool_use")
+      | select(
+          if $kind == "skill"
+          then (.name == "Skill" and ((.input.skill? // "") == $skill))
+          else (.name == "Bash" and (((.input.command? // "") | tostring) | test($cmdre)))
+          end
+        )
+      | .id
+    ] as $ids
+  | [ $recs[]
+      | .message.content[]?
+      | select(.type == "tool_result")
+      | select((.tool_use_id? // "") as $t | ($ids | index($t)) != null)
+      | select((.is_error? // false) != true)
+    ] as $ok
+  | {
+      invocations: ($ids | length),
+      succeeded: ($ok | length),
+      rejections: ($rej | length),
+      failure_text: ($rej[0] // "")
+    }
+'
+
+scan() {
+  local per_file agg f
+  per_file="$(mktemp)"
+
+  while IFS= read -r f; do
+    [[ -n "$f" ]] || continue
+    if ! jq -s -c \
+      --arg cwd "$CWD" \
+      --arg since "$SINCE" \
+      --arg rejre "$REJECT_RE" \
+      --arg kind "$KIND" \
+      --arg skill "$SKILL_ARG" \
+      --arg cmdre "$COMMAND_PATTERN" \
+      "$JQ_PROG" "$f" >>"$per_file" 2>/dev/null
+    then
+      # A corrupt or alien transcript must not abort the verdict; report and
+      # move on (same posture as aggregate-usage.sh's files_failed tally).
+      echo "dispatch-verify-instrument-invocation: skipping unparseable transcript: $f" >&2
+    fi
+  done < <(find "$PROJECTS_ROOT" -type f -name '*.jsonl' 2>/dev/null)
+
+  # Aggregate the per-file objects. jq reads the file directly — never an
+  # echo-into-jq round-trip of a captured variable (.claude/rules/shell-json.md).
+  agg=$(jq -s -c '{
+      invocations: (map(.invocations) | add // 0),
+      succeeded:   (map(.succeeded)   | add // 0),
+      rejections:  (map(.rejections)  | add // 0),
+      failure_text: ((map(select(.failure_text != "") | .failure_text))[0] // "")
+    }' "$per_file")
+
+  INVOCATIONS=$(jq -r '.invocations' <<<"$agg")
+  SUCCEEDED=$(jq -r '.succeeded' <<<"$agg")
+  REJECTIONS=$(jq -r '.rejections' <<<"$agg")
+  FAILURE_TEXT=$(jq -r '.failure_text' <<<"$agg")
+
+  rm -f "$per_file"
+}
+
+scan
+
+# Flush lag: only when the first pass found NO evidence either way is a bounded
+# re-scan worth doing. Any rejection or any invocation is already a verdict.
+waited=0
+while [[ "$INVOCATIONS" -eq 0 && "$REJECTIONS" -eq 0 && "$waited" -lt "$WAIT_SECS" ]]; do
+  sleep 1
+  waited=$((waited + 1))
+  scan
+done
+
+REASON=""
+if [[ "$SUCCEEDED" -ge 1 && "$REJECTIONS" -eq 0 ]]; then
+  VERIFIED=true
+else
+  VERIFIED=false
+  if [[ "$INVOCATIONS" -eq 0 && "$REJECTIONS" -eq 0 ]]; then
+    # Fail-closed: absence of evidence is not evidence of invocation.
+    REASON="no invocation record found"
+  fi
+fi
+
+jq -n -c \
+  --arg instrument "$INSTRUMENT" \
+  --arg kind "$KIND" \
+  --argjson invocations "$INVOCATIONS" \
+  --argjson succeeded "$SUCCEEDED" \
+  --argjson rejections "$REJECTIONS" \
+  --argjson verified "$VERIFIED" \
+  --arg failure_text "$FAILURE_TEXT" \
+  --arg reason "$REASON" \
+  '{instrument: $instrument, kind: $kind, invocations: $invocations,
+    succeeded: $succeeded, rejections: $rejections, verified: $verified,
+    failure_text: $failure_text, reason: $reason}'
+
+[[ "$VERIFIED" == "true" ]] && exit 0
+exit 1

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-verify-instrument-invocation
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-verify-instrument-invocation
@@ -31,10 +31,11 @@
 #                        sessions/worktrees write into the transcript tree at
 #                        once. The project directory is deliberately NOT derived
 #                        from a path slug.
-#     --wait-secs        bounded poll (default 10) used ONLY when the first pass
-#                        found no evidence either way, since transcripts can lag
-#                        a moment behind real-time writes. This is
-#                        evidence-gathering, not a substitute invocation.
+#     --wait-secs        bounded poll (default 10) used ONLY while no terminal
+#                        evidence (a paired success or a paired failure) has been
+#                        seen, since transcripts can lag a moment behind
+#                        real-time writes. This is evidence-gathering, not a
+#                        substitute invocation.
 #
 # WHAT IT SCANS
 #   Projects root: ${DISPATCH_AUDIT_PROJECTS_ROOT:-$HOME/.claude/projects} — the
@@ -46,20 +47,37 @@
 #   workflow-subagent nesting
 #   (<projectdir>/<sessionid>/subagents/workflows/wf_<id>/agent-*.jsonl).
 #
+#   The candidate set is pruned to files whose mtime is at/after --since (minus a
+#   slack margin). A record timestamped at/after --since cannot live in a file
+#   last written before it, so this cannot hide evidence — it just keeps the
+#   parse off the host's entire transcript history. Each candidate is parsed with
+#   a STREAMING jq (`-n` + `inputs`), never a whole-file slurp, and the poll loop
+#   re-parses only files whose mtime advanced since the previous pass.
+#
 # WHAT IT COUNTS (over the cwd+since-filtered records)
-#   rejections   `.type == "user"` records carrying a `tool_result` content block
-#                with `.is_error == true` whose stringified `.content` matches
-#                "Skill <instrument> cannot be used with Skill tool". The first
-#                match is reported verbatim (untruncated — the caller truncates)
-#                as failure_text.
 #   invocations  `.type == "assistant"` records carrying a matching `tool_use`
 #                content block (see --kind). Their `.id`s form the pairing set.
 #   succeeded    `tool_result` blocks whose `.tool_use_id` is in that set and
 #                whose `.is_error` is not true. The tool_use and its paired
-#                tool_result always appear in the same transcript file, so
-#                per-file id-pairing is sufficient — no cross-file joins.
+#                tool_result always appear in the same transcript file, in that
+#                order, so a single streaming pass per file is sufficient — no
+#                cross-file joins and no second pass.
+#   rejections   `tool_result` blocks whose `.tool_use_id` is in that SAME set
+#                and whose `.is_error` is true — i.e. this instrument's own call
+#                failed. The first one's `.content` is reported verbatim
+#                (untruncated — the caller truncates) as failure_text.
 #
-#   verified is true iff succeeded >= 1 AND rejections == 0.
+#                Pairing by id is what makes the count non-fabricable. An earlier
+#                revision instead substring-matched "Skill <instrument> cannot be
+#                used with Skill tool" against the error text of ANY failed tool
+#                call in the window; that phrase is plain text an attacker can
+#                commit to their own PR (a doc, a fixture, a comment) and get
+#                echoed back by any failing Edit/Bash, which would have let a PR
+#                author suppress review of their own diff.
+#
+#   verified is true iff succeeded >= 1. A paired success is direct evidence the
+#   harness ran the instrument, so it is authoritative even if the same
+#   instrument was also rejected on an earlier attempt in the window.
 #
 # OUTPUT / EXIT CONTRACT (mirrors dispatch-recover-session-id's 0/1/2 style)
 #   0  verified; exactly one JSON document on stdout.
@@ -148,80 +166,140 @@ if [[ ! "$SINCE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2} ]]; t
   exit 2
 fi
 
+# Epoch form of --since, used as the `find -newermt` candidate-file floor in
+# scan(). The slack below it absorbs filesystem mtime granularity and small clock
+# skew between whoever wrote a transcript and this process; it only ever WIDENS
+# the candidate set, so it cannot suppress evidence.
+if ! SINCE_EPOCH=$(date -u -d "$SINCE" +%s); then
+  echo "dispatch-verify-instrument-invocation: --since could not be converted to an epoch: $SINCE" >&2
+  exit 2
+fi
+MTIME_FLOOR="@$((SINCE_EPOCH - 600))"
+
 PROJECTS_ROOT="${DISPATCH_AUDIT_PROJECTS_ROOT:-${HOME:-}/.claude/projects}"
 if [[ -z "$PROJECTS_ROOT" || ! -d "$PROJECTS_ROOT" ]]; then
   echo "dispatch-verify-instrument-invocation: transcript root '$PROJECTS_ROOT' is not a directory" >&2
   exit 2
 fi
 
-# The rejection signature the substitution incident produced verbatim:
-#   <tool_use_error>Skill code-review cannot be used with Skill tool due to
-#   disable-model-invocation</tool_use_error>
-REJECT_RE="Skill ${INSTRUMENT} cannot be used with Skill tool"
-
 INVOCATIONS=0
 SUCCEEDED=0
 REJECTIONS=0
 FAILURE_TEXT=""
 
-# Per-file jq program. Slurps one transcript's records, filters to this cwd and
-# time window, then emits one compact object. Files are handled independently so
-# a huge tree is never slurped whole, and id-pairing stays within a session.
+# Per-file jq program. STREAMING (`-n` + `inputs`): records are folded one at a
+# time, so peak memory is the id set rather than the whole transcript — a
+# multi-hundred-MB session file no longer becomes a slurp-sized allocation.
+#
+# The single pass relies on the transcript's own ordering invariant: a tool_use
+# is appended before the tool_result that answers it, in the same file. That is
+# why no pending/second-pass bookkeeping is needed to pair them.
+#
+# Both outcomes are counted only through that id pairing — a tool_result is
+# attributed to this instrument iff its .tool_use_id is one this instrument's
+# tool_use emitted. Nothing is matched against free-form error text, so text an
+# attacker can plant in the repo (and get echoed back by an unrelated failing
+# tool call) cannot manufacture a rejection.
 JQ_PROG='
-  map(select(((.cwd? // "") == $cwd) and ((.timestamp? // "") >= $since))) as $recs
-  | [ $recs[]
-      | select(.type == "user")
-      | .message.content[]?
-      | select(.type == "tool_result" and .is_error == true)
-      | (.content | tostring)
-      | select(test($rejre))
-    ] as $rej
-  | [ $recs[]
-      | select(.type == "assistant")
-      | .message.content[]?
-      | select(.type == "tool_use")
-      | select(
-          if $kind == "skill"
-          then (.name == "Skill" and ((.input.skill? // "") == $skill))
-          else (.name == "Bash" and (((.input.command? // "") | tostring) | test($cmdre)))
-          end
-        )
-      | .id
-    ] as $ids
-  | [ $recs[]
-      | .message.content[]?
-      | select(.type == "tool_result")
-      | select((.tool_use_id? // "") as $t | ($ids | index($t)) != null)
-      | select((.is_error? // false) != true)
-    ] as $ok
-  | {
-      invocations: ($ids | length),
-      succeeded: ($ok | length),
-      rejections: ($rej | length),
-      failure_text: ($rej[0] // "")
-    }
+  def matches_instrument:
+    if $kind == "skill"
+    then (.name == "Skill" and ((.input.skill? // "") == $skill))
+    else (.name == "Bash" and (((.input.command? // "") | tostring) | test($cmdre)))
+    end;
+  reduce (
+    inputs
+    | select(((.cwd? // "") == $cwd) and ((.timestamp? // "") >= $since))
+  ) as $r (
+    {ids: {}, invocations: 0, succeeded: 0, rejections: 0, failure_text: ""};
+    reduce ($r.message.content[]?) as $b (
+      .;
+      if ($r.type == "assistant"
+          and $b.type == "tool_use"
+          and (($b.id? // "") != "")
+          and ($b | matches_instrument))
+      then .ids[($b.id | tostring)] = true
+           | .invocations += 1
+      elif ($b.type == "tool_result"
+            and (($b.tool_use_id? // "") != "")
+            and (.ids[($b.tool_use_id | tostring)] // false))
+      then (if (($b.is_error? // false) == true)
+            then .rejections += 1
+                 | (if .failure_text == ""
+                    then .failure_text = ($b.content | tostring)
+                    else . end)
+            else .succeeded += 1
+            end)
+      else .
+      end
+    )
+  )
+  | {invocations, succeeded, rejections, failure_text}
 '
 
+# Per-file parse cache, keyed by path, holding the mtime the cached counts were
+# computed from. The poll loop below re-parses a file only when its mtime moved.
+declare -A CACHE_MTIME
+declare -A CACHE_JSON
+
 scan() {
-  local per_file agg f
+  local list err per_file agg f mtime json
+
+  list="$(mktemp)"
+  err="$(mktemp)"
   per_file="$(mktemp)"
+
+  # Candidate files only: transcripts written at/after the --since floor. A
+  # record timestamped at/after --since cannot sit in a file whose last write
+  # predates it, so this prunes the host's entire transcript history to the
+  # current window without changing any verdict.
+  #
+  # find's stderr is NOT discarded: an unreadable directory or an IO error is an
+  # environment error and must surface as exit 2, never as "no invocation record
+  # found" (.claude/rules/code-style.md — clear errors over silent fallbacks).
+  if ! find "$PROJECTS_ROOT" -type f -name '*.jsonl' -newermt "$MTIME_FLOOR" \
+       >"$list" 2>"$err" || [[ -s "$err" ]]; then
+    echo "dispatch-verify-instrument-invocation: transcript scan failed under '$PROJECTS_ROOT':" >&2
+    cat "$err" >&2
+    rm -f "$list" "$err" "$per_file"
+    exit 2
+  fi
 
   while IFS= read -r f; do
     [[ -n "$f" ]] || continue
-    if ! jq -s -c \
+
+    if ! mtime=$(stat -c %Y "$f" 2>/dev/null); then
+      # The file disappeared between the find and the stat (session cleanup).
+      # There is nothing to read; a later pass sees whatever replaced it.
+      echo "dispatch-verify-instrument-invocation: skipping vanished transcript: $f" >&2
+      continue
+    fi
+
+    if [[ "${CACHE_MTIME[$f]:-}" == "$mtime" ]]; then
+      # Unchanged since the previous pass — reuse its counts. This is what keeps
+      # the bounded poll from re-parsing the whole candidate set once a second.
+      printf '%s\n' "${CACHE_JSON[$f]}" >>"$per_file"
+      continue
+    fi
+
+    if json=$(jq -n -c \
       --arg cwd "$CWD" \
       --arg since "$SINCE" \
-      --arg rejre "$REJECT_RE" \
       --arg kind "$KIND" \
       --arg skill "$SKILL_ARG" \
       --arg cmdre "$COMMAND_PATTERN" \
-      "$JQ_PROG" "$f" >>"$per_file" 2>/dev/null
+      "$JQ_PROG" "$f" 2>/dev/null)
     then
+      CACHE_MTIME["$f"]="$mtime"
+      CACHE_JSON["$f"]="$json"
+      printf '%s\n' "$json" >>"$per_file"
+    else
       # A corrupt or alien transcript must not abort the verdict; report and
-      # move on (same posture as aggregate-usage.sh's files_failed tally).
+      # move on (same posture as aggregate-usage.sh's files_failed tally). The
+      # failure is deliberately NOT cached, so a file that was mid-write when it
+      # was read is retried on the next pass.
       echo "dispatch-verify-instrument-invocation: skipping unparseable transcript: $f" >&2
     fi
-  done < <(find "$PROJECTS_ROOT" -type f -name '*.jsonl' 2>/dev/null)
+  done <"$list"
 
   # Aggregate the per-file objects. jq reads the file directly — never an
   # echo-into-jq round-trip of a captured variable (.claude/rules/shell-json.md).
@@ -237,28 +315,35 @@ scan() {
   REJECTIONS=$(jq -r '.rejections' <<<"$agg")
   FAILURE_TEXT=$(jq -r '.failure_text' <<<"$agg")
 
-  rm -f "$per_file"
+  rm -f "$list" "$err" "$per_file"
 }
 
 scan
 
-# Flush lag: only when the first pass found NO evidence either way is a bounded
-# re-scan worth doing. Any rejection or any invocation is already a verdict.
+# Flush lag: re-scan only while no TERMINAL evidence has landed. A paired
+# success or a paired failure is already a verdict; a bare tool_use whose result
+# has not been flushed yet is not, so that case keeps waiting too. Repeat passes
+# re-parse only files whose mtime advanced (see scan()), so the wait is cheap.
 waited=0
-while [[ "$INVOCATIONS" -eq 0 && "$REJECTIONS" -eq 0 && "$waited" -lt "$WAIT_SECS" ]]; do
+while [[ "$SUCCEEDED" -eq 0 && "$REJECTIONS" -eq 0 && "$waited" -lt "$WAIT_SECS" ]]; do
   sleep 1
   waited=$((waited + 1))
   scan
 done
 
 REASON=""
-if [[ "$SUCCEEDED" -ge 1 && "$REJECTIONS" -eq 0 ]]; then
+if [[ "$SUCCEEDED" -ge 1 ]]; then
+  # A paired non-error result is direct evidence the harness ran the instrument.
+  # It stands even alongside a rejection: an instrument that was refused once and
+  # then genuinely ran did run.
   VERIFIED=true
 else
   VERIFIED=false
-  if [[ "$INVOCATIONS" -eq 0 && "$REJECTIONS" -eq 0 ]]; then
+  if [[ "$INVOCATIONS" -eq 0 ]]; then
     # Fail-closed: absence of evidence is not evidence of invocation.
     REASON="no invocation record found"
+  elif [[ "$REJECTIONS" -eq 0 ]]; then
+    REASON="invocation recorded but no completed result within the wait window"
   fi
 fi
 

--- a/.claude/skills/dispatch-propagate/scripts/review-fix-instrument-probe.mjs
+++ b/.claude/skills/dispatch-propagate/scripts/review-fix-instrument-probe.mjs
@@ -79,7 +79,7 @@ if (!sliceSource) {
 }
 
 const instrumentVerdict = (function () {
-  // eslint-disable-next-line no-eval
+  // eslint-disable-next-line no-eval -- see comment above // type-safety-ok: eval is required (not new Function) because the sliced source has two top-level statements, not a single expression
   return eval(`(function () { ${sliceSource}\nreturn instrumentVerdict; })()`);
 })();
 

--- a/.claude/skills/dispatch-propagate/scripts/review-fix-instrument-probe.mjs
+++ b/.claude/skills/dispatch-propagate/scripts/review-fix-instrument-probe.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// review-fix-instrument-probe.mjs (tactic-lane-instrument-substitution-guard)
+//
+// CI-vector probe for instrumentVerdict (and its INSTRUMENTS registry) in
+// .claude/workflows/review-fix.js. run-unit-tests.sh has no mapping for
+// .claude/workflows/*, so a PR touching only review-fix.js triggers no vitest
+// suite. Its test-*.sh glob over this directory is NOT a fallback either: that
+// glob only runs when RUN_PR_SCRIPTS is set, which auto-detect sets solely for
+// changed paths under .claude/skills/dispatch-propagate/scripts/
+// (run-unit-tests.sh:88). The actual CI vector is the hook-tests job in
+// .github/workflows/unit-tests.yml, which runs test-review-fix-instrument.sh
+// (this probe's driver) unconditionally on every PR. Keep that step wired —
+// deleting it removes all coverage here.
+//
+// review-fix.js is a Workflow-tool script (top-level await + injected globals),
+// so it CANNOT be imported/executed by node. Instead this probe SLICES the pure
+// INSTRUMENTS + instrumentVerdict text out from between two sentinel comments
+// and evals just that slice, then runs it on a fixture set and prints the
+// verdicts.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Resolve review-fix.js relative to this helper's own location. This helper
+// sits at .claude/skills/dispatch-propagate/scripts/, so review-fix.js is
+// three dirs up at .claude/workflows/review-fix.js.
+const reviewFixPath = fileURLToPath(
+  new URL('../../../workflows/review-fix.js', import.meta.url)
+);
+
+const source = readFileSync(reviewFixPath, 'utf8');
+
+const START =
+  "// >>> instrument gate: sliced + eval'd by review-fix-instrument-probe.mjs >>>";
+const END = '// <<< instrument gate <<<';
+
+// FAIL LOUDLY: each sentinel must appear exactly once.
+function countOccurrences(haystack, needle) {
+  let count = 0;
+  let idx = haystack.indexOf(needle);
+  while (idx !== -1) {
+    count += 1;
+    idx = haystack.indexOf(needle, idx + needle.length);
+  }
+  return count;
+}
+
+const startCount = countOccurrences(source, START);
+const endCount = countOccurrences(source, END);
+if (startCount !== 1) {
+  process.stderr.write(
+    `review-fix-instrument-probe: START sentinel not found exactly once (count=${startCount}) in ${reviewFixPath}\n`
+  );
+  process.exit(1);
+}
+if (endCount !== 1) {
+  process.stderr.write(
+    `review-fix-instrument-probe: END sentinel not found exactly once (count=${endCount}) in ${reviewFixPath}\n`
+  );
+  process.exit(1);
+}
+
+// The sliced text is strictly between the end of the START sentinel line and
+// the start of the END sentinel line.
+const startIdx = source.indexOf(START) + START.length;
+const endIdx = source.indexOf(END);
+// .trim() is load-bearing for the same ASI reason the qa-fix-partition-probe
+// documents — but the shape here differs: the slice contains TWO top-level
+// statements (`const INSTRUMENTS = {...}` then `function instrumentVerdict...`),
+// not a single expression, so it cannot be wrapped as `new Function('return ' +
+// fnSource)()` the way a single function expression can. Instead the slice is
+// eval'd directly (in an IIFE, to avoid leaking into this module's top level)
+// and the IIFE returns instrumentVerdict, closing over INSTRUMENTS.
+const sliceSource = source.slice(startIdx, endIdx).trim();
+
+if (!sliceSource) {
+  process.stderr.write('review-fix-instrument-probe: empty slice between sentinels\n');
+  process.exit(1);
+}
+
+const instrumentVerdict = (function () {
+  // eslint-disable-next-line no-eval
+  return eval(`(function () { ${sliceSource}\nreturn instrumentVerdict; })()`);
+})();
+
+// Fixture table (Unit 3 of tactic-lane-instrument-substitution-guard).
+const NOT_INVOKED_FAILURE_TEXT =
+  'Skill code-review cannot be used with Skill tool due to disable-model-invocation';
+
+const cases = [
+  { id: 'lane-b', name: 'cost', res: {} },
+  { id: 'null-res', name: 'code-review', res: null },
+  {
+    id: 'no-receipt',
+    name: 'code-review',
+    res: { fixed: [], residue: [] },
+  },
+  {
+    id: 'wrong-name',
+    name: 'code-review',
+    res: {
+      instrument: { name: 'security-review', invoked: true, failure_text: '' },
+      fixed: [],
+      residue: [],
+    },
+  },
+  {
+    id: 'not-invoked',
+    name: 'code-review',
+    res: {
+      instrument: {
+        name: 'code-review',
+        invoked: false,
+        failure_text: NOT_INVOKED_FAILURE_TEXT,
+      },
+      fixed: [],
+      residue: [],
+    },
+  },
+  {
+    id: 'sig-no-touched-files',
+    name: 'code-review',
+    res: {
+      instrument: { name: 'code-review', invoked: true, failure_text: '' },
+      fixed: [{ title: 'x', touched_files: [] }],
+      residue: [],
+    },
+  },
+  {
+    id: 'sig-security-edited',
+    name: 'security-review',
+    res: {
+      instrument: { name: 'security-review', invoked: true, failure_text: '' },
+      fixed: [{ title: 'x', touched_files: ['a.js'] }],
+      residue: [],
+    },
+  },
+  {
+    id: 'clean-code-review',
+    name: 'code-review',
+    res: {
+      instrument: { name: 'code-review', invoked: true, failure_text: '' },
+      fixed: [{ title: 'x', touched_files: ['a.js'] }],
+      residue: [],
+    },
+  },
+  {
+    id: 'clean-security-review',
+    name: 'security-review',
+    res: {
+      instrument: { name: 'security-review', invoked: true, failure_text: '' },
+      fixed: [],
+      residue: [{ title: 'y' }],
+    },
+  },
+];
+
+const results = {};
+for (const c of cases) {
+  results[c.id] = instrumentVerdict(c.name, c.res);
+}
+
+process.stdout.write(JSON.stringify(results) + '\n');

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-verify-instrument-invocation.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-verify-instrument-invocation.sh
@@ -29,9 +29,13 @@ export DISPATCH_AUDIT_PROJECTS_ROOT="$VERIFY_ROOT"
 
 CWD_A="/home/tester/wt/node-a"
 CWD_B="/home/tester/wt/node-b"
-SINCE="2026-07-31T12:00:00.000Z"
-T_OK="2026-07-31T12:05:00.000Z"
-T_OLD="2026-07-31T09:00:00.000Z"
+# Derived from the wall clock, not hard-coded: the SUT prunes candidate files to
+# those whose mtime is at/after --since, and every fixture file below is written
+# NOW. A fixed calendar instant would make the suite pass or fail depending on
+# the hour of day it runs at.
+SINCE="$(date -u -d '-1 hour' +%Y-%m-%dT%H:%M:%S.000Z)"
+T_OK="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+T_OLD="$(date -u -d '-3 hours' +%Y-%m-%dT%H:%M:%S.000Z)"
 
 # Mimic the nested workflow-subagent layout so the recursive find is exercised
 # at its deepest real nesting, not just the flat top level.
@@ -116,16 +120,22 @@ assert_eq "case 1: no rejections" "0" "$(jq -r '.rejections' <<<"$OUT")"
 assert_eq "case 1: reason empty" "" "$(jq -r '.reason' <<<"$OUT")"
 
 # ============================================================================
-# Case 2 — the real rejection: is_error result carrying the substitution text.
+# Case 2 — the real rejection: the Skill tool_use the harness refused, plus its
+# paired is_error result. Both halves are present in a real transcript, and the
+# SUT counts a rejection ONLY through that tool_use_id pairing.
 # ============================================================================
 reset_fixtures
-err_result_record "$CWD_A" "$T_OK" "toolu_rej1" "$REJECT_TEXT" > "$PROJ_DIR/agent-rej.jsonl"
+{
+  skill_use_record "$CWD_A" "$T_OK" "toolu_rej1" "code-review"
+  err_result_record "$CWD_A" "$T_OK" "toolu_rej1" "$REJECT_TEXT"
+} > "$PROJ_DIR/agent-rej.jsonl"
 
 run_sut "$SUT" --instrument code-review --kind skill --skill code-review \
   --since "$SINCE" --cwd "$CWD_A" --wait-secs 0
 assert_eq "case 2: rejection exits 1" "1" "$RC"
 assert_eq "case 2: not verified" "false" "$(jq -r '.verified' <<<"$OUT")"
 assert_eq "case 2: rejections counted" "1" "$(jq -r '.rejections' <<<"$OUT")"
+assert_eq "case 2: no success counted" "0" "$(jq -r '.succeeded' <<<"$OUT")"
 assert_eq "case 2: failure_text is verbatim" "$REJECT_TEXT" "$(jq -r '.failure_text' <<<"$OUT")"
 # A rejection IS evidence, so the fail-closed no-evidence reason must NOT fire.
 assert_eq "case 2: reason empty (rejection is evidence)" "" "$(jq -r '.reason' <<<"$OUT")"
@@ -135,7 +145,10 @@ assert_eq "case 2: reason empty (rejection is evidence)" "" "$(jq -r '.reason' <
 # A rejection in another worktree must not poison this worktree's verdict.
 # ============================================================================
 reset_fixtures
-err_result_record "$CWD_B" "$T_OK" "toolu_rej1" "$REJECT_TEXT" > "$PROJ_DIR/agent-rej.jsonl"
+{
+  skill_use_record "$CWD_B" "$T_OK" "toolu_rej1" "code-review"
+  err_result_record "$CWD_B" "$T_OK" "toolu_rej1" "$REJECT_TEXT"
+} > "$PROJ_DIR/agent-rej.jsonl"
 
 run_sut "$SUT" --instrument code-review --kind skill --skill code-review \
   --since "$SINCE" --cwd "$CWD_A" --wait-secs 0
@@ -210,5 +223,79 @@ run_sut "$SUT" --instrument code-review --kind skill --skill code-review \
   --since "yesterday" --cwd "$CWD_A" --wait-secs 0
 assert_eq "case 6c: unparseable --since exits 2" "2" "$RC"
 assert_eq "case 6c: unparseable --since prints no stdout" "" "$OUT"
+
+# ============================================================================
+# Case 7 — rejection-text poisoning. An UNRELATED failed tool call (a Bash that
+# exited non-zero after echoing a repo file, say) whose error text happens to
+# contain the rejection phrase must NOT count as a rejection: the phrase is
+# plain text anyone can commit to the PR under review. Only tool_use_id pairing
+# counts, so the genuine invocation below stays verified.
+# ============================================================================
+reset_fixtures
+{
+  skill_use_record "$CWD_A" "$T_OK" "toolu_ok2" "code-review"
+  ok_result_record "$CWD_A" "$T_OK" "toolu_ok2"
+  bash_use_record "$CWD_A" "$T_OK" "toolu_bash1" "cat fixtures/notes.md"
+  err_result_record "$CWD_A" "$T_OK" "toolu_bash1" "$REJECT_TEXT"
+} > "$PROJ_DIR/agent-poison.jsonl"
+
+run_sut "$SUT" --instrument code-review --kind skill --skill code-review \
+  --since "$SINCE" --cwd "$CWD_A" --wait-secs 0
+assert_eq "case 7: unpaired reject text does not flip the verdict" "0" "$RC"
+assert_eq "case 7: still verified" "true" "$(jq -r '.verified' <<<"$OUT")"
+assert_eq "case 7: unpaired reject text not counted" "0" "$(jq -r '.rejections' <<<"$OUT")"
+assert_eq "case 7: failure_text stays empty" "" "$(jq -r '.failure_text' <<<"$OUT")"
+
+# The same poisoning attempt with NO genuine invocation must still be no-evidence
+# (fail-closed) rather than a counted rejection.
+reset_fixtures
+{
+  bash_use_record "$CWD_A" "$T_OK" "toolu_bash2" "cat fixtures/notes.md"
+  err_result_record "$CWD_A" "$T_OK" "toolu_bash2" "$REJECT_TEXT"
+} > "$PROJ_DIR/agent-poison.jsonl"
+
+run_sut "$SUT" --instrument code-review --kind skill --skill code-review \
+  --since "$SINCE" --cwd "$CWD_A" --wait-secs 0
+assert_eq "case 7b: poison-only exits 1" "1" "$RC"
+assert_eq "case 7b: poison-only not counted as rejection" "0" "$(jq -r '.rejections' <<<"$OUT")"
+assert_eq "case 7b: fail-closed reason" "no invocation record found" "$(jq -r '.reason' <<<"$OUT")"
+
+# ============================================================================
+# Case 8 — refused once, then genuinely run. A paired success is direct evidence
+# the harness executed the instrument, so it is authoritative over the earlier
+# paired rejection.
+# ============================================================================
+reset_fixtures
+{
+  skill_use_record "$CWD_A" "$T_OK" "toolu_rej2" "code-review"
+  err_result_record "$CWD_A" "$T_OK" "toolu_rej2" "$REJECT_TEXT"
+  skill_use_record "$CWD_A" "$T_OK" "toolu_ok3" "code-review"
+  ok_result_record "$CWD_A" "$T_OK" "toolu_ok3"
+} > "$PROJ_DIR/agent-retry.jsonl"
+
+run_sut "$SUT" --instrument code-review --kind skill --skill code-review \
+  --since "$SINCE" --cwd "$CWD_A" --wait-secs 0
+assert_eq "case 8: retry-after-rejection exits 0" "0" "$RC"
+assert_eq "case 8: verified" "true" "$(jq -r '.verified' <<<"$OUT")"
+assert_eq "case 8: both attempts counted" "2" "$(jq -r '.invocations' <<<"$OUT")"
+assert_eq "case 8: rejection still reported" "1" "$(jq -r '.rejections' <<<"$OUT")"
+
+# ============================================================================
+# Case 9 — a transcript file whose mtime predates --since is pruned from the
+# candidate set before parsing (the scan-scoping guard). Its records would match
+# on cwd and timestamp, so only the mtime prefilter can exclude it.
+# ============================================================================
+reset_fixtures
+{
+  skill_use_record "$CWD_A" "$T_OK" "toolu_stale1" "code-review"
+  ok_result_record "$CWD_A" "$T_OK" "toolu_stale1"
+} > "$PROJ_DIR/agent-stale.jsonl"
+# Well under the SUT's slack margin below --since (1h ago): 2 days back.
+touch -d '2 days ago' "$PROJ_DIR/agent-stale.jsonl"
+
+run_sut "$SUT" --instrument code-review --kind skill --skill code-review \
+  --since "$SINCE" --cwd "$CWD_A" --wait-secs 0
+assert_eq "case 9: stale-mtime transcript is not parsed" "1" "$RC"
+assert_eq "case 9: no invocations from a pruned file" "0" "$(jq -r '.invocations' <<<"$OUT")"
 
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-verify-instrument-invocation.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-verify-instrument-invocation.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Tests for dispatch-verify-instrument-invocation — the independent transcript
+# reader that checks whether a named instrument was ACTUALLY invoked, rather
+# than trusting the finder agent's own receipt
+# (tactic-lane-instrument-substitution-guard, Unit 4).
+#
+# Every fixture is a hand-authored .jsonl in the real Claude transcript record
+# shape: one JSON object per line carrying .type/.cwd/.timestamp/.sessionId and
+# a .message.content[] array of tool_use / tool_result blocks.
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=dispatch-test-fixture.sh
+source "$FIXTURE_DIR/dispatch-test-fixture.sh"
+
+SUT="$SCRIPT_DIR/dispatch-verify-instrument-invocation"
+
+echo "Test: dispatch-verify-instrument-invocation"
+
+# Temp projects root. mktemp -d honors $TMPDIR when set and is what every
+# sibling suite in this directory uses, so it never lands in a bare /tmp the
+# sandbox denies (.claude/rules/sandbox.md).
+VERIFY_ROOT="$(mktemp -d)"
+# Chain onto the fixture's own EXIT trap (dispatch-test-fixture.sh:1394) rather
+# than replacing it — a bare `trap ... EXIT` here would silently disarm the
+# host-systemd leak guard and the fixture's own tmp cleanup.
+trap 'rm -rf "$VERIFY_ROOT"; _dispatch_test_exit_trap' EXIT
+export DISPATCH_AUDIT_PROJECTS_ROOT="$VERIFY_ROOT"
+
+CWD_A="/home/tester/wt/node-a"
+CWD_B="/home/tester/wt/node-b"
+SINCE="2026-07-31T12:00:00.000Z"
+T_OK="2026-07-31T12:05:00.000Z"
+T_OLD="2026-07-31T09:00:00.000Z"
+
+# Mimic the nested workflow-subagent layout so the recursive find is exercised
+# at its deepest real nesting, not just the flat top level.
+PROJ_DIR="$VERIFY_ROOT/-home-tester-wt-node-a/sess-1/subagents/workflows/wf_abc"
+mkdir -p "$PROJ_DIR"
+
+# write_case <file> — reset the fixture tree to just this file's records (read
+# from stdin), so cases never leak evidence into each other.
+reset_fixtures() {
+  rm -f "$PROJ_DIR"/*.jsonl
+}
+
+# --- helpers to emit one transcript record ----------------------------------
+
+skill_use_record() {
+  # $1 cwd  $2 timestamp  $3 tool_use id  $4 skill arg
+  jq -n -c --arg cwd "$1" --arg ts "$2" --arg id "$3" --arg skill "$4" '{
+    type: "assistant", cwd: $cwd, timestamp: $ts, sessionId: "sess-1",
+    message: { role: "assistant", content: [
+      { type: "tool_use", id: $id, name: "Skill", input: { skill: $skill, args: "" } }
+    ] }
+  }'
+}
+
+bash_use_record() {
+  # $1 cwd  $2 timestamp  $3 tool_use id  $4 command
+  jq -n -c --arg cwd "$1" --arg ts "$2" --arg id "$3" --arg cmd "$4" '{
+    type: "assistant", cwd: $cwd, timestamp: $ts, sessionId: "sess-1",
+    message: { role: "assistant", content: [
+      { type: "tool_use", id: $id, name: "Bash", input: { command: $cmd } }
+    ] }
+  }'
+}
+
+ok_result_record() {
+  # $1 cwd  $2 timestamp  $3 tool_use_id
+  jq -n -c --arg cwd "$1" --arg ts "$2" --arg id "$3" '{
+    type: "user", cwd: $cwd, timestamp: $ts, sessionId: "sess-1",
+    message: { role: "user", content: [
+      { type: "tool_result", tool_use_id: $id, is_error: false, content: "done" }
+    ] }
+  }'
+}
+
+err_result_record() {
+  # $1 cwd  $2 timestamp  $3 tool_use_id  $4 error text
+  jq -n -c --arg cwd "$1" --arg ts "$2" --arg id "$3" --arg text "$4" '{
+    type: "user", cwd: $cwd, timestamp: $ts, sessionId: "sess-1",
+    message: { role: "user", content: [
+      { type: "tool_result", tool_use_id: $id, is_error: true, content: $text }
+    ] }
+  }'
+}
+
+# The verbatim rejection the substitution incident produced.
+REJECT_TEXT='<tool_use_error>Skill code-review cannot be used with Skill tool due to disable-model-invocation</tool_use_error>'
+
+run_sut() {
+  # Runs the SUT, capturing stdout and exit code into OUT / RC.
+  set +e
+  OUT=$("$@" 2>/dev/null)
+  RC=$?
+  set -e
+}
+
+# ============================================================================
+# Case 1 — a real, successful invocation: tool_use + paired non-error result.
+# ============================================================================
+reset_fixtures
+{
+  skill_use_record "$CWD_A" "$T_OK" "toolu_ok1" "code-review"
+  ok_result_record "$CWD_A" "$T_OK" "toolu_ok1"
+} > "$PROJ_DIR/agent-ok.jsonl"
+
+run_sut "$SUT" --instrument code-review --kind skill --skill code-review \
+  --since "$SINCE" --cwd "$CWD_A" --wait-secs 0
+assert_eq "case 1: successful invocation exits 0" "0" "$RC"
+assert_eq "case 1: verified" "true" "$(jq -r '.verified' <<<"$OUT")"
+assert_eq "case 1: invocations counted" "1" "$(jq -r '.invocations' <<<"$OUT")"
+assert_eq "case 1: succeeded counted" "1" "$(jq -r '.succeeded' <<<"$OUT")"
+assert_eq "case 1: no rejections" "0" "$(jq -r '.rejections' <<<"$OUT")"
+assert_eq "case 1: reason empty" "" "$(jq -r '.reason' <<<"$OUT")"
+
+# ============================================================================
+# Case 2 — the real rejection: is_error result carrying the substitution text.
+# ============================================================================
+reset_fixtures
+err_result_record "$CWD_A" "$T_OK" "toolu_rej1" "$REJECT_TEXT" > "$PROJ_DIR/agent-rej.jsonl"
+
+run_sut "$SUT" --instrument code-review --kind skill --skill code-review \
+  --since "$SINCE" --cwd "$CWD_A" --wait-secs 0
+assert_eq "case 2: rejection exits 1" "1" "$RC"
+assert_eq "case 2: not verified" "false" "$(jq -r '.verified' <<<"$OUT")"
+assert_eq "case 2: rejections counted" "1" "$(jq -r '.rejections' <<<"$OUT")"
+assert_eq "case 2: failure_text is verbatim" "$REJECT_TEXT" "$(jq -r '.failure_text' <<<"$OUT")"
+# A rejection IS evidence, so the fail-closed no-evidence reason must NOT fire.
+assert_eq "case 2: reason empty (rejection is evidence)" "" "$(jq -r '.reason' <<<"$OUT")"
+
+# ============================================================================
+# Case 3 — cwd scoping: the same rejection, but recorded under a DIFFERENT cwd.
+# A rejection in another worktree must not poison this worktree's verdict.
+# ============================================================================
+reset_fixtures
+err_result_record "$CWD_B" "$T_OK" "toolu_rej1" "$REJECT_TEXT" > "$PROJ_DIR/agent-rej.jsonl"
+
+run_sut "$SUT" --instrument code-review --kind skill --skill code-review \
+  --since "$SINCE" --cwd "$CWD_A" --wait-secs 0
+assert_eq "case 3: foreign-cwd rejection exits 1" "1" "$RC"
+assert_eq "case 3: not verified" "false" "$(jq -r '.verified' <<<"$OUT")"
+assert_eq "case 3: foreign rejection not counted" "0" "$(jq -r '.rejections' <<<"$OUT")"
+assert_eq "case 3: fail-closed reason" "no invocation record found" "$(jq -r '.reason' <<<"$OUT")"
+
+# ============================================================================
+# Case 4 — since filtering: a successful invocation that predates --since.
+# ============================================================================
+reset_fixtures
+{
+  skill_use_record "$CWD_A" "$T_OLD" "toolu_old1" "code-review"
+  ok_result_record "$CWD_A" "$T_OLD" "toolu_old1"
+} > "$PROJ_DIR/agent-old.jsonl"
+
+run_sut "$SUT" --instrument code-review --kind skill --skill code-review \
+  --since "$SINCE" --cwd "$CWD_A" --wait-secs 0
+assert_eq "case 4: pre-since invocation exits 1" "1" "$RC"
+assert_eq "case 4: not verified" "false" "$(jq -r '.verified' <<<"$OUT")"
+assert_eq "case 4: pre-since invocation not counted" "0" "$(jq -r '.invocations' <<<"$OUT")"
+assert_eq "case 4: fail-closed reason" "no invocation record found" "$(jq -r '.reason' <<<"$OUT")"
+
+# ============================================================================
+# Case 5 — --kind command: a Bash tool_use matching an ERE, paired with a
+# non-error result. Forward-compatibility for a future non-Skill instrument.
+# ============================================================================
+reset_fixtures
+{
+  bash_use_record "$CWD_A" "$T_OK" "toolu_cmd1" "npx some-linter --strict ."
+  ok_result_record "$CWD_A" "$T_OK" "toolu_cmd1"
+} > "$PROJ_DIR/agent-cmd.jsonl"
+
+run_sut "$SUT" --instrument some-linter --kind command \
+  --command-pattern '(^|/| )some-linter( |$)' \
+  --since "$SINCE" --cwd "$CWD_A" --wait-secs 0
+assert_eq "case 5: command-kind invocation exits 0" "0" "$RC"
+assert_eq "case 5: verified" "true" "$(jq -r '.verified' <<<"$OUT")"
+assert_eq "case 5: invocations counted" "1" "$(jq -r '.invocations' <<<"$OUT")"
+assert_eq "case 5: kind echoed" "command" "$(jq -r '.kind' <<<"$OUT")"
+
+# A non-matching command must NOT count.
+reset_fixtures
+{
+  bash_use_record "$CWD_A" "$T_OK" "toolu_cmd2" "npx other-linter ."
+  ok_result_record "$CWD_A" "$T_OK" "toolu_cmd2"
+} > "$PROJ_DIR/agent-cmd.jsonl"
+
+run_sut "$SUT" --instrument some-linter --kind command \
+  --command-pattern '(^|/| )some-linter( |$)' \
+  --since "$SINCE" --cwd "$CWD_A" --wait-secs 0
+assert_eq "case 5b: non-matching command exits 1" "1" "$RC"
+assert_eq "case 5b: non-matching command not counted" "0" "$(jq -r '.invocations' <<<"$OUT")"
+
+# ============================================================================
+# Case 6 — usage error: --instrument omitted. Exit 2, NO stdout JSON.
+# ============================================================================
+run_sut "$SUT" --kind skill --skill code-review --since "$SINCE" --cwd "$CWD_A" --wait-secs 0
+assert_eq "case 6: missing --instrument exits 2" "2" "$RC"
+assert_eq "case 6: missing --instrument prints no stdout" "" "$OUT"
+
+# Environment error: an absent transcript root is exit 2, never verified:false.
+run_sut env DISPATCH_AUDIT_PROJECTS_ROOT="$VERIFY_ROOT/does-not-exist" \
+  "$SUT" --instrument code-review --kind skill --skill code-review \
+  --since "$SINCE" --cwd "$CWD_A" --wait-secs 0
+assert_eq "case 6b: absent transcript root exits 2" "2" "$RC"
+assert_eq "case 6b: absent transcript root prints no stdout" "" "$OUT"
+
+# Unparseable --since is likewise an environment error, not a false verdict.
+run_sut "$SUT" --instrument code-review --kind skill --skill code-review \
+  --since "yesterday" --cwd "$CWD_A" --wait-secs 0
+assert_eq "case 6c: unparseable --since exits 2" "2" "$RC"
+assert_eq "case 6c: unparseable --since prints no stdout" "" "$OUT"
+
+report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-review-fix-instrument.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-review-fix-instrument.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Tests for the instrument gate (INSTRUMENTS + instrumentVerdict, sliced out of
+# .claude/workflows/review-fix.js by review-fix-instrument-probe.mjs) --
+# modeled directly on test-qa-fix-partition.sh (tactic-lane-instrument-substitution-guard).
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=dispatch-test-fixture.sh
+source "$FIXTURE_DIR/dispatch-test-fixture.sh"
+
+# ============================================================================
+# === review-fix instrument gate (tactic-lane-instrument-substitution-guard) ===
+# ============================================================================
+# CI vector: run-unit-tests.sh has no mapping for .claude/workflows/*, so a PR
+# touching only review-fix.js triggers no vitest suite. The hook-tests job
+# (this script) is the only test that runs on every PR, so coverage for
+# instrumentVerdict must live here. The probe slices the pure INSTRUMENTS +
+# instrumentVerdict text out of review-fix.js between sentinel comments and
+# evals just that slice.
+
+echo "Test: review-fix instrument gate"
+
+out=$(node "$SCRIPT_DIR/review-fix-instrument-probe.mjs")
+
+# Lane-B lenses (no named instrument) — the gate must not touch them.
+assert_eq "instrument gate: lane-b ok" "true" "$(printf '%s' "$out" | jq -r '."lane-b".ok')"
+assert_eq "instrument gate: lane-b checked" "false" "$(printf '%s' "$out" | jq -r '."lane-b".checked')"
+
+# null finder result (probe-wave throttle signal) — must pass through inert.
+assert_eq "instrument gate: null-res ok" "true" "$(printf '%s' "$out" | jq -r '."null-res".ok')"
+assert_eq "instrument gate: null-res checked" "false" "$(printf '%s' "$out" | jq -r '."null-res".checked')"
+
+# no instrument receipt at all — schema violation, must fail.
+assert_eq "instrument gate: no-receipt ok" "false" "$(printf '%s' "$out" | jq -r '."no-receipt".ok')"
+
+# instrument receipt names the wrong stage — must fail.
+assert_eq "instrument gate: wrong-name ok" "false" "$(printf '%s' "$out" | jq -r '."wrong-name".ok')"
+
+# instrument reported not invoked — must fail, and the reason must carry the
+# verbatim failure text so a human/agent reading it sees why the skill refused.
+assert_eq "instrument gate: not-invoked ok" "false" "$(printf '%s' "$out" | jq -r '."not-invoked".ok')"
+assert_eq "instrument gate: not-invoked reason contains failure text" "true" \
+  "$(printf '%s' "$out" | jq -r '."not-invoked".reason | contains("Skill code-review cannot be used with Skill tool due to disable-model-invocation")')"
+
+# payload-signature mismatch: code-review (edits_nothing:false) reports a fix
+# with no touched_files — must fail.
+assert_eq "instrument gate: sig-no-touched-files ok" "false" "$(printf '%s' "$out" | jq -r '."sig-no-touched-files".ok')"
+
+# payload-signature mismatch: security-review (edits_nothing:true) reports a
+# non-empty fixed[] — must fail.
+assert_eq "instrument gate: sig-security-edited ok" "false" "$(printf '%s' "$out" | jq -r '."sig-security-edited".ok')"
+
+# clean receipts — must pass and be marked checked.
+assert_eq "instrument gate: clean-code-review ok" "true" "$(printf '%s' "$out" | jq -r '."clean-code-review".ok')"
+assert_eq "instrument gate: clean-code-review checked" "true" "$(printf '%s' "$out" | jq -r '."clean-code-review".checked')"
+assert_eq "instrument gate: clean-security-review ok" "true" "$(printf '%s' "$out" | jq -r '."clean-security-review".ok')"
+assert_eq "instrument gate: clean-security-review checked" "true" "$(printf '%s' "$out" | jq -r '."clean-security-review".checked')"
+
+# --- call-site / doctrine coverage (anti-regression teeth) ------------------
+# A future edit that keeps instrumentVerdict but stops calling it would
+# otherwise pass every fixture case above. These greps pin the call site and
+# every downstream consumer that must still reference it.
+
+# The gate call site — not just the definition.
+assert_eq "instrument gate: call site present in review-fix.js" "1" \
+  "$(grep -c 'const v = instrumentVerdict(name, res);' "$REPO_ROOT/.claude/workflows/review-fix.js" || true)"
+
+# code-review capture const is guarded by instrumentFailed.
+assert_eq "instrument gate: codeReviewResult guarded by instrumentFailed" "1" \
+  "$(grep -c "instrumentFailed.has('code-review')" "$REPO_ROOT/.claude/workflows/review-fix.js" || true)"
+
+# security-review capture const is guarded by instrumentFailed.
+assert_eq "instrument gate: securityReviewResult guarded by instrumentFailed" "1" \
+  "$(grep -c "instrumentFailed.has('security-review')" "$REPO_ROOT/.claude/workflows/review-fix.js" || true)"
+
+# instrument_failures is surfaced in the returned object.
+assert_eq "instrument gate: instrument_failures in returned object" "1" \
+  "$(grep -c 'instrument_failures: instrumentFailures' "$REPO_ROOT/.claude/workflows/review-fix.js" || true)"
+
+# instrumentFailures.length is folded into deviation (and gates coverage_incomplete
+# above it) — two sites total in the current file.
+assert_eq "instrument gate: instrumentFailures.length referenced" "2" \
+  "$(grep -c 'instrumentFailures.length' "$REPO_ROOT/.claude/workflows/review-fix.js" || true)"
+
+# instrumentClause(...) is CALLED in BOTH Lane-A prompt branches (code-review,
+# security-review). Match the call sites (instrumentClause(INSTRUMENTS[...]))
+# rather than the bare substring, which would also match the one-line function
+# definition (`function instrumentClause(spec) {`) and over-count to 3.
+assert_eq "instrument gate: instrumentClause used in both Lane-A prompt branches" "2" \
+  "$(grep -c 'instrumentClause(INSTRUMENTS' "$REPO_ROOT/.claude/workflows/review-fix.js" || true)"
+
+# LANE_A_SCHEMA requires 'instrument' in its payload.
+assert_eq "instrument gate: LANE_A_SCHEMA requires instrument" "1" \
+  "$(grep -c "required: \['fixed', 'residue', 'instrument'\]" "$REPO_ROOT/.claude/workflows/review-fix.js" || true)"
+
+report_results

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -295,6 +295,7 @@ result = {
   security_followup_input: [ ...codeql/npm out-of-scope subset... ],
   verify_report:        [ {id, location, verdict, skeptic_votes, rationale} ],
   deviation:            <bool>,
+  instrument_failures:  [ {instrument, reason} ],
   coverage_incomplete:  <bool>,
   coverage_note?:       <string>,
   security_note?:       <string>

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -261,7 +261,15 @@ command block, normalization rules, and the per-finder roster and descriptions.
 ### 2. Build `args` and invoke the Workflow
 
 Collect the fields for the Workflow invocation. Parse `Closes #N` from the pack's
-`=== PR ===` body to resolve `implementing_issues`:
+`=== PR ===` body to resolve `implementing_issues`. Workflow scripts cannot call
+`new Date()` / `Date.now()` themselves (the runtime throws — it would break
+resume), so capture the instrument-verification lower-bound timestamp here in
+bash, immediately before invoking the Workflow, and pass it through as
+`run_started_at`:
+
+```bash
+RUN_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+```
 
 ```
 args = {
@@ -273,6 +281,7 @@ args = {
   app_or_rules:        <true|false>,
   prescanned_findings: [ ...normalized CodeQL + npm + erosion findings in Per-finding schema... ],
   implementing_issues: [ <N>, ... ],    // parsed from Closes #N lines; [] if none
+  run_started_at:      <RUN_STARTED_AT>, // ISO8601 lower bound for the instrument-invocation transcript verifier
   security_note:       <string or omit>, // set for empty/docs/tests; omit for code
   prior_phase_log:     <string or omit> // PRIOR_PHASE_LOG from the preamble; omit when phase-log: none
 }

--- a/.claude/skills/review-fix/references/schema-edge-cases-notes.md
+++ b/.claude/skills/review-fix/references/schema-edge-cases-notes.md
@@ -121,7 +121,15 @@ Step 7 escalates to office-hours via `dispatch-mark-deviation`. The transcript
 verdict wins any disagreement with the receipt: a receipt claiming `invoked:true`
 against a transcript that shows no successful invocation is exactly the
 fabrication signature the check exists to catch, and a verifier agent that died
-fails the gate too (fail-closed).
+fails the gate too (fail-closed). That verifier agent sees counts and booleans
+only: the verify script's verbatim transcript rejection text is
+attacker-influenceable (it is transcript content — the error body of this
+instrument's own failed tool call, quoted verbatim), so each command it runs
+projects the verdict down to
+`{instrument, verified, invocations, succeeded, rejections}` with `jq` and drops
+stderr before the output reaches the agent, and the schema has no free-text field.
+The "why not verified" phrase in `coverage_note` is rebuilt from those integers by
+the orchestrator, never transcribed by the agent.
 
 Do not conflate this with the throttle path above. They look superficially alike
 — both set `coverage_incomplete` — but they end differently and deliberately so:

--- a/.claude/skills/review-fix/references/schema-edge-cases-notes.md
+++ b/.claude/skills/review-fix/references/schema-edge-cases-notes.md
@@ -106,3 +106,37 @@ This is a launch-efficiency change only; genuine worker *death* on a transient
 rate-limit (and its backed-off resume) remains #1733's responsibility via the Stop
 hook, not this gate. `coverage_incomplete` is independent of the `deviation`
 criterion.
+
+**Unverified instrument — NOT the same path as the throttle short-circuit.** A
+Lane-A finder (`code-review`, `security-review`) names a built-in instrument it
+must actually invoke. Two independent checks run: the finder's own
+`instrument: {name, invoked, failure_text}` receipt, and a separate agent's read
+of the actual Claude session transcript record (via
+`.claude/skills/dispatch-propagate/scripts/dispatch-verify-instrument-invocation`).
+Either one failing discards that instrument's payload entirely — never merged
+under the instrument's name, never dispositioned, never credited to
+`fixes_applied` — records the reason in `result.instrument_failures`, sets
+`coverage_incomplete` with a human `coverage_note`, **and sets `deviation`**, so
+Step 7 escalates to office-hours via `dispatch-mark-deviation`. The transcript
+verdict wins any disagreement with the receipt: a receipt claiming `invoked:true`
+against a transcript that shows no successful invocation is exactly the
+fabrication signature the check exists to catch, and a verifier agent that died
+fails the gate too (fail-closed).
+
+Do not conflate this with the throttle path above. They look superficially alike
+— both set `coverage_incomplete` — but they end differently and deliberately so:
+
+| | throttle short-circuit | unverified instrument |
+|---|---|---|
+| trigger | finder returned `null` (died after retries) | receipt or transcript check failed |
+| payload | there was none | discarded |
+| `deviation` | unchanged (usually false) | **true** |
+| terminal action | applies `dispatch:reviewed`, writes the marker | escalates to office-hours |
+
+The reason for the split: a `null` finder contributed no payload, so nothing is
+attributed to the instrument and there is nothing to guard — turning that into a
+lane failure would park the node on every rate-limit. An unverified instrument,
+by contrast, means a review was reported under a name that did not run. That is
+not a degraded review, it is a false one, and it escalates unconditionally
+(never severity-scaled — the failure is that the review did not happen, not that
+a finding went unfixed).

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -294,6 +294,38 @@ const RESIDUE_TREE_SCHEMA = {
   },
 };
 
+// Independent instrument-invocation verification schema — the non-fabricable half
+// of the instrument gate. instrumentVerdict() below can only read a receipt the
+// finder wrote about ITSELF; `invoked: true` is fabricable. This schema carries the
+// verdict of a SEPARATE agent whose only job is to run
+// .claude/skills/dispatch-propagate/scripts/dispatch-verify-instrument-invocation,
+// which reads the actual Claude session transcript record (tool-call history). Like
+// residue-tree-verify, that agent is fed NO finding text — only a command line — so
+// a prompt-injection payload embedded in an attacker-controlled finding description
+// cannot steer it.
+const INSTRUMENT_VERIFY_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['results'],
+  properties: {
+    results: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['instrument', 'verified', 'rejections', 'failure_text', 'reason'],
+        properties: {
+          instrument: { type: 'string' },
+          verified: { type: 'boolean' },
+          rejections: { type: 'integer' },
+          failure_text: { type: 'string' },
+          reason: { type: 'string' },
+        },
+      },
+    },
+  },
+};
+
 // --- inline kernel helpers (thin mirrors of the pure scripts) ----------------
 
 // The trust-the-built-in review-and-fix sources: these run the built-in review
@@ -661,6 +693,11 @@ function finderPrompt(name, args) {
 const _a = typeof args === 'string' ? JSON.parse(args) : (args || {});
 log(`args type: ${typeof args}; surface=${_a.surface}; changed_files count=${(_a.changed_files || []).length}`);
 
+// Lower bound for the instrument-invocation transcript search. Captured ONCE here,
+// before any finder is launched, so the verifier can never credit an invocation
+// recorded by an earlier run in this same worktree.
+const runStartedAt = new Date().toISOString();
+
 // subagents_launched (source 1, this Workflow's own fan-out): a single
 // accumulator incremented at each spawn site, inside the guard that actually
 // launches the agents. A launched-but-dead agent still counts — increment at
@@ -741,6 +778,71 @@ const finderResults = qualityFinders
   .map((name, i) => ({ name, res: qualityResults[i] }))
   .concat(securityFinders.map((name, i) => ({ name, res: securityResults[i] })));
 
+// --- independent instrument-invocation verification --------------------------
+// The receipt instrumentVerdict() reads is SELF-REPORTED by the same agent that
+// might fabricate it. The honest "it failed" path is trustworthy — an agent
+// narrating its own rejection is not lying in the direction that hurts — but
+// `invoked: true` is fabricable. Check it against the actual transcript record.
+//
+// Modeled on residue-tree-verify: ONE separate, minimally-scoped agent, fed ONLY
+// the command line(s) to run and the return shape. NO finding text, NO residue
+// content, NO diff context reaches it. That is load-bearing, not tidiness: it is
+// what keeps a prompt-injection payload embedded in an untrusted finding
+// description from steering the verifier into reporting a false `verified`.
+const laneAChecked = finderResults
+  .filter(({ name, res }) => INSTRUMENTS[name] && res !== null && res !== undefined)
+  .map(({ name }) => name);
+let instrumentVerifyResults = null;
+if (laneAChecked.length) {
+  const verifyLines = laneAChecked.map((name) => {
+    const spec = INSTRUMENTS[name];
+    return (
+      `.claude/skills/dispatch-propagate/scripts/dispatch-verify-instrument-invocation ` +
+      `--instrument ${name} --kind ${spec.kind} --skill ${spec.skill} ` +
+      `--since ${runStartedAt} --cwd <CWD>`
+    );
+  });
+  subagentsLaunched += 1;
+  instrumentVerifyResults = await agent(
+    [
+      'FIRST run `pwd` and note the absolute path it prints. Substitute that path',
+      'for <CWD> in every command below (the orchestrator cannot inject a literal',
+      'cwd reliably across environments, so you determine it yourself).',
+      '',
+      'Then run EACH of these commands exactly as written, from that directory:',
+      ...verifyLines,
+      '',
+      'A non-zero exit from this command is EXPECTED and NORMAL when the instrument',
+      'was not verified — this is a successful verification run reporting a negative',
+      'result, NOT a failure of your task. You MUST return the JSON printed on the',
+      "command's stdout regardless of its exit status. Do NOT treat a non-zero exit",
+      'as your own failure and do NOT retry the command.',
+      '',
+      'Make NO edits, NO commits, NO pushes; run nothing else.',
+      '',
+      'Return { "results": [ ... ] } with one object per command, each carrying the',
+      'instrument, verified, rejections, failure_text and reason values from that',
+      "command's stdout JSON. If a command printed no stdout JSON at all, return that",
+      'instrument with verified:false, rejections:0, failure_text:"" and reason set to',
+      'the stderr diagnostic.',
+    ].join('\n'),
+    {
+      model: 'sonnet',
+      agentType: 'general-purpose',
+      schema: INSTRUMENT_VERIFY_SCHEMA,
+      label: 'instrument-verify',
+      phase: 'finders',
+    }
+  );
+}
+// Index the transcript verdicts by instrument name. `null` means the verifier
+// agent itself died after retries — NOT "verification not required": every
+// checked instrument then fails the gate below (fail-closed).
+const verifyByInstrument = new Map();
+for (const r of (instrumentVerifyResults && instrumentVerifyResults.results) || []) {
+  if (r && typeof r.instrument === 'string') verifyByInstrument.set(r.instrument, r);
+}
+
 // --- instrument gate ---------------------------------------------------------
 // A stage that claims to have run a named built-in must return a receipt proving
 // it did. A missing/false/inconsistent receipt means the named review did NOT
@@ -750,10 +852,33 @@ const instrumentFailures = []; // [{ instrument, reason }]
 const instrumentFailed = new Set();
 for (const { name, res } of finderResults) {
   const v = instrumentVerdict(name, res);
-  if (v.ok) continue;
-  instrumentFailures.push({ instrument: name, reason: v.reason });
+  if (!v.ok) {
+    instrumentFailures.push({ instrument: name, reason: v.reason });
+    instrumentFailed.add(name);
+    log(`finders: INSTRUMENT GATE FAILED — ${v.reason}`);
+  }
+  // Transcript check. This runs even when the self-report already PASSED: a
+  // receipt-vs-transcript disagreement (receipt says invoked, transcript
+  // disagrees) is exactly the fabrication signature this stage exists to catch,
+  // and the transcript verdict WINS that conflict. It is skipped where the
+  // self-report gate itself does not apply (Lane-B lens, or a dead finder whose
+  // null result is the probe-wave throttle signal) OR where the self-report
+  // already failed this instrument above — a second push here would double-count
+  // the same instrument in instrumentFailures/coverage_note.
+  if (!laneAChecked.includes(name) || instrumentFailed.has(name)) continue;
+  const tv = verifyByInstrument.get(name);
+  if (tv && tv.verified === true) continue;
+  const why = tv
+    ? String(tv.reason || tv.failure_text || 'no verdict detail returned')
+        .trim()
+        .replace(/\s+/g, ' ')
+    : 'the independent transcript verifier returned no result (agent died after retries)';
+  const reason =
+    `${name}: instrument invocation not verified in the transcript record — ` +
+    (why.length <= 300 ? why : why.slice(0, 300));
+  instrumentFailures.push({ instrument: name, reason });
   instrumentFailed.add(name);
-  log(`finders: INSTRUMENT GATE FAILED — ${v.reason}`);
+  log(`finders: INSTRUMENT GATE FAILED — ${reason}`);
 }
 if (instrumentFailures.length) {
   coverage_incomplete = true;

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -21,7 +21,9 @@
  *     deps:bool, app_or_rules:bool,
  *     prescanned_findings:[...Per-finding items, Source "codeql"|"npm",
  *       carrying their source-specific fields...],
- *     implementing_issues:[N,...], security_note?:string }
+ *     implementing_issues:[N,...], run_started_at:string (ISO8601, captured by
+ *       the skill via `date -u` immediately before this Workflow is invoked —
+ *       this script cannot call `new Date()`/`Date.now()` itself), security_note?:string }
  *
  * return OUT (the ONLY thing this script returns):
  *   { dispositions:[{id, short_desc, location, bucket, sources:[...],
@@ -299,10 +301,17 @@ const RESIDUE_TREE_SCHEMA = {
 // finder wrote about ITSELF; `invoked: true` is fabricable. This schema carries the
 // verdict of a SEPARATE agent whose only job is to run
 // .claude/skills/dispatch-propagate/scripts/dispatch-verify-instrument-invocation,
-// which reads the actual Claude session transcript record (tool-call history). Like
-// residue-tree-verify, that agent is fed NO finding text — only a command line — so
-// a prompt-injection payload embedded in an attacker-controlled finding description
-// cannot steer it.
+// which reads the actual Claude session transcript record (tool-call history).
+//
+// The schema is deliberately COUNTS-AND-BOOLEANS ONLY — no free-text field. The
+// verify script also emits a `failure_text` (the verbatim rejection message it
+// found in the transcript) and a `reason`, but that rejection text is transcript
+// content selected by a substring match, i.e. attacker-influenceable: a payload
+// planted in an errored tool_result would land in the verifier's context in the
+// position of maximum influence over its own output if the agent were asked to
+// transcribe it. So the command the agent runs projects those fields away before
+// the agent ever sees them (see verifyLines below), and the human-readable
+// "why not verified" phrase is derived script-side from these integers.
 const INSTRUMENT_VERIFY_SCHEMA = {
   type: 'object',
   additionalProperties: false,
@@ -313,13 +322,13 @@ const INSTRUMENT_VERIFY_SCHEMA = {
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['instrument', 'verified', 'rejections', 'failure_text', 'reason'],
+        required: ['instrument', 'verified', 'invocations', 'succeeded', 'rejections'],
         properties: {
           instrument: { type: 'string' },
           verified: { type: 'boolean' },
+          invocations: { type: 'integer' },
+          succeeded: { type: 'integer' },
           rejections: { type: 'integer' },
-          failure_text: { type: 'string' },
-          reason: { type: 'string' },
         },
       },
     },
@@ -423,6 +432,31 @@ function instrumentVerdict(name, res) {
   return { ok: true, checked: true, reason: '' };
 }
 // <<< instrument gate <<<
+
+// Pure. Renders the independent transcript verdict as a FIXED, script-authored
+// phrase derived only from the verdict's integer counts. Nothing the verifier
+// agent read as text is passed through: the rejection message the verify script
+// finds in the transcript is attacker-influenceable, so it is projected away
+// before the agent sees it and never reconstructed here. `tv` is null/undefined
+// when the verifier agent itself died after retries (fail-closed).
+function transcriptVerdictDetail(tv) {
+  if (!tv) {
+    return 'the independent transcript verifier returned no result (agent died after retries)';
+  }
+  const rejections = Number.isFinite(tv.rejections) ? tv.rejections : 0;
+  const invocations = Number.isFinite(tv.invocations) ? tv.invocations : 0;
+  const succeeded = Number.isFinite(tv.succeeded) ? tv.succeeded : 0;
+  if (rejections > 0) {
+    return `the transcript records ${rejections} rejected invocation(s) of this instrument`;
+  }
+  if (invocations === 0) {
+    return 'no invocation record found in the transcript';
+  }
+  if (succeeded === 0) {
+    return `${invocations} invocation record(s) found, none of which returned successfully`;
+  }
+  return 'the verifier reported verified:false';
+}
 
 // normative spec: .claude/skills/dispatch-propagate/scripts/dispatch-review-finders
 // Returns the AGENT finder-source set (the codeql/npm finders are NOT agents —
@@ -693,10 +727,14 @@ function finderPrompt(name, args) {
 const _a = typeof args === 'string' ? JSON.parse(args) : (args || {});
 log(`args type: ${typeof args}; surface=${_a.surface}; changed_files count=${(_a.changed_files || []).length}`);
 
-// Lower bound for the instrument-invocation transcript search. Captured ONCE here,
-// before any finder is launched, so the verifier can never credit an invocation
-// recorded by an earlier run in this same worktree.
-const runStartedAt = new Date().toISOString();
+// Lower bound for the instrument-invocation transcript search. The skill
+// captures this in bash (via `date -u`) immediately before invoking this
+// Workflow and passes it in as `args.run_started_at` — Workflow scripts cannot
+// call `new Date()`/`Date.now()` themselves (it would break resume; the
+// runtime throws on any such call). Capturing it in the caller, one step
+// before the Workflow launches any finder, still gives the verifier a lower
+// bound no earlier run in this worktree could have satisfied.
+const runStartedAt = _a.run_started_at;
 
 // subagents_launched (source 1, this Workflow's own fan-out): a single
 // accumulator incremented at each spawn site, inside the guard that actually
@@ -786,9 +824,20 @@ const finderResults = qualityFinders
 //
 // Modeled on residue-tree-verify: ONE separate, minimally-scoped agent, fed ONLY
 // the command line(s) to run and the return shape. NO finding text, NO residue
-// content, NO diff context reaches it. That is load-bearing, not tidiness: it is
-// what keeps a prompt-injection payload embedded in an untrusted finding
-// description from steering the verifier into reporting a false `verified`.
+// content, NO diff context reaches it.
+//
+// Being fed no ORCHESTRATOR-supplied text is not by itself isolation, because the
+// command the agent runs prints text of its own: the verify script reports the
+// verbatim transcript rejection message as `failure_text`, and that string is
+// transcript content selected by a substring match — attacker-influenceable by
+// exactly the primitive this gate exists to catch (plant a crafted
+// `<tool_use_error>` payload, get it read back into the verifier's context, and
+// steer it into reporting a false `verified`). So the isolation is enforced in the
+// command line, not in the prompt: each command projects the verdict down to
+// counts and booleans with `jq` and drops stderr, so the untrusted text never
+// enters the agent's context at all, and the schema has no free-text field for it
+// to land in. The "why not verified" prose the gate reports is rebuilt script-side
+// from the integers by transcriptVerdictDetail().
 const laneAChecked = finderResults
   .filter(({ name, res }) => INSTRUMENTS[name] && res !== null && res !== undefined)
   .map(({ name }) => name);
@@ -796,10 +845,15 @@ let instrumentVerifyResults = null;
 if (laneAChecked.length) {
   const verifyLines = laneAChecked.map((name) => {
     const spec = INSTRUMENTS[name];
+    // The trailing `2>/dev/null | jq …` is the isolation boundary, not cosmetics:
+    // it strips the verify script's verbatim transcript rejection text (and its
+    // stderr, which echoes transcript file paths) so only counts and booleans
+    // reach the agent's context.
     return (
       `.claude/skills/dispatch-propagate/scripts/dispatch-verify-instrument-invocation ` +
       `--instrument ${name} --kind ${spec.kind} --skill ${spec.skill} ` +
-      `--since ${runStartedAt} --cwd <CWD>`
+      `--since ${runStartedAt} --cwd <CWD> 2>/dev/null ` +
+      `| jq -c '{instrument, verified, invocations, succeeded, rejections}'`
     );
   });
   subagentsLaunched += 1;
@@ -812,19 +866,24 @@ if (laneAChecked.length) {
       'Then run EACH of these commands exactly as written, from that directory:',
       ...verifyLines,
       '',
-      'A non-zero exit from this command is EXPECTED and NORMAL when the instrument',
+      'Run each pipeline WHOLE — keep the `2>/dev/null` and the trailing `| jq ...`',
+      'exactly as given. Do NOT run the script without that filter, and do NOT go',
+      'looking for the unfiltered output: the filter is a security boundary, and the',
+      'five fields it prints are the only ones anyone wants from you.',
+      '',
+      'A non-zero exit from this pipeline is EXPECTED and NORMAL when the instrument',
       'was not verified — this is a successful verification run reporting a negative',
       'result, NOT a failure of your task. You MUST return the JSON printed on the',
-      "command's stdout regardless of its exit status. Do NOT treat a non-zero exit",
+      "pipeline's stdout regardless of its exit status. Do NOT treat a non-zero exit",
       'as your own failure and do NOT retry the command.',
       '',
       'Make NO edits, NO commits, NO pushes; run nothing else.',
       '',
-      'Return { "results": [ ... ] } with one object per command, each carrying the',
-      'instrument, verified, rejections, failure_text and reason values from that',
-      "command's stdout JSON. If a command printed no stdout JSON at all, return that",
-      'instrument with verified:false, rejections:0, failure_text:"" and reason set to',
-      'the stderr diagnostic.',
+      'Return { "results": [ ... ] } with one object per command, copying the',
+      'instrument, verified, invocations, succeeded and rejections values from that',
+      "pipeline's stdout JSON verbatim. If a pipeline printed no stdout JSON at all,",
+      'return that instrument with verified:false and invocations, succeeded and',
+      'rejections all 0. Report nothing else — no prose, no quoted output.',
     ].join('\n'),
     {
       model: 'sonnet',
@@ -868,14 +927,12 @@ for (const { name, res } of finderResults) {
   if (!laneAChecked.includes(name) || instrumentFailed.has(name)) continue;
   const tv = verifyByInstrument.get(name);
   if (tv && tv.verified === true) continue;
-  const why = tv
-    ? String(tv.reason || tv.failure_text || 'no verdict detail returned')
-        .trim()
-        .replace(/\s+/g, ' ')
-    : 'the independent transcript verifier returned no result (agent died after retries)';
+  // Script-authored detail only — see transcriptVerdictDetail(). No transcript
+  // text (attacker-influenceable) is echoed into the reason, so no truncation or
+  // sanitization is needed here.
   const reason =
     `${name}: instrument invocation not verified in the transcript record — ` +
-    (why.length <= 300 ? why : why.slice(0, 300));
+    transcriptVerdictDetail(tv);
   instrumentFailures.push({ instrument: name, reason });
   instrumentFailed.add(name);
   log(`finders: INSTRUMENT GATE FAILED — ${reason}`);

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -555,6 +555,28 @@ const DOMAIN_PROMPTS = {
     'Firebase-specific: Firestore rules permissiveness (overly broad `allow` conditions, missing field constraints), emulator-only code reachable on production paths, Firebase API key or config exposure.',
 };
 
+// Terminal-condition clause for a Lane-A finder that is required to invoke a
+// named built-in instrument. Invoking that instrument IS the finder's contract
+// — not a step toward its own review. A rejected/errored/unavailable
+// invocation is a terminal condition, not a retry point, and it is never
+// license to perform the review yourself and report it under the built-in's
+// name (that substitution is exactly how issue node
+// tactic-lane-instrument-substitution-guard's incident happened: four days
+// undetected).
+function instrumentClause(spec) {
+  return [
+    `Invoking ${spec.label} is this agent's ENTIRE contract.`,
+    `If that invocation is rejected, errors, or ${spec.label} is unavailable → terminal condition.`,
+    'Do NOT loop or retry.',
+    `Performing the review yourself is NOT an acceptable fallback. Output you produced yourself,`,
+    `reported under ${spec.label}'s name, is a false report.`,
+    'On that terminal condition, return exactly:',
+    `{ "fixed": [], "residue": [], "instrument": { "name": "${spec.skill}", "invoked": false, "failure_text": "<the VERBATIM error text you received, unedited>" } } and stop.`,
+    `On a successful invocation, return the normal payload with "instrument": { "name": "${spec.skill}", "invoked": true, "failure_text": "" }.`,
+    `Report "invoked": true ONLY if you received a non-error result from ${spec.label} itself — your own analysis is never that result.`,
+  ].join('\n');
+}
+
 function finderPrompt(name, args) {
   const ctx = diffContext(args);
   if (name === 'code-review') {
@@ -576,6 +598,7 @@ function finderPrompt(name, args) {
       '  action).',
       '- IGNORE every finding with outcome "no_change_needed" entirely — add it to neither array.',
       'Return `{ fixed: [...], residue: [...] }` matching the schema below.',
+      instrumentClause(INSTRUMENTS['code-review']),
       LANE_A_BLURB,
     ].join('\n');
   }
@@ -593,6 +616,7 @@ function finderPrompt(name, args) {
       '`exploit_scenario` (the concrete attack scenario from the report), `recommended_fix` (the',
       'concrete remediation from the report).',
       'Return `{ fixed: [], residue: [...] }` — `fixed` is always empty for this source.',
+      instrumentClause(INSTRUMENTS['security-review']),
       LANE_A_BLURB,
     ].join('\n');
   }

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -30,7 +30,8 @@
  *     deferred_filings:[{title, body, blocker_issue_nums:[N,...]|"independent"}],
  *     security_followup_input:[...codeql/npm out-of-scope subset...],
  *     verify_report:[{id, location, verdict, skeptic_votes, rationale}],
- *     deviation:bool, security_note?, coverage_incomplete:bool, coverage_note?:string }
+ *     deviation:bool, security_note?, coverage_incomplete:bool, coverage_note?:string,
+ *     instrument_failures:[{instrument, reason}] }
  *
  * NORMATIVE SPECS for the three inline kernel helpers below are the pure bash/jq
  * scripts (unit-tested by the per-SUT test-*.sh files sharing
@@ -185,8 +186,21 @@ const FIX_SCHEMA = {
 const LANE_A_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['fixed', 'residue'],
+  required: ['fixed', 'residue', 'instrument'],
   properties: {
+    // The instrument receipt: which named built-in this stage was required to
+    // invoke, whether it actually ran, and — when it did not — the verbatim
+    // failure text. Consumed by instrumentVerdict().
+    instrument: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['name', 'invoked', 'failure_text'],
+      properties: {
+        name: { type: 'string' },
+        invoked: { type: 'boolean' },
+        failure_text: { type: 'string' },
+      },
+    },
     fixed: {
       type: 'array',
       items: {
@@ -287,6 +301,96 @@ const RESIDUE_TREE_SCHEMA = {
 // fixed/residue envelope (LANE_A_SCHEMA) rather than findings for the shared
 // gather→classify→verify→fix pipeline.
 const LANE_A = new Set(['code-review', 'security-review']);
+
+// >>> instrument gate: sliced + eval'd by review-fix-instrument-probe.mjs >>>
+// Named instruments a finder is required to invoke — a stage that claims to run
+// a built-in under its own name must return a receipt proving it did. Without
+// this, a finder whose Skill(...) call is rejected can silently substitute its
+// own review and report the result under the built-in's name.
+const INSTRUMENTS = {
+  'code-review': {
+    label: '/code-review',
+    kind: 'skill',        // 'skill' → Skill tool; 'command' → Bash command
+    skill: 'code-review', // the Skill-tool `skill` argument to look for
+    edits_nothing: false, // runs with --fix, so it applies its own edits
+  },
+  'security-review': {
+    label: '/security-review',
+    kind: 'skill',
+    skill: 'security-review',
+    edits_nothing: true,  // no --fix flag; it is inherently findings-only
+  },
+};
+
+// Pure. Returns { ok, checked, reason }.
+//   checked:false  → the gate does not apply (no named instrument, or the
+//                    finder returned nothing at all — see the null note below).
+function instrumentVerdict(name, res) {
+  const spec = INSTRUMENTS[name];
+  // Lane-B lenses (cost, input-validation, red-team, …) are the agent's OWN
+  // work by design: they name no instrument, so the gate must not touch them.
+  if (!spec) return { ok: true, checked: false, reason: '' };
+  // LOAD-BEARING: a null/undefined finder result is the existing probe-wave
+  // throttle signal, which deliberately still applies dispatch:reviewed and
+  // writes the marker. A dead finder contributed no payload, so nothing is
+  // attributed to the instrument and there is nothing to guard. Turning this
+  // into a lane failure would park the node on every rate-limit.
+  if (res === null || res === undefined) return { ok: true, checked: false, reason: '' };
+
+  const receipt = res.instrument;
+  if (!receipt || typeof receipt !== 'object') {
+    return {
+      ok: false,
+      checked: true,
+      reason: `${name}: no instrument receipt returned (schema violation)`,
+    };
+  }
+  if (receipt.name !== spec.skill) {
+    return {
+      ok: false,
+      checked: true,
+      reason: `${name}: instrument receipt names "${receipt.name}" but this stage must invoke "${spec.skill}"`,
+    };
+  }
+  if (receipt.invoked !== true) {
+    const raw = (receipt.failure_text || '').trim().replace(/\s+/g, ' ');
+    const why = raw.length <= 300 ? raw : raw.slice(0, 300);
+    return {
+      ok: false,
+      checked: true,
+      reason: `${name}: instrument reported NOT invoked — ${why}`,
+    };
+  }
+
+  // Payload-signature rules. Be honest about what these buy: they raise the
+  // cost of a fabricated receipt (the fabrication must now also be internally
+  // consistent with what the real instrument's output looks like), they do NOT
+  // make one impossible. The non-fabricable evidence is the independent
+  // transcript verdict — a separate stage, not this function.
+  const fixed = res.fixed || [];
+  if (spec.edits_nothing === true && fixed.length > 0) {
+    return {
+      ok: false,
+      checked: true,
+      reason: `${name}: payload signature mismatch — this instrument applies no edits, but the payload reports ${fixed.length} fix(es)`,
+    };
+  }
+  if (spec.edits_nothing === false) {
+    // A real --fix run edits a file for every fix it reports.
+    for (const e of fixed) {
+      if (!e || !e.touched_files || e.touched_files.length === 0) {
+        return {
+          ok: false,
+          checked: true,
+          reason: `${name}: payload signature mismatch — a "fixed" entry reports no touched_files`,
+        };
+      }
+    }
+  }
+
+  return { ok: true, checked: true, reason: '' };
+}
+// <<< instrument gate <<<
 
 // normative spec: .claude/skills/dispatch-propagate/scripts/dispatch-review-finders
 // Returns the AGENT finder-source set (the codeql/npm finders are NOT agents —
@@ -417,7 +521,11 @@ const LANE_A_BLURB = [
   '- "category": the finding\'s category (code-review category or vulnerability class)',
   '- "exploit_scenario": the concrete attack scenario, or "" for a non-security finding',
   '- "recommended_fix": the concrete corrective action',
-  'Return { "fixed": [ ... ], "residue": [ ... ] }. Use [] for an empty array.',
+  'Also return an "instrument" object recording the built-in you were told to invoke:',
+  '- "name": the exact skill name you invoked (e.g. "code-review")',
+  '- "invoked": true only if the Skill tool actually ran that built-in and it returned',
+  '- "failure_text": "" when invoked is true; otherwise the VERBATIM error/rejection text',
+  'Return { "fixed": [ ... ], "residue": [ ... ], "instrument": { ... } }. Use [] for an empty array.',
 ].join('\n');
 
 function diffContext(args) {
@@ -609,16 +717,50 @@ const finderResults = qualityFinders
   .map((name, i) => ({ name, res: qualityResults[i] }))
   .concat(securityFinders.map((name, i) => ({ name, res: securityResults[i] })));
 
+// --- instrument gate ---------------------------------------------------------
+// A stage that claims to have run a named built-in must return a receipt proving
+// it did. A missing/false/inconsistent receipt means the named review did NOT
+// happen, so whatever the stage returned is its own unattributed work — it is
+// DISCARDED below rather than merged under the instrument's name.
+const instrumentFailures = []; // [{ instrument, reason }]
+const instrumentFailed = new Set();
+for (const { name, res } of finderResults) {
+  const v = instrumentVerdict(name, res);
+  if (v.ok) continue;
+  instrumentFailures.push({ instrument: name, reason: v.reason });
+  instrumentFailed.add(name);
+  log(`finders: INSTRUMENT GATE FAILED — ${v.reason}`);
+}
+if (instrumentFailures.length) {
+  coverage_incomplete = true;
+  const notes = instrumentFailures.map(
+    (f) =>
+      `Instrument not verified — ${f.reason}. Its output was DISCARDED, not merged under the instrument's name.`
+  );
+  // Preserve any note the throttle path already set.
+  coverage_note = [coverage_note, ...notes].filter(Boolean).join(' ');
+}
+
 // --- Lane-A capture (code-review, security-review) ---------------------------
 // These two finders bypass the shared dedup→classify→verify→fix pipeline. Capture
 // their raw { fixed, residue } results here, separately from the Lane-B gather, so
 // a LATER unit's "residue" phase can dispose of the residue and merge the fixes.
 // code-review is wave 1 (qualityFinders has exactly one entry when present).
-const codeReviewResult = qualityResults[qualityFinders.indexOf('code-review')] || null;
+// A failed instrument gate nulls the capture: the payload is never merged, never
+// dispositioned, never credited. Everything downstream (laneAFixed, laneAResidue,
+// the residue phase, fixed[], dispositions[], fixes_applied) already degrades
+// correctly from a null capture, so a discarded payload also contributes zero
+// yield — no token economy can be credited to an unverified instrument.
+const codeReviewResult = instrumentFailed.has('code-review')
+  ? null
+  : qualityResults[qualityFinders.indexOf('code-review')] || null;
 // security-review is a wave-2 finder (only launched when surface === 'code');
 // securityFinders and securityResults are parallel/same-index.
 const securityReviewIdx = securityFinders.indexOf('security-review');
-const securityReviewResult = securityReviewIdx >= 0 ? securityResults[securityReviewIdx] : null;
+const securityReviewResult =
+  instrumentFailed.has('security-review') || securityReviewIdx < 0
+    ? null
+    : securityResults[securityReviewIdx];
 
 // Seed fixed[] early with code-review's own applied fixes. Synthesize sequential
 // ids in array order. Unit 4 merges laneAFixed into the final fixed[] envelope;
@@ -1440,7 +1582,12 @@ const security_followup_input = deduped
 //     resolve — an ignore/defer/phantom-resolve leaves the item unresolved and escalates.
 // A high-severity original item with no returned disposition (agent dropped it) has no
 // map entry (!== true) and therefore also escalates.
+//
+// An unverified instrument escalates UNCONDITIONALLY — it is not severity-scaled,
+// because the failure is not "a finding went unfixed" but "the named review did
+// not happen at all". No severity can be read off a review that never ran.
 const deviation =
+  instrumentFailures.length > 0 ||
   keptFindings.some(
     (f) =>
       f.bucket === 'Required' &&
@@ -1548,6 +1695,10 @@ return {
   // likely throttled), surfaced in the Step 6 partial-coverage comment line.
   coverage_incomplete,
   coverage_note,
+  // One entry per stage whose named-instrument receipt failed verification. A
+  // non-empty array means that stage's payload was discarded and `deviation` is
+  // true regardless of finding severity.
+  instrument_failures: instrumentFailures,
   findings_surfaced,
   findings_actionable,
   fixes_applied,

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -208,6 +208,8 @@ jobs:
         run: .claude/skills/dispatch-propagate/scripts/test-qa-fix-partition.sh
       - name: Run align-tactics resolveTempRefs tests
         run: .claude/skills/dispatch-propagate/scripts/test-align-tactics-tempref.sh
+      - name: Run review-fix instrument-gate tests
+        run: .claude/skills/dispatch-propagate/scripts/test-review-fix-instrument.sh
       - name: Run dispatch-stop hook tests
         run: .claude/skills/dispatch-propagate/scripts/test-dispatch-stop-hook.sh
       - name: Run dispatch-office-hours-strip hook tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -210,6 +210,8 @@ jobs:
         run: .claude/skills/dispatch-propagate/scripts/test-align-tactics-tempref.sh
       - name: Run review-fix instrument-gate tests
         run: .claude/skills/dispatch-propagate/scripts/test-review-fix-instrument.sh
+      - name: Run dispatch-verify-instrument-invocation tests
+        run: .claude/skills/dispatch-propagate/scripts/test-dispatch-verify-instrument-invocation.sh
       - name: Run dispatch-stop hook tests
         run: .claude/skills/dispatch-propagate/scripts/test-dispatch-stop-hook.sh
       - name: Run dispatch-office-hours-strip hook tests


### PR DESCRIPTION
## Context

On 2026-07-31 an investigation found that `/code-review` had never run inside
the review-fix workflow. Across 18 runs (2026-07-27 → 07-31) every
`Skill(skill: "code-review")` call was rejected with `disable-model-invocation`.
The finder subagent read the rejection, performed its own review instead, and
the workflow merged that output under the built-in's name — undetected for
four days.

This PR generalizes the fix: a lane that cannot invoke its named instrument
now fails loudly instead of substituting an ad-hoc equivalent.

## What changed

- **Unit 1** — `.claude/workflows/review-fix.js`: an `INSTRUMENTS` registry, a
  pure `instrumentVerdict(name, res)` function (sentinel-delimited so it can be
  sliced and tested without executing the Workflow-tool script), a receipt
  field (`instrument: {name, invoked, failure_text}`) added to `LANE_A_SCHEMA`,
  a gate that discards a failed instrument's payload entirely, surfaces the
  failure via `coverage_note`, and escalates the lane via the existing
  `deviation` → `dispatch-mark-deviation` path.
- **Unit 2** — an `instrumentClause(spec)` helper inserted into the
  `code-review` and `security-review` finder prompts: invoking the named
  instrument is the agent's entire contract; a rejection is terminal; self-
  performing the review is explicitly forbidden as a fallback.
- **Unit 3** — CI coverage: `review-fix-instrument-probe.mjs` slices and evals
  the gate helper, `test-review-fix-instrument.sh` exercises 9 fixture cases
  plus 7 anti-regression call-site greps, wired into `unit-tests.yml`'s
  `hook-tests` job (the only CI vector for `.claude/workflows/*.js`).
- **Unit 4** — closes the fabrication path: the self-report receipt from
  Units 1-2 is trustworthy in the "it failed" direction but fabricable in the
  "it succeeded" direction. `dispatch-verify-instrument-invocation` reads the
  actual Claude session transcript record (tool-call history, scoped by `cwd`
  and `--since`) to independently confirm an instrument was really invoked.
  A separate, minimally-scoped `instrument-verify` subagent (modeled on the
  existing residue-tree-verify pattern) runs it and feeds only the command
  line — no finding text — so a prompt-injection payload can't steer it. A
  receipt-vs-transcript disagreement fails the gate even when the self-report
  claims `invoked: true`.

Also fixed during review: the gate loop double-counted an instrument that
failed both the self-report and transcript checks (duplicate entries in
`instrument_failures`/`coverage_note`) — now deduped.

## Out of scope

Rewiring `/code-review` onto a working entry point (sibling node
`tactic-review-code-review-invocation-contract`) — this PR ships the guard
that makes a rejected invocation loud and holds while that rewiring is in
flight independently.

## Verification

```verify
node --check .claude/workflows/review-fix.js
```

```verify
.claude/skills/dispatch-propagate/scripts/test-review-fix-instrument.sh
```

```verify
.claude/skills/dispatch-propagate/scripts/test-dispatch-verify-instrument-invocation.sh
```

```verify
.claude/skills/dispatch-propagate/scripts/run-lint.sh
```

All four pass locally. Manual/judgment checks (live no-false-failure run on
this PR's own `/review-fix` pass, induced-unavailability check, throttle-path
non-regression, transcript sweep, token-economy sensor reading) are documented
in the node body and remain for QA.

Graph node: tactic-lane-instrument-substitution-guard
