### PR TITLE
tactic-attention-boost-scripts: script the boost-to-top-rank attention-write operation

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -236,6 +236,8 @@ jobs:
         run: .claude/skills/dispatch-propagate/scripts/test-dispatch-daemon-liveness.sh
       - name: Run park-node CAS-guard tests
         run: packages/intentionsutil/scripts/test-park-node.sh
+      - name: Run boost-node tests
+        run: packages/intentionsutil/scripts/test-boost-node.sh
       - name: Run transition-node CAS-guard tests
         run: packages/intentionsutil/scripts/test-transition-node.sh
       - name: Run graph-commit tests

--- a/packages/intentionsutil/scripts/boost-node
+++ b/packages/intentionsutil/scripts/boost-node
@@ -1,0 +1,437 @@
+#!/usr/bin/env bash
+# boost-node — the author's "boost this node to the top of the frontier"
+# operation, landed on main (tactic-attention-boost-scripts, unit 3).
+#
+# The bash landing half of the boost tool. The planner
+# (packages/intentionsutil/src/boost.ts) and the store-level CLI
+# (packages/intentionsutil/scripts/boost-node.ts) do all the thinking; this
+# script does the git: fetch origin/main, refresh the node from it, delegate the
+# mutation to the CLI's `--write` mode, land through `graph-commit`, then
+# re-read origin/main and assert the write actually achieved what it promised.
+#
+# It authors no node content — the CLI's readNode → validateNode → writeNode
+# path is the single validation gate — and it never edits any node but the one
+# named on the command line.
+#
+# Why a wrapper at all: the boost the author wants is a claim about the CURRENT
+# landed graph. Computing it against a stale worktree copy sizes it against a
+# frontier that no longer exists, and writing it from a stale copy reverts
+# whatever landed in between. So both the plan and the write run against
+# origin/main's content, and the land carries a `--base` compare-and-swap token
+# pinned to the blob that was read (same guarantee park-node gives).
+#
+# REPO_ROOT is derived from this script's OWN on-disk location, never cwd. A
+# caller invoking the main checkout's copy by absolute path from inside a
+# worktree therefore targets the main checkout — deliberate, and the reason the
+# `graph-commit -C "$REPO_ROOT"` below is mandatory rather than cosmetic.
+#
+# Usage:
+#   boost-node [--base <blobsha>|<id>=<blobsha>|<manifest-file>]
+#              [--boost <n>] [--rank <n>] [--include-exempt] [--ack]
+#              [--preview] <node-id> [<rationale>]
+#
+# Preview mode — no <rationale>, or an explicit `--preview` — snapshots
+# origin/main into a temp dir, prints the plan (what own boost the node needs,
+# the top of the ranking, whether rule 18's ACK is implicated), and writes
+# nothing anywhere. This is the default because a boost is an authored claim on
+# scarce attention: the author should see the sizing before it lands.
+#
+# Landing mode — <rationale> supplied, no `--preview` — writes
+# `attention.boost` with that verbatim rationale and lands it on main.
+# <rationale> is mandatory for a write and is never synthesized here or by the
+# CLI: `attention.rationale` is the record of WHY the author spent the
+# attention, and an unexplained boost is unreviewable. A call that carries a
+# write-only flag (`--boost`/`--ack`) but no <rationale> is a usage error (exit
+# 2), not a silent preview — the flag says a write was intended, so the missing
+# rationale is named rather than discarded.
+#
+# Flags, all passed through to boost-node.ts:
+#   --boost <n>       write this own-boost verbatim instead of the planner's
+#                     recommendation. Post-land rank verification is REPORTED
+#                     but not asserted for an explicit value — the author chose
+#                     the number, so the planner made no promise about it.
+#   --rank <n>        target a named composed rank instead of "top candidate".
+#   --include-exempt  bring strategy-main-health's subtree into the contest
+#                     (by default the always-on trunk-health signal is not
+#                     something discretionary work has to out-rank).
+#   --ack             opt in to validateGraph rule 18 when the sized boost
+#                     matches or exceeds strategy-main-health's dominant boost;
+#                     the CLI appends the acknowledgement clause to the
+#                     rationale. Without it such a write is refused (exit 4).
+#
+# --base <blobsha>|<id>=<blobsha>|<manifest-file>: the diagnosis-time
+# compare-and-swap pin, identical in contract to park-node's — the blob the
+# caller diagnosed against, compared against origin/main's CURRENT blob before
+# any mutation. A mismatch exits 3 (`stale-diagnosis`) with nothing written, so
+# the decision can be re-made against what is actually landed rather than
+# silently absorbing a concurrent write. See
+# .claude/skills/ref-diagnosis-time-cas/SKILL.md for the caller loop.
+#
+# Post-land verification: after graph-commit succeeds, origin/main is re-read
+# into a fresh snapshot and the CLI is re-run against it in preview mode. The
+# assertion is the CLI's OWN ranking and exemption computation — the target is
+# the top contested candidate (or has reached `--rank <n>`) — never a
+# re-derivation of either in bash/jq. A failed assertion exits 6 and reports the
+# landed state. It does NOT roll back: the write is already on main, and undoing
+# it here would be a second unreviewed graph-commit, worse than an honest
+# visible state.
+#
+# NOT in scope, deliberately: the tier-aware default (what boost a node of a
+# given tier should carry without an author naming a number) and the
+# tier-change script are follow-up work gated on `tactic-attention-tier-ranking`
+# — an unmerged, parked tactic. This script implements only the ungated "boost
+# to top rank" operation.
+#
+# Unlike park-node this script never calls mark-node-terminal: a boost is an
+# author's attention write, not a node worker's terminal disposition.
+#
+# Exit codes:
+#   0  landed on main and verified (or a clean preview)
+#   1  the write, graph-commit, or a git/schema operation failed
+#   2  usage error (bad flags, missing node-id, unresolvable --base)
+#   3  stale-diagnosis — the supplied --base no longer matches origin/main;
+#      nothing was written
+#   4  boost-node.ts refused the write: no reachable boost, or rule 18's ACK is
+#      required and --ack was not given. Nothing was written.
+#   6  the boost LANDED on main but post-land verification failed — the node is
+#      not where the plan said it would be. Nothing is rolled back; re-plan
+#      against the now-landed state.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+INTENTIONS_DIR="$REPO_ROOT/intentions"
+BOOST_TS="$SCRIPT_DIR/boost-node.ts"
+
+USAGE="usage: boost-node [--base <blobsha>|<id>=<blobsha>|<manifest-file>] [--boost <n>] [--rank <n>] [--include-exempt] [--ack] [--preview] <node-id> [<rationale>]"
+
+# Leading-flags-only parse: consume flags while the current arg starts with
+# `--`; the first non-flag argument ends flag parsing and every remaining
+# argument is positional VERBATIM (no re-scan for flags — <rationale> is free
+# text that may start with `-`).
+BASE_ARG=""
+BOOST_ARG=""
+RANK_ARG=""
+INCLUDE_EXEMPT=0
+ACK=0
+PREVIEW=0
+# Flag PRESENCE is tracked separately from the flag's VALUE: an explicitly
+# supplied but empty base (`--base ''` / `--base=`) must be a usage error, not a
+# silent degradation to an unpinned write. Gating the resolver on
+# `-n "$BASE_ARG"` alone would make that case indistinguishable from omitting
+# the flag, quietly dropping the compare-and-swap guarantee the caller asked for
+# (.claude/skills/ref-diagnosis-time-cas/SKILL.md).
+BASE_SUPPLIED=0
+ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      shift
+      if [[ $# -eq 0 ]]; then echo "$USAGE" >&2; exit 2; fi
+      BASE_ARG="$1"; BASE_SUPPLIED=1; shift
+      ;;
+    --base=*)
+      BASE_ARG="${1#--base=}"; BASE_SUPPLIED=1; shift
+      ;;
+    --boost)
+      shift
+      if [[ $# -eq 0 ]]; then echo "$USAGE" >&2; exit 2; fi
+      BOOST_ARG="$1"
+      if [[ ! "$BOOST_ARG" =~ ^-?[0-9]+$ ]]; then
+        echo "$USAGE (--boost must be an integer)" >&2
+        exit 2
+      fi
+      shift
+      ;;
+    --rank)
+      shift
+      if [[ $# -eq 0 ]]; then echo "$USAGE" >&2; exit 2; fi
+      RANK_ARG="$1"
+      if [[ ! "$RANK_ARG" =~ ^-?[0-9]+(\.[0-9]+)?$ ]]; then
+        echo "$USAGE (--rank must be a number)" >&2
+        exit 2
+      fi
+      shift
+      ;;
+    --include-exempt) INCLUDE_EXEMPT=1; shift ;;
+    --ack) ACK=1; shift ;;
+    --preview) PREVIEW=1; shift ;;
+    --*)
+      echo "$USAGE" >&2
+      exit 2
+      ;;
+    *)
+      # First non-flag argument: stop flag parsing, take everything verbatim.
+      ARGS=("$@")
+      break
+      ;;
+  esac
+done
+
+NODE_ID="${ARGS[0]:-}"
+RATIONALE="${ARGS[1]:-}"
+if [[ ${#ARGS[@]} -lt 1 || ${#ARGS[@]} -gt 2 || -z "$NODE_ID" ]]; then
+  echo "$USAGE" >&2
+  exit 2
+fi
+
+# A write-only flag with no <rationale> is a usage error, not a silent preview.
+# Bare `<node-id>` IS the documented preview form, so an absent rationale
+# ordinarily selects preview mode — but `--boost`/`--ack` only mean anything to
+# a write, so a call carrying one of them plainly intended to land something.
+# Previewing it would silently discard the author's stated intent; refusing
+# names the missing piece instead.
+if [[ ${#ARGS[@]} -lt 2 && $PREVIEW -eq 0 && ( -n "$BOOST_ARG" || $ACK -eq 1 ) ]]; then
+  echo "boost-node: --boost/--ack are write-only flags, but no <rationale> was given — a rationale is mandatory for a write and is never synthesized. Supply one to land, or drop the flag to preview." >&2
+  exit 2
+fi
+
+# Flags the preview/verification invocations of boost-node.ts share with the
+# write invocation. `--boost`/`--ack` are write-only and deliberately absent.
+PLAN_FLAGS=()
+[[ -n "$RANK_ARG" ]] && PLAN_FLAGS+=(--rank "$RANK_ARG")
+[[ $INCLUDE_EXEMPT -eq 1 ]] && PLAN_FLAGS+=(--include-exempt)
+
+# Resolve --base (if supplied) to a 40-hex blob sha, before any network call,
+# so a malformed base is a cheap usage error rather than a mid-flight failure.
+PINNED_BASE=""
+if [[ $BASE_SUPPLIED -eq 1 && -z "$BASE_ARG" ]]; then
+  echo "boost-node: --base requires a non-empty <blobsha>|<id>=<blobsha>|<manifest-file> value" >&2
+  exit 2
+fi
+if [[ $BASE_SUPPLIED -eq 1 ]]; then
+  if [[ -f "$BASE_ARG" ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      [[ -z "$line" ]] && continue
+      line_id="${line%%=*}"
+      line_sha="${line#*=}"
+      if [[ "$line_id" == "$NODE_ID" ]]; then
+        PINNED_BASE="$line_sha"
+        break
+      fi
+    done <"$BASE_ARG"
+    if [[ -z "$PINNED_BASE" ]]; then
+      echo "boost-node: manifest '$BASE_ARG' has no entry for node id '$NODE_ID'" >&2
+      exit 2
+    fi
+  elif [[ "$BASE_ARG" == *=* ]]; then
+    pair_id="${BASE_ARG%%=*}"
+    pair_sha="${BASE_ARG#*=}"
+    if [[ "$pair_id" != "$NODE_ID" ]]; then
+      echo "boost-node: --base id '$pair_id' does not match node id '$NODE_ID'" >&2
+      exit 2
+    fi
+    PINNED_BASE="$pair_sha"
+  else
+    PINNED_BASE="$BASE_ARG"
+  fi
+  if [[ ! "$PINNED_BASE" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "boost-node: --base resolved to '$PINNED_BASE', not a full 40-hex blob sha" >&2
+    exit 2
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Preview mode: snapshot origin/main and print the plan. No writes anywhere.
+# ---------------------------------------------------------------------------
+if [[ $PREVIEW -eq 1 || ${#ARGS[@]} -lt 2 ]]; then
+  if ! git -C "$REPO_ROOT" fetch origin main >&2; then
+    echo "boost-node: could not fetch origin/main to plan a boost for $NODE_ID" >&2
+    exit 1
+  fi
+  SNAPSHOT_DIR="$(mktemp -d)" \
+    || { echo "boost-node: mktemp failed for the origin/main snapshot" >&2; exit 1; }
+  # Same primitive graph-select-target uses: selection and planning read
+  # origin/main's store, never a branch or the working tree.
+  if ! git -C "$REPO_ROOT" archive origin/main intentions | tar -x -C "$SNAPSHOT_DIR"; then
+    rm -rf "$SNAPSHOT_DIR"
+    echo "boost-node: failed to snapshot intentions/ from origin/main" >&2
+    exit 1
+  fi
+  (cd "$REPO_ROOT" && npx tsx "$BOOST_TS" "$NODE_ID" --dir "$SNAPSHOT_DIR/intentions" "${PLAN_FLAGS[@]+"${PLAN_FLAGS[@]}"}")
+  rc=$?
+  rm -rf "$SNAPSHOT_DIR"
+  # boost-node.ts's own exit code is the answer — a preview that reports
+  # "unreachable" is still a successful preview (exit 0), and a schema error
+  # is still exit 1.
+  exit $rc
+fi
+
+# ---------------------------------------------------------------------------
+# Landing mode.
+# ---------------------------------------------------------------------------
+# Refresh the LOCAL node file from origin/main BEFORE the write, so the
+# attention mutation lands on top of the current landed content rather than a
+# stale worktree copy. An unreachable origin/main or a node absent from
+# origin/main is genuine environment breakage — fail with a clear error, never
+# fall back to the local copy (code-style.md).
+if ! git -C "$REPO_ROOT" fetch origin main >&2; then
+  echo "boost-node: could not fetch origin/main to refresh $NODE_ID before boosting" >&2
+  exit 1
+fi
+if ! FRESH_BLOB="$(git -C "$REPO_ROOT" rev-parse "origin/main:intentions/$NODE_ID.md" 2>/dev/null)"; then
+  # Absent-on-origin/main stays exit 1 UNCHANGED even when --base was supplied
+  # — the pin check below never runs in this branch. This is a hard "cannot
+  # boost a node that is not landed" state, not a staleness condition: a
+  # re-diagnosis retry loop would spin forever rather than converge.
+  echo "boost-node: intentions/$NODE_ID.md does not exist on origin/main — cannot boost a node that is not landed" >&2
+  exit 1
+fi
+
+# The pin check runs before ANY mutation — before the local-file overwrite,
+# before MUTATED is set, before the EXIT trap is installed — so a stale pin has
+# zero side effects and nothing to roll back.
+if [[ -n "$PINNED_BASE" && "$PINNED_BASE" != "$FRESH_BLOB" ]]; then
+  echo "boost-node: stale-diagnosis — intentions/$NODE_ID.md on origin/main is now $FRESH_BLOB but the pinned --base is $PINNED_BASE; the node changed between diagnosis and execution. Re-read the node, re-plan the boost, and retry with a freshly captured base. Nothing was written." >&2
+  exit 3
+fi
+
+if ! git -C "$REPO_ROOT" show "origin/main:intentions/$NODE_ID.md" > "$INTENTIONS_DIR/$NODE_ID.md"; then
+  echo "boost-node: could not refresh intentions/$NODE_ID.md from origin/main" >&2
+  exit 1
+fi
+
+# MUTATED gates the rollback below: only restore intentions/$NODE_ID.md if this
+# script actually changed it. It is set HERE, immediately after the origin/main
+# refresh — that overwrite is already a content change relative to whatever the
+# working tree held — so the trap covers every downstream failure, including a
+# refused boost-node.ts --write and a failed graph-commit. It is cleared again
+# once graph-commit has landed, so a post-land verification failure never rolls
+# main's own content back out of the working tree.
+MUTATED=0
+VERIFY_DIR=""
+trap '
+  rc=$?
+  [[ -n "$VERIFY_DIR" ]] && rm -rf "$VERIFY_DIR"
+  if [[ "$MUTATED" == 1 && $rc -ne 0 ]]; then
+    # Restore from the immutable blob SHA captured before the mutation, not the
+    # moving origin/main ref (a concurrent fetch may have pruned/relocated the
+    # node). Write to a temp file and mv into place only on success, so a failed
+    # git-show never truncates the node file to zero bytes.
+    if git -C "$REPO_ROOT" show "$FRESH_BLOB" > "$INTENTIONS_DIR/$NODE_ID.md.rollback"; then
+      mv "$INTENTIONS_DIR/$NODE_ID.md.rollback" "$INTENTIONS_DIR/$NODE_ID.md"
+    else
+      rm -f "$INTENTIONS_DIR/$NODE_ID.md.rollback"
+    fi
+  fi
+' EXIT
+MUTATED=1
+
+WRITE_FLAGS=()
+[[ -n "$BOOST_ARG" ]] && WRITE_FLAGS+=(--boost "$BOOST_ARG")
+[[ $ACK -eq 1 ]] && WRITE_FLAGS+=(--ack)
+
+(cd "$REPO_ROOT" && npx tsx "$BOOST_TS" "$NODE_ID" \
+  --dir "$INTENTIONS_DIR" --write --rationale "$RATIONALE" \
+  "${PLAN_FLAGS[@]+"${PLAN_FLAGS[@]}"}" "${WRITE_FLAGS[@]+"${WRITE_FLAGS[@]}"}" >&2)
+write_rc=$?
+if [[ $write_rc -ne 0 ]]; then
+  # Propagate boost-node.ts's own exit code faithfully — a 2 (usage / blank
+  # rationale) or 4 (unreachable, or ACK required and not given) is a REFUSAL,
+  # and the caller must be able to tell it from a landing failure. Nothing
+  # reaches graph-commit in any of these cases; the trap restores the file.
+  echo "boost-node: boost-node.ts refused or failed the write for $NODE_ID (exit $write_rc); nothing was landed" >&2
+  exit $write_rc
+fi
+
+# EXPECT_BLOB captures the blob just written to intentions/$NODE_ID.md under
+# this script's OWN REPO_ROOT, for graph-commit's --expect guard. Hashing
+# failure is genuine environment breakage — fail loudly rather than omitting
+# --expect (code-style.md).
+if ! EXPECT_BLOB="$(git -C "$REPO_ROOT" hash-object -- "intentions/$NODE_ID.md" 2>/dev/null)"; then
+  echo "boost-node: could not hash intentions/$NODE_ID.md after the attention write" >&2
+  exit 1
+fi
+
+# One-line commit subject: the rationale's first line, bounded.
+SUMMARY="${RATIONALE%%$'\n'*}"
+if [[ ${#SUMMARY} -gt 72 ]]; then
+  SUMMARY="${SUMMARY:0:69}..."
+fi
+
+# -C "$REPO_ROOT" is mandatory, not cosmetic: this script's REPO_ROOT is derived
+# from SCRIPT_DIR (its own on-disk location), and the attention write above
+# targets "$INTENTIONS_DIR" under THAT repo, while graph-commit resolves its own
+# repo from -C if given, else from cwd. Callers routinely invoke the main
+# checkout's copy of this script by absolute path from inside a worktree, so
+# without -C the two would resolve to DIFFERENT checkouts.
+#
+# --expect is a race guard here rather than an independent repo check:
+# EXPECT_BLOB is hashed under the same "$REPO_ROOT" passed as -C. What it buys
+# is (1) asserting graph-commit's `git rev-parse --show-toplevel` resolution of
+# -C lands on the tree this script wrote (they can differ if REPO_ROOT is not
+# itself a git toplevel), and (2) catching a concurrent writer that touched
+# intentions/$NODE_ID.md between the hash above and graph-commit's staging.
+if ! "$SCRIPT_DIR/graph-commit" -C "$REPO_ROOT" \
+     --base "$NODE_ID=$FRESH_BLOB" --expect "$NODE_ID=$EXPECT_BLOB" \
+     -m "graph: boost $NODE_ID ($SUMMARY)" "$NODE_ID"; then
+  echo "boost-node: graph-commit failed for $NODE_ID; the attention write was rolled back" >&2
+  exit 1
+fi
+
+# Landed. From here on the working-tree file matches what is on main, so the
+# rollback must not fire — a post-land failure is reported, never undone.
+MUTATED=0
+
+# ---------------------------------------------------------------------------
+# Post-land verification: did the write achieve what the plan promised?
+# ---------------------------------------------------------------------------
+if ! git -C "$REPO_ROOT" fetch origin main >&2; then
+  echo "boost-node: boost LANDED but origin/main could not be re-fetched to verify it" >&2
+  exit 6
+fi
+VERIFY_DIR="$(mktemp -d)" \
+  || { echo "boost-node: boost LANDED but mktemp failed for the verification snapshot" >&2; exit 6; }
+if ! git -C "$REPO_ROOT" archive origin/main intentions | tar -x -C "$VERIFY_DIR"; then
+  echo "boost-node: boost LANDED but intentions/ could not be snapshotted from origin/main to verify it" >&2
+  exit 6
+fi
+
+echo "boost-node: post-land frontier (top 5) as landed on origin/main:" >&2
+(cd "$REPO_ROOT" && npx tsx "$BOOST_TS" "$NODE_ID" --dir "$VERIFY_DIR/intentions" --top 5 \
+  "${PLAN_FLAGS[@]+"${PLAN_FLAGS[@]}"}") >&2
+
+if ! VERIFY_JSON="$(cd "$REPO_ROOT" && npx tsx "$BOOST_TS" "$NODE_ID" \
+     --dir "$VERIFY_DIR/intentions" --json "${PLAN_FLAGS[@]+"${PLAN_FLAGS[@]}"}")"; then
+  echo "boost-node: boost LANDED but the post-land plan could not be recomputed against origin/main" >&2
+  exit 6
+fi
+
+LANDED_RANK="$(jq -r '.target_current_rank // "null"' <<<"$VERIFY_JSON")"
+LANDED_BOOST="$(jq -r --arg id "$NODE_ID" 'first(.ranking[] | select(.id == $id) | .own_boost) // "null"' <<<"$VERIFY_JSON")"
+echo "boost-node: $NODE_ID landed with own boost $LANDED_BOOST, composed rank $LANDED_RANK" >&2
+
+if [[ -n "$BOOST_ARG" ]]; then
+  # An explicit --boost is the author's own number; the planner promised
+  # nothing about where it lands, so the state is REPORTED, not asserted.
+  echo "boost-node: --boost was explicit, so the ranking outcome above is reported, not asserted" >&2
+  exit 0
+fi
+
+# The assertion reuses boost-node.ts's OWN ranking and exemption computation
+# (the `exempt` flag on each row comes from src/boost.ts's main-health
+# derivation) rather than re-deriving either here.
+if [[ -n "$RANK_ARG" ]]; then
+  if ! jq -e --argjson want "$RANK_ARG" '.target_current_rank != null and .target_current_rank >= $want' \
+       <<<"$VERIFY_JSON" >/dev/null; then
+    echo "boost-node: post-land verification FAILED — $NODE_ID's composed rank on origin/main is $LANDED_RANK, below the requested --rank $RANK_ARG. The boost IS landed; nothing was rolled back. Re-plan against the landed state." >&2
+    exit 6
+  fi
+  echo "boost-node: verified — $NODE_ID reached the requested rank ($LANDED_RANK >= $RANK_ARG) on origin/main" >&2
+  exit 0
+fi
+
+if [[ $INCLUDE_EXEMPT -eq 1 ]]; then
+  TOP_ID="$(jq -r 'first(.ranking[].id) // "none"' <<<"$VERIFY_JSON")"
+  CONTEST="candidate (exempt included)"
+else
+  TOP_ID="$(jq -r 'first(.ranking[] | select(.exempt | not) | .id) // "none"' <<<"$VERIFY_JSON")"
+  CONTEST="non-exempt candidate"
+fi
+if [[ "$TOP_ID" != "$NODE_ID" ]]; then
+  echo "boost-node: post-land verification FAILED — the top $CONTEST on origin/main is '$TOP_ID', not '$NODE_ID' (landed rank $LANDED_RANK). The boost IS landed; nothing was rolled back. Re-plan against the landed state." >&2
+  exit 6
+fi
+
+echo "boost-node: verified — $NODE_ID is the top $CONTEST on origin/main (rank $LANDED_RANK)" >&2
+exit 0

--- a/packages/intentionsutil/scripts/boost-node.ts
+++ b/packages/intentionsutil/scripts/boost-node.ts
@@ -1,0 +1,404 @@
+// Boost planner CLI + write path (tactic-attention-boost-scripts Unit 2).
+//
+// Thin wrapper around `planBoost` (../src/boost.ts, Unit 1): a preview mode
+// that answers "what own attention.boost does <node-id> need?" without
+// touching disk, and a `--write` mode that lands the answer (or an author's
+// explicit override) through the normal readNode -> validateNode -> writeNode
+// gate.
+//
+// Store-level only: no git, no `gh`, no graph-commit anywhere in this file.
+// It reads/writes whatever `intentions/` directory `--dir` points at (the
+// repo-local store by default, resolved from this file's own location, never
+// cwd). Unit 3 wraps this CLI in the bash landing script that does the
+// git/graph-commit dance.
+//
+// Usage:
+//   npx tsx packages/intentionsutil/scripts/boost-node.ts <node-id> [--dir <intentions-dir>]
+//       [--rank <n>] [--include-exempt] [--json] [--top <n>]
+//   npx tsx packages/intentionsutil/scripts/boost-node.ts <node-id> --write --rationale <text>
+//       [--dir <dir>] [--boost <n>] [--rank <n>] [--include-exempt] [--ack]
+//
+// Exit codes:
+//   0  ok (including a successful preview that reports "unreachable")
+//   1  schema/graph error (unknown id, non-goal-layer target, validateGraph violation, ...)
+//   2  usage error (bad flags, missing node-id, missing/blank --rationale on --write)
+//   4  no usable boost (unreachable and no explicit --boost given, or ACK required and not given)
+
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { listNodes, readNode, writeNode } from "../src/store.js";
+import { MAIN_HEALTH_DOMINANCE_ACK, validateGraph, validateNode } from "../src/schema.js";
+import type { IntentionNode } from "../src/schema.js";
+import { planBoost } from "../src/boost.js";
+import type { BoostMode, BoostPlan, RankRow } from "../src/boost.js";
+
+// --- Exit codes --------------------------------------------------------------
+export const EXIT_OK = 0;
+export const EXIT_SCHEMA_ERROR = 1;
+export const EXIT_USAGE = 2;
+export const EXIT_UNREACHABLE = 4;
+
+// --- Table rendering -----------------------------------------------------
+
+function padRow(id: string, kind: string, phase: string, rank: string, ownBoost: string, marker: string): string {
+  return [
+    id.padEnd(40),
+    kind.padEnd(9),
+    phase.padEnd(14),
+    rank.padStart(10),
+    ownBoost.padStart(10),
+    marker,
+  ].join(" ");
+}
+
+function rowToLine(row: RankRow): string {
+  return padRow(
+    row.id,
+    row.kind,
+    row.phase,
+    row.rank.toFixed(3),
+    row.own_boost === null ? "-" : String(row.own_boost),
+    row.exempt ? "*" : "",
+  );
+}
+
+/** Human-readable rendering of a BoostPlan: a fixed-width table plus a summary. */
+export function renderPlan(plan: BoostPlan, top: number): string {
+  const rows = plan.ranking.slice(0, top);
+  const lines: string[] = [
+    padRow("id", "kind", "phase", "rank", "own_boost", ""),
+    ...rows.map(rowToLine),
+    "",
+    `target: ${plan.target}`,
+    `target current rank: ${plan.target_current_rank ?? "n/a (not goal-layer-ranked)"}`,
+    plan.incumbent === null
+      ? "incumbent: none (no contested candidate)"
+      : `incumbent: ${plan.incumbent.id} (rank ${plan.incumbent.rank.toFixed(3)})`,
+  ];
+
+  if (plan.recommended_boost === null) {
+    lines.push(`unreachable: ${plan.unreachable_reason}`);
+  } else {
+    lines.push(`recommended boost: ${plan.recommended_boost}`);
+    lines.push(`resulting rank: ${plan.resulting_rank}`);
+    if (plan.needs_ack) {
+      lines.push(
+        `NOTE: this boost would match or exceed strategy-main-health's dominant boost (${plan.ceiling}) — ` +
+          `validateGraph rule 18 would refuse the write unless the rationale carries ` +
+          `"${MAIN_HEALTH_DOMINANCE_ACK}". Pass --ack to a --write invocation to append that clause and opt in.`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+// --- Preview mode --------------------------------------------------------
+
+export interface PreviewOpts {
+  dir: string;
+  nodeId: string;
+  mode: BoostMode;
+  includeExempt: boolean;
+  json: boolean;
+  top: number;
+}
+
+export interface PreviewResult {
+  /** 0 = plan computed (even when unreachable), 1 = schema/graph error. */
+  exitCode: 0 | 1;
+  stdout: string | null;
+  stderr: string[];
+  plan: BoostPlan | null;
+}
+
+/**
+ * Compute and render a BoostPlan. Never writes to disk. Exit 0 whenever the
+ * plan computes successfully — an "unreachable" plan is still a successful
+ * preview, it answered the question. Exit 1 on any thrown Error (unknown id,
+ * non-goal-layer target, ...).
+ */
+export function previewBoost(opts: PreviewOpts): PreviewResult {
+  try {
+    const nodes = listNodes(opts.dir);
+    const plan = planBoost(nodes, opts.nodeId, opts.mode, { includeExempt: opts.includeExempt });
+    const stdout = opts.json ? JSON.stringify(plan) : renderPlan(plan, opts.top);
+    return { exitCode: 0, stdout, stderr: [], plan };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { exitCode: 1, stdout: null, stderr: [message], plan: null };
+  }
+}
+
+// --- Write mode ------------------------------------------------------------
+
+export interface WriteOpts {
+  dir: string;
+  nodeId: string;
+  mode: BoostMode;
+  includeExempt: boolean;
+  /** Mandatory in spirit; null/blank is rejected inside writeBoost with exit 2. */
+  rationale: string | null;
+  /** Author's explicit boost value, verbatim; null means "use the planner's recommendation". */
+  explicitBoost: number | null;
+  ack: boolean;
+}
+
+export interface WriteResult {
+  exitCode: 0 | 1 | 2 | 4;
+  stdout: string | null;
+  stderr: string[];
+}
+
+/**
+ * Compute the plan, resolve the boost to write (explicit or recommended),
+ * enforce rule 18's ACK gate, then land it through readNode -> validateNode ->
+ * writeNode — the same single validation gate write-node.ts uses, mirrored
+ * here for a narrower attention-only mutation. A pre-write validateGraph call
+ * is a defense-in-depth backstop so a rule 5/18 violation surfaces here with a
+ * clear message rather than only at land time.
+ */
+export function writeBoost(opts: WriteOpts): WriteResult {
+  const rationale = (opts.rationale ?? "").trim();
+  if (rationale === "") {
+    return {
+      exitCode: EXIT_USAGE,
+      stdout: null,
+      stderr: [
+        "boost-node: --rationale is mandatory for --write — the attention field requires an " +
+          "author rationale, and this script never synthesizes one",
+      ],
+    };
+  }
+
+  let nodes: IntentionNode[];
+  let plan: BoostPlan;
+  try {
+    nodes = listNodes(opts.dir);
+    plan = planBoost(nodes, opts.nodeId, opts.mode, { includeExempt: opts.includeExempt });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { exitCode: EXIT_SCHEMA_ERROR, stdout: null, stderr: [message] };
+  }
+
+  const preview = renderPlan(plan, 10);
+
+  let chosenBoost: number;
+  if (opts.explicitBoost !== null) {
+    chosenBoost = opts.explicitBoost;
+  } else if (plan.recommended_boost !== null) {
+    chosenBoost = plan.recommended_boost;
+  } else {
+    return {
+      exitCode: EXIT_UNREACHABLE,
+      stdout: preview,
+      stderr: [plan.unreachable_reason ?? "boost-node: no boost reachable and none explicitly given"],
+    };
+  }
+
+  const needsAck = plan.ceiling !== null && chosenBoost >= plan.ceiling;
+  if (needsAck && !opts.ack) {
+    return {
+      exitCode: EXIT_UNREACHABLE,
+      stdout: preview,
+      stderr: [
+        `boost-node: boost ${chosenBoost} would match or exceed strategy-main-health's dominant boost ` +
+          `(${plan.ceiling}) — validateGraph rule 18 would refuse this write. Pass --ack to append the ` +
+          `acknowledgement clause and opt in.`,
+      ],
+    };
+  }
+
+  const finalRationale = needsAck && opts.ack ? `${rationale} (${MAIN_HEALTH_DOMINANCE_ACK})` : rationale;
+
+  let node: IntentionNode;
+  try {
+    node = readNode(opts.dir, opts.nodeId);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { exitCode: EXIT_SCHEMA_ERROR, stdout: null, stderr: [message] };
+  }
+
+  const mutated: IntentionNode = {
+    ...node,
+    attention: { boost: chosenBoost, override: null, rationale: finalRationale },
+  };
+
+  let validated: IntentionNode;
+  try {
+    validated = validateNode(mutated);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { exitCode: EXIT_SCHEMA_ERROR, stdout: null, stderr: [message] };
+  }
+
+  // Defense-in-depth: catch a rule 5/18 violation here rather than only at
+  // land time. On any throw, exit 1 — the explicit ACK gate above is the
+  // primary path for rule 18; this is a backstop, not a second decision point.
+  try {
+    const mutatedNodes = nodes.map((n) => (n.id === opts.nodeId ? validated : n));
+    validateGraph(mutatedNodes);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { exitCode: EXIT_SCHEMA_ERROR, stdout: null, stderr: [message] };
+  }
+
+  writeNode(opts.dir, validated);
+
+  const rankLine =
+    opts.explicitBoost === null
+      ? `predicted resulting rank: ${plan.resulting_rank}`
+      : "(rank not predicted for an explicit --boost value; re-run without --write to preview)";
+
+  const stdout = [
+    `wrote ${opts.nodeId}: attention.boost = ${chosenBoost}`,
+    `rationale: ${finalRationale}`,
+    rankLine,
+  ].join("\n");
+
+  return { exitCode: EXIT_OK, stdout, stderr: [] };
+}
+
+// --- Arg parsing -------------------------------------------------------------
+
+interface CliArgs {
+  nodeId: string;
+  dir: string;
+  mode: BoostMode;
+  includeExempt: boolean;
+  json: boolean;
+  top: number;
+  write: boolean;
+  rationale: string | null;
+  explicitBoost: number | null;
+  ack: boolean;
+}
+
+function requireNumberArg(argv: string[], i: number, flag: string): number {
+  const v = argv[i];
+  const n = v === undefined ? NaN : Number(v);
+  if (v === undefined || v === "" || !Number.isFinite(n)) {
+    throw new Error(`boost-node: ${flag} requires a numeric argument`);
+  }
+  return n;
+}
+
+function parseArgs(argv: string[], defaultDir: string): CliArgs {
+  const positional: string[] = [];
+  let dir = defaultDir;
+  let rankValue: number | null = null;
+  let includeExempt = false;
+  let json = false;
+  let top = 10;
+  let write = false;
+  let rationale: string | null = null;
+  let explicitBoost: number | null = null;
+  let ack = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--dir") {
+      const v = argv[++i];
+      if (v === undefined || v === "") throw new Error("boost-node: --dir requires a directory argument");
+      dir = v;
+    } else if (arg === "--rank") {
+      rankValue = requireNumberArg(argv, ++i, "--rank");
+    } else if (arg === "--include-exempt") {
+      includeExempt = true;
+    } else if (arg === "--json") {
+      json = true;
+    } else if (arg === "--top") {
+      const n = requireNumberArg(argv, ++i, "--top");
+      if (!Number.isInteger(n) || n <= 0) throw new Error("boost-node: --top requires a positive integer argument");
+      top = n;
+    } else if (arg === "--write") {
+      write = true;
+    } else if (arg === "--rationale") {
+      const v = argv[++i];
+      if (v === undefined) throw new Error("boost-node: --rationale requires a text argument");
+      rationale = v;
+    } else if (arg === "--boost") {
+      explicitBoost = requireNumberArg(argv, ++i, "--boost");
+    } else if (arg === "--ack") {
+      ack = true;
+    } else if (arg.startsWith("--")) {
+      throw new Error(`boost-node: unknown argument '${arg}'`);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  if (positional.length !== 1) {
+    throw new Error(
+      "usage:\n" +
+        "  boost-node.ts <node-id> [--dir <intentions-dir>] [--rank <n>] [--include-exempt] [--json] [--top <n>]\n" +
+        "  boost-node.ts <node-id> --write --rationale <text> [--dir <dir>] [--boost <n>] " +
+        "[--rank <n>] [--include-exempt] [--ack]",
+    );
+  }
+
+  const mode: BoostMode = rankValue !== null ? { kind: "rank", value: rankValue } : { kind: "top-candidate" };
+
+  return {
+    nodeId: positional[0],
+    dir,
+    mode,
+    includeExempt,
+    json,
+    top,
+    write,
+    rationale,
+    explicitBoost,
+    ack,
+  };
+}
+
+// --- Main --------------------------------------------------------------------
+// The script lives at `packages/intentionsutil/scripts/boost-node.ts`, so the
+// repo root is three directories up. Resolved from this file's own location,
+// never cwd — mirrors select-targets.ts.
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = dirname(dirname(dirname(scriptDir)));
+
+function main(argv: string[]): void {
+  const defaultDir = join(repoRoot, "intentions");
+  const args = parseArgs(argv, defaultDir);
+
+  if (args.write) {
+    const result = writeBoost({
+      dir: args.dir,
+      nodeId: args.nodeId,
+      mode: args.mode,
+      includeExempt: args.includeExempt,
+      rationale: args.rationale,
+      explicitBoost: args.explicitBoost,
+      ack: args.ack,
+    });
+    for (const line of result.stderr) process.stderr.write(`${line}\n`);
+    if (result.stdout !== null) process.stdout.write(`${result.stdout}\n`);
+    process.exit(result.exitCode);
+  } else {
+    const result = previewBoost({
+      dir: args.dir,
+      nodeId: args.nodeId,
+      mode: args.mode,
+      includeExempt: args.includeExempt,
+      json: args.json,
+      top: args.top,
+    });
+    for (const line of result.stderr) process.stderr.write(`${line}\n`);
+    if (result.stdout !== null) process.stdout.write(`${result.stdout}\n`);
+    process.exit(result.exitCode);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main(process.argv.slice(2));
+  } catch (err) {
+    // Usage/argument errors from parseArgs are config-class (exit 2).
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`${message}\n`);
+    process.exit(EXIT_USAGE);
+  }
+}

--- a/packages/intentionsutil/scripts/test-boost-node.sh
+++ b/packages/intentionsutil/scripts/test-boost-node.sh
@@ -1,0 +1,397 @@
+#!/usr/bin/env bash
+#
+# test-boost-node.sh — functional harness for the `boost-node` bash landing
+# wrapper (tactic-attention-boost-scripts, unit 3).
+#
+# Mirrors test-park-node.sh's setup: a throwaway bare origin plus writer clones,
+# a `gh` PATH shim standing in for the GitHub API's check-run listing, and
+# GRAPH_COMMIT_* env overrides shrinking the poll windows. `boost-node`,
+# `boost-node.ts` and `graph-commit` under test are the ones next to this file;
+# all three are copied into the scratch repo at their real repo-relative paths
+# so their REPO_ROOT/SCRIPT_DIR resolution points at the scratch clone.
+#
+# Unlike test-park-node.sh there is NO `npx` shim: every mutation here runs
+# through the REAL boost-node.ts, and therefore the real src/boost.ts,
+# src/router.ts, src/attention.ts, src/schema.ts and src/store.ts. That is the
+# point — the wrapper's whole job is to feed those the right store and land what
+# they produce, so faking them would test nothing. The harness copies the repo's
+# real `packages/intentionsutil/src/` (plus its package.json, whose
+# `"type": "module"` is what keeps tsx's ESM loader working outside the real
+# tree) into the scratch repo, and symlinks the real `node_modules` into each
+# clone so `npx tsx` resolves tsx and the `yaml` package. Only `gh` is shimmed.
+#
+# The fixture graph, sized so one store can exercise both an ordinary boost and
+# an ACK-gated one (the top-candidate bar is a GLOBAL property of the store, so
+# the two cases are separated by the main-health EXEMPTION rather than by rank):
+#
+#   strategy-main-health   attention.boost 25          → rule-18 ceiling = 25
+#   tactic-mh-child        serves main-health, boost 4 → rank 29, EXEMPT
+#   strategy-cold          (no attention)
+#   tactic-incumbent       serves cold, boost 20       → rank 20, contested
+#   tactic-boost-*         serves cold, no attention   → the targets
+#
+# So an ordinary `boost-node <target> <rationale>` must beat rank 20 with a
+# boost of 21 — comfortably below the ceiling, no ACK. The same call with
+# `--include-exempt` must beat tactic-mh-child's rank 29 instead, needing 30,
+# which matches-or-exceeds the ceiling and so is refused without `--ack`.
+#
+# Covers:
+#   1. `--preview` prints a recommended boost and lands NOTHING (origin/main's
+#      sha is byte-identical before and after).
+#   2. A landing write records attention.boost and the VERBATIM rationale, and
+#      the change is present on origin/main afterwards. The wrapper's own
+#      post-land verification (exit 0, not 6) is part of the assertion — it
+#      re-reads origin/main and asserts the target now tops the contested list.
+#   3. No <rationale> and no --preview is NOT a silent preview-by-omission when
+#      other write flags are present: `--boost` without a rationale reaches
+#      boost-node.ts's mandatory-rationale gate and exits 2 with nothing
+#      written. (Bare `<node-id>` alone IS the documented preview form; case 1
+#      covers it.)
+#   4. A stale `--base` pin refuses with exit 3 BEFORE any mutation: origin/main
+#      unchanged and the local node file byte-identical (empty `git diff`).
+#   5. A graph-commit failure after the attention write has already landed on
+#      disk rolls intentions/<id>.md back byte-identically (empty `git diff`
+#      against the clone's HEAD, not merely "the file exists").
+#   6. A boost that would match-or-exceed strategy-main-health's dominant boost
+#      is refused without `--ack`: exit 4, origin/main unchanged, no local diff.
+#
+# No network needed: bash + git + jq + a real `node`/`npx tsx` (resolved against
+# a node_modules SYMLINK to this repo's own — read-only, never written here).
+
+set -uo pipefail
+
+HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REAL_REPO_ROOT="$(cd "$HARNESS_DIR/../../.." && pwd)"
+BN_SCRIPT="$HARNESS_DIR/boost-node"
+BN_TS="$HARNESS_DIR/boost-node.ts"
+GC_SCRIPT="$HARNESS_DIR/graph-commit"
+[[ -f "$BN_SCRIPT" ]] || { echo "error: boost-node not found at $BN_SCRIPT" >&2; exit 1; }
+[[ -f "$BN_TS" ]] || { echo "error: boost-node.ts not found at $BN_TS" >&2; exit 1; }
+[[ -f "$GC_SCRIPT" ]] || { echo "error: graph-commit not found at $GC_SCRIPT" >&2; exit 1; }
+command -v jq >/dev/null || { echo "error: jq not found (required by boost-node and the gh shim)" >&2; exit 1; }
+
+WORK="$(mktemp -d)" || { echo "error: mktemp failed" >&2; exit 1; }
+harness_cleanup() { rm -rf "$WORK"; }
+trap harness_cleanup EXIT
+
+PASS=0; FAIL=0
+ok() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+no() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# --- Scratch origin + seed content ------------------------------------------
+ORIGIN="$WORK/origin.git"
+git init -q --bare "$ORIGIN"
+git -C "$ORIGIN" symbolic-ref HEAD refs/heads/main
+
+SEED="$WORK/seed"
+mkdir -p "$SEED"
+git -C "$SEED" init -q -b main
+git -C "$SEED" config user.email harness@test
+git -C "$SEED" config user.name harness
+git -C "$SEED" remote add origin "$ORIGIN"
+mkdir -p "$SEED/intentions" \
+         "$SEED/packages/intentionsutil/scripts" \
+         "$SEED/packages/intentionsutil/src"
+cp "$BN_SCRIPT" "$SEED/packages/intentionsutil/scripts/boost-node"
+cp "$BN_TS" "$SEED/packages/intentionsutil/scripts/boost-node.ts"
+cp "$GC_SCRIPT" "$SEED/packages/intentionsutil/scripts/graph-commit"
+chmod +x "$SEED/packages/intentionsutil/scripts/boost-node" \
+         "$SEED/packages/intentionsutil/scripts/graph-commit"
+# The REAL planner/store/schema/router — every mutation in this harness runs
+# through them. Every file under src/ is a same-package relative import (the
+# only external dep is the npm "yaml" package, resolved via the node_modules
+# symlink each clone gets below), so a blanket copy is simpler and safer than
+# cherry-picking.
+cp -r "$REAL_REPO_ROOT/packages/intentionsutil/src/." "$SEED/packages/intentionsutil/src/"
+# "type": "module" — without it Node finds no package.json above the scratch
+# tree and defaults .ts/.js resolution to CommonJS, breaking tsx's ESM loader.
+cp "$REAL_REPO_ROOT/packages/intentionsutil/package.json" "$SEED/packages/intentionsutil/package.json"
+
+# --- Fixture graph -----------------------------------------------------------
+kind_node() { # <kind-name> <goal-layer:true|false>
+  cat >"$SEED/intentions/kind-$1.md" <<NODE
+---
+id: kind-$1
+kind: kind
+statement: harness kind node for $1
+owner: human
+status: codified
+attributes:
+  goal_layer: $2
+  status_vocabulary:
+    codified: the harness treats every fixture node as settled
+---
+# harness kind node for $1
+NODE
+}
+kind_node kind false
+kind_node strategy true
+kind_node tactic true
+
+strategy_node() { # <id> [<boost>]
+  {
+    echo "---"
+    echo "id: $1"
+    echo "kind: strategy"
+    echo "statement: harness strategy $1"
+    echo "owner: ai"
+    echo "status: codified"
+    # A validated reading keeps the strategy out of the selector's candidate
+    # list, so the rank arithmetic in this fixture is pure authored flow.
+    echo "reading: \"validated (2026-07-01)\""
+    if [[ -n "${2:-}" ]]; then
+      echo "attention:"
+      echo "  boost: $2"
+      echo "  override: null"
+      echo "  rationale: harness fixture boost"
+    fi
+    echo "---"
+    echo "# harness strategy $1"
+  } >"$SEED/intentions/$1.md"
+}
+
+tactic_node() { # <id> <serves-strategy> [<boost>]
+  {
+    echo "---"
+    echo "id: $1"
+    echo "kind: tactic"
+    echo "statement: harness tactic $1"
+    echo "owner: ai"
+    echo "status: codified"
+    echo "phase: implement"
+    echo "serves:"
+    echo "  - $2"
+    if [[ -n "${3:-}" ]]; then
+      echo "attention:"
+      echo "  boost: $3"
+      echo "  override: null"
+      echo "  rationale: harness fixture boost"
+    fi
+    echo "---"
+    echo "# harness tactic $1"
+  } >"$SEED/intentions/$1.md"
+}
+
+strategy_node strategy-main-health 25
+strategy_node strategy-cold
+tactic_node tactic-mh-child strategy-main-health 4
+tactic_node tactic-incumbent strategy-cold 20
+for t in tactic-boost-preview tactic-boost-land tactic-boost-usage \
+         tactic-boost-stale tactic-boost-rollback tactic-boost-ack; do
+  tactic_node "$t" strategy-cold
+done
+
+git -C "$SEED" add -A
+git -C "$SEED" commit -qm seed
+git -C "$SEED" push -q origin main
+
+# --- Independent writer clones ----------------------------------------------
+make_clone() { # <dst> <identity>
+  git clone -q "$ORIGIN" "$1"
+  git -C "$1" config user.email "$2@test"
+  git -C "$1" config user.name "$2"
+  # node_modules SYMLINK (never copied, never committed — untracked, so
+  # graph-commit's assert_clean_outside_ids guard skips it via its '??'
+  # exemption). Needed by every `npx tsx` invocation in this harness, which
+  # resolves tsx and the "yaml" package by walking up from the clone's own root.
+  ln -s "$REAL_REPO_ROOT/node_modules" "$1/node_modules"
+}
+
+# --- gh PATH shim -------------------------------------------------------------
+# Always reports the four required checks green, so graph-commit's required-check
+# gate passes without a network call. `app.slug` is required, not decorative:
+# graph-commit's gate only counts rows authored by the github-actions App.
+mkdir -p "$WORK/bin" "$WORK/fixtures"
+cat >"$WORK/fixtures/green.json" <<'JSON'
+{"check_runs": [
+  {"name": "acceptance", "status": "completed", "conclusion": "success", "id": 1, "app": {"slug": "github-actions"}},
+  {"name": "preview-and-smoke", "status": "completed", "conclusion": "success", "id": 2, "app": {"slug": "github-actions"}},
+  {"name": "lint", "status": "completed", "conclusion": "success", "id": 3, "app": {"slug": "github-actions"}},
+  {"name": "unit-tests", "status": "completed", "conclusion": "success", "id": 4, "app": {"slug": "github-actions"}}
+]}
+JSON
+cat >"$WORK/bin/gh" <<'SH'
+#!/usr/bin/env bash
+# gh shim: runs graph-commit's REAL --jq program against the green fixture, so
+# the filter itself is exercised rather than a hardcoded count string.
+jq_program=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--jq" ]]; then jq_program="$2"; break; fi
+  shift
+done
+jq -r "$jq_program" "$GC_FIXTURE_DIR/green.json"
+SH
+chmod +x "$WORK/bin/gh"
+
+FIXTURE_DIR="$WORK/fixtures"
+origin_show() { git -C "$ORIGIN" show "main:intentions/$1.md"; }
+origin_sha() { git -C "$ORIGIN" rev-parse main; }
+
+run_bn() { # <clone> [boost-node args...]
+  local clone="$1"; shift
+  (
+    cd "$clone" || exit 99
+    export PATH="$WORK/bin:$PATH"
+    export GC_FIXTURE_DIR="$FIXTURE_DIR"
+    export GRAPH_COMMIT_CHECK_POLL_SECONDS=0
+    export GRAPH_COMMIT_CHECK_TIMEOUT_SECONDS=5
+    export GRAPH_COMMIT_MAX_ATTEMPTS=5
+    bash packages/intentionsutil/scripts/boost-node "$@"
+  )
+}
+
+RATIONALE='top-rank this: the harness needs a verbatim, multi-word rationale'
+
+# ---------------------------------------------------------------------------
+# Case 1: --preview reports a recommendation and writes nothing.
+# ---------------------------------------------------------------------------
+A="$WORK/a"
+make_clone "$A" writer-a
+before_sha="$(origin_sha)"
+out="$(run_bn "$A" --preview tactic-boost-preview 2>&1)"; rc=$?
+after_sha="$(origin_sha)"
+porcelain="$(git -C "$A" status --porcelain -- intentions/)"
+if [[ $rc -eq 0 ]] \
+   && grep -q 'recommended boost: 21' <<<"$out" \
+   && grep -q 'incumbent: tactic-incumbent' <<<"$out" \
+   && [[ "$after_sha" == "$before_sha" ]] \
+   && [[ -z "$porcelain" ]]; then
+  ok "preview: recommends the boost sized against the incumbent's COMPOSED rank, lands nothing"
+else
+  no "preview (rc=$rc before_sha=$before_sha after_sha=$after_sha porcelain='$porcelain')"
+  printf '%s\n' "$out"
+fi
+
+# Bare invocation with no rationale is the same preview path (no --preview flag).
+before_sha="$(origin_sha)"
+out_bare="$(run_bn "$A" tactic-boost-preview 2>&1)"; rc_bare=$?
+if [[ $rc_bare -eq 0 ]] && grep -q 'recommended boost: 21' <<<"$out_bare" \
+   && [[ "$(origin_sha)" == "$before_sha" ]]; then
+  ok "preview: a bare <node-id> with no rationale previews rather than writing"
+else
+  no "bare preview (rc=$rc_bare)"; printf '%s\n' "$out_bare"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: a landing write records the boost and the verbatim rationale on main.
+# ---------------------------------------------------------------------------
+B="$WORK/b"
+make_clone "$B" writer-b
+out="$(run_bn "$B" tactic-boost-land "$RATIONALE" 2>&1)"; rc=$?
+content="$(origin_show tactic-boost-land)"
+if [[ $rc -eq 0 ]] \
+   && grep -q 'boost: 21' <<<"$content" \
+   && grep -qF "$RATIONALE" <<<"$content" \
+   && grep -q 'is the top non-exempt candidate' <<<"$out"; then
+  ok "landing: attention.boost 21 + verbatim rationale on origin/main, post-land verification passes (exit 0)"
+else
+  no "landing (rc=$rc)"; printf '%s\n' "$out"; printf '%s\n' "$content"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3: a write invocation without a rationale is refused (exit 2).
+# ---------------------------------------------------------------------------
+# A bare <node-id> is the documented preview form (case 1), so the missing
+# rationale has to be reached with a write flag present: `--boost 5` with no
+# rationale hits boost-node.ts's mandatory-rationale gate. Exit 2, nothing
+# written anywhere.
+C="$WORK/c"
+make_clone "$C" writer-c
+before_sha="$(origin_sha)"
+out="$(run_bn "$C" --boost 5 tactic-boost-usage 2>&1)"; rc=$?
+porcelain="$(git -C "$C" status --porcelain -- intentions/)"
+if [[ $rc -eq 2 ]] \
+   && grep -q 'rationale is mandatory' <<<"$out" \
+   && [[ "$(origin_sha)" == "$before_sha" ]] \
+   && [[ -z "$porcelain" ]]; then
+  ok "missing rationale on a write: exit 2, origin/main unchanged, no working-tree residue"
+else
+  no "missing rationale (rc=$rc porcelain='$porcelain')"; printf '%s\n' "$out"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 4: a stale --base pin refuses before any mutation (exit 3).
+# ---------------------------------------------------------------------------
+# Capture the pin, land a boost on the SAME node (advancing origin/main's blob
+# for it), then re-use the now-stale pin. The pin check runs before the
+# origin/main refresh overwrites the local file, so there is nothing to roll
+# back: assert exit 3, origin/main byte-unchanged, and an empty local diff.
+D="$WORK/d"
+make_clone "$D" writer-d
+pin="$(git -C "$ORIGIN" rev-parse main:intentions/tactic-boost-stale.md)"
+out_match="$(run_bn "$D" --base "$pin" tactic-boost-stale "$RATIONALE" 2>&1)"; rc_match=$?
+
+before_sha="$(origin_sha)"
+out_stale="$(run_bn "$D" --base "$pin" tactic-boost-stale 'second rationale' 2>&1)"; rc_stale=$?
+diff_after="$(git -C "$D" diff -- intentions/tactic-boost-stale.md)"
+if [[ $rc_match -eq 0 ]] \
+   && [[ $rc_stale -eq 3 ]] \
+   && grep -q 'stale-diagnosis' <<<"$out_stale" \
+   && [[ "$(origin_sha)" == "$before_sha" ]] \
+   && [[ -z "$diff_after" ]]; then
+  ok "--base pin: a matching pin lands normally (exit 0); a stale pin refuses before any mutation (exit 3, main unchanged, no local diff)"
+else
+  no "--base pin (rc_match=$rc_match rc_stale=$rc_stale)"
+  printf 'match: %s\n' "$out_match"; printf 'stale: %s\n' "$out_stale"
+  printf 'diff: %s\n' "$diff_after"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 5: a graph-commit failure rolls the attention write back byte-identically.
+# ---------------------------------------------------------------------------
+# graph-commit is swapped for a stub that unconditionally fails — boost-node.ts's
+# real write still runs and lands on disk first, so MUTATED=1 is genuinely
+# reached. What is under test is boost-node's OWN trap-based rollback, not
+# graph-commit's internals (test-graph-commit.sh covers those). Assert
+# byte-identical restore via an EMPTY `git diff` against the clone's HEAD, not
+# merely "the file exists". graph-commit is untracked-after-overwrite only in
+# the sense that the stub replaces a tracked file, but the stub never runs
+# graph-commit's assert_clean_outside_ids guard, so no commit is needed.
+E="$WORK/e"
+make_clone "$E" writer-e
+cat >"$E/packages/intentionsutil/scripts/graph-commit" <<'SH'
+#!/usr/bin/env bash
+echo "graph-commit stub: simulated post-mutation failure" >&2
+exit 1
+SH
+chmod +x "$E/packages/intentionsutil/scripts/graph-commit"
+before_sha="$(origin_sha)"
+out="$(run_bn "$E" tactic-boost-rollback "$RATIONALE" 2>&1)"; rc=$?
+diff_after="$(git -C "$E" diff -- intentions/tactic-boost-rollback.md)"
+if [[ $rc -eq 1 ]] \
+   && grep -q 'attention write was rolled back' <<<"$out" \
+   && [[ -z "$diff_after" ]] \
+   && [[ "$(origin_sha)" == "$before_sha" ]]; then
+  ok "byte-identical rollback: a graph-commit failure restores intentions/<id>.md exactly (git diff empty), main unchanged"
+else
+  no "byte-identical rollback (rc=$rc)"
+  printf '%s\n' "$out"; printf 'diff: %s\n' "$diff_after"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 6: a boost needing rule 18's ACK is refused without --ack (exit 4).
+# ---------------------------------------------------------------------------
+# `--include-exempt` puts tactic-mh-child (rank 29, main-health-derived) back
+# into the contest, so topping the list needs a boost of 30 — at or above
+# strategy-main-health's dominant boost of 25, which validateGraph rule 18
+# refuses without the acknowledgement clause. boost-node.ts exits 4 and this
+# wrapper propagates it verbatim, landing nothing.
+F="$WORK/f"
+make_clone "$F" writer-f
+before_sha="$(origin_sha)"
+out="$(run_bn "$F" --include-exempt tactic-boost-ack "$RATIONALE" 2>&1)"; rc=$?
+diff_after="$(git -C "$F" diff -- intentions/tactic-boost-ack.md)"
+if [[ $rc -eq 4 ]] \
+   && grep -q 'Pass --ack' <<<"$out" \
+   && [[ "$(origin_sha)" == "$before_sha" ]] \
+   && [[ -z "$diff_after" ]]; then
+  ok "rule-18 ACK gate: a boost matching/exceeding main-health's dominant boost is refused without --ack (exit 4), nothing written"
+else
+  no "rule-18 ACK gate (rc=$rc)"
+  printf '%s\n' "$out"; printf 'diff: %s\n' "$diff_after"
+fi
+
+echo
+echo "passed: $PASS  failed: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/packages/intentionsutil/src/boost.ts
+++ b/packages/intentionsutil/src/boost.ts
@@ -1,0 +1,342 @@
+import { resolveAttention } from "./attention.js";
+import { IntentionSchemaError } from "./errors.js";
+import { selectGraphTargets } from "./router.js";
+import { dominantMainHealthBoost, kindIsNotGoalLayer } from "./schema.js";
+import type { IntentionNode } from "./schema.js";
+
+// Boost planner (tactic-attention-boost-scripts).
+//
+// Answers one question an author cannot answer by eyeballing the store: what
+// OWN `attention.boost` must node X carry so that it tops the selector's
+// candidate list (or reaches a named composed rank)?
+//
+// The trap this exists to close: the frontier view shows each node's COMPOSED
+// rank while `intentions/*.md` records each node's OWN authored boost, and the
+// two differ whenever a node inherits claims (down `parent`/`serves`, backward
+// along `blocked_by`). Copying an incumbent's authored `boost:` value is
+// therefore mis-sized in both directions — it overshoots when the target
+// inherits more than the incumbent, and undershoots when it inherits less.
+// This module sizes the boost against the RESOLVED ranks, by probing the real
+// resolver and the real selector rather than re-deriving either.
+//
+// Read-only and pure: it never writes a node. The caller decides what to do
+// with the plan.
+
+// --- Types -------------------------------------------------------------------
+
+/** One row of the ranking table shown to the author. */
+export interface RankRow {
+  id: string;
+  kind: "strategy" | "tactic";
+  /** `GraphCandidate.phase` — the directive rung the selector would dispatch. */
+  phase: string;
+  /** Composed rank from `resolveAttention`. */
+  rank: number;
+  /** The node's OWN authored boost, for contrast with `rank`. */
+  own_boost: number | null;
+  own_override: number | null;
+  /** Main-health-derived: not part of the top-rank contest. */
+  exempt: boolean;
+}
+
+export type BoostMode =
+  | { kind: "top-candidate" } // beat every non-exempt selector candidate
+  | { kind: "rank"; value: number }; // reach at least this composed rank
+
+export interface BoostPlan {
+  target: string;
+  /** The target appears in `selectGraphTargets()`'s candidate list. */
+  target_is_candidate: boolean;
+  /** Resolved rank today; null when the target is not goal-layer-eligible. */
+  target_current_rank: number | null;
+  /** Full candidate list in selector order (rank desc, …), not truncated. */
+  ranking: RankRow[];
+  /** Highest-ranked non-exempt candidate other than the target. */
+  incumbent: RankRow | null;
+  /** MINIMAL own-boost meeting the mode, or null when unreachable. */
+  recommended_boost: number | null;
+  /** The target's composed rank at `recommended_boost`. */
+  resulting_rank: number | null;
+  /** `strategy-main-health`'s live boost (rule 18's threshold), or null. */
+  ceiling: number | null;
+  /** `recommended_boost >= ceiling` — the author must ACK rule 18. */
+  needs_ack: boolean;
+  /** Set iff `recommended_boost` is null. */
+  unreachable_reason: string | null;
+}
+
+// --- Constants ---------------------------------------------------------------
+
+const MAIN_HEALTH_ID = "strategy-main-health";
+
+/** Default upper search bound when there is no live rule-18 ceiling. */
+const DEFAULT_MAX_BOOST = 1000;
+
+/** Rank comparisons are on floats (the capture term is fractional). */
+const EPSILON = 1e-9;
+
+// --- Planner -----------------------------------------------------------------
+
+/**
+ * Plan the minimal own `attention.boost` for `targetId` under `mode`.
+ *
+ * Throws `IntentionSchemaError` for an unknown id, a non-goal-layer target
+ * (validateGraph rule 5: `attention` is goal-layer-only), or a failed
+ * monotonicity self-check (see the binary-search comment below).
+ */
+export function planBoost(
+  nodes: IntentionNode[],
+  targetId: string,
+  mode: BoostMode,
+  opts?: { includeExempt?: boolean; maxBoost?: number },
+): BoostPlan {
+  const includeExempt = opts?.includeExempt ?? false;
+  const maxBoost = opts?.maxBoost ?? DEFAULT_MAX_BOOST;
+
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+
+  // 1. Unknown id — a clear error, never a fallback.
+  const target = byId.get(targetId);
+  if (target === undefined) {
+    throw new IntentionSchemaError(`boost: no node with id "${targetId}" in the graph`);
+  }
+
+  // 2. Attention is goal-layer-only (validateGraph rule 5). Reuse the single
+  //    gate definition rather than re-deriving `kind-<kind>.attributes.goal_layer`.
+  if (kindIsNotGoalLayer(target.kind, byId)) {
+    throw new IntentionSchemaError(
+      `boost: "${targetId}" has kind "${target.kind}", which is not a goal-layer kind — ` +
+        `attention is only valid on goal-layer kinds (validateGraph rule 5), so no boost applies`,
+    );
+  }
+
+  // 3. The selector and the resolver are the authoritative sources for the
+  //    candidate list, its ordering, and every node's composed rank.
+  const baseSelection = selectGraphTargets(nodes);
+  const baseAttention = resolveAttention(nodes);
+
+  // 4. Main-health exemption: main-health and its subtree are the always-on
+  //    trunk-health signal, not discretionary work, so "top ranking" means #1
+  //    BELOW main-health. A candidate is exempt when it IS main-health or when
+  //    its resolved `sources` carry main-health's claim. `includeExempt` drops
+  //    the exemption from the contest (the flag itself still reports the
+  //    main-health derivation).
+  const isExempt = (id: string): boolean =>
+    id === MAIN_HEALTH_ID || (baseAttention.get(id)?.sources.includes(MAIN_HEALTH_ID) ?? false);
+  const contested = (id: string): boolean =>
+    id !== targetId && (includeExempt || !isExempt(id));
+
+  const ranking: RankRow[] = baseSelection.candidates.map((c) => {
+    const node = byId.get(c.id);
+    return {
+      id: c.id,
+      kind: c.kind,
+      phase: c.phase,
+      rank: c.rank,
+      own_boost: node?.attention?.boost ?? null,
+      own_override: node?.attention?.override ?? null,
+      exempt: isExempt(c.id),
+    };
+  });
+
+  const targetIsCandidate = baseSelection.candidates.some((c) => c.id === targetId);
+  const targetCurrentRank = baseAttention.get(targetId)?.value ?? null;
+  // `ranking` is already in selector order, so the first contested row is the
+  // incumbent.
+  const incumbent = ranking.find((r) => contested(r.id)) ?? null;
+
+  // 5. Rule-18 ceiling, read live from the graph.
+  const ceiling = dominantMainHealthBoost(nodes);
+
+  // 6. Probe: re-resolve the graph with the target's attention replaced by the
+  //    candidate own-boost. `rationale` is never empty — the schema requires a
+  //    non-empty string and `validateAttention` is the gate — so an absent one
+  //    is filled with a placeholder that never reaches the store.
+  const probeRationale =
+    target.attention !== null && target.attention.rationale !== ""
+      ? target.attention.rationale
+      : "boost-planner probe";
+  const probeCache = new Map<number, { rank: number; tops: boolean }>();
+  const probe = (b: number): { rank: number; tops: boolean } => {
+    const cached = probeCache.get(b);
+    if (cached !== undefined) return cached;
+    const probed = nodes.map((n) =>
+      n.id === targetId
+        ? { ...n, attention: { boost: b, override: null, rationale: probeRationale } }
+        : n,
+    );
+    const attention = resolveAttention(probed);
+    const rank = attention.get(targetId)?.value ?? 0;
+    const candidates = selectGraphTargets(probed).candidates;
+    const present = candidates.some((c) => c.id === targetId);
+    const tops =
+      present && candidates.every((c) => !contested(c.id) || rank > c.rank + EPSILON);
+    const result = { rank, tops };
+    probeCache.set(b, result);
+    return result;
+  };
+
+  const meetsMode = (b: number): boolean =>
+    mode.kind === "top-candidate" ? probe(b).tops : probe(b).rank >= mode.value - EPSILON;
+
+  // 7. Minimal `b` by integer binary search.
+  //
+  //    Why binary search is sound here: a boost `b` on X adds the single claim
+  //    `(X, b)` to X's outgoing set, and that claim flows to exactly the same
+  //    set of distributees at every `b` (the flow relation — parent/serves/
+  //    blocked_by — does not depend on the amount). So each node's composed
+  //    rank is either constant in `b` or rises by exactly `b`; every
+  //    peer-minus-target difference is therefore monotone non-decreasing in
+  //    `b`, which makes both `tops` and "rank >= value" monotone predicates.
+  //
+  //    That argument depends on `resolveAttention`'s CURRENT flow model, which
+  //    may still change — so the search self-checks its answer below instead of
+  //    trusting the property. A failed self-check throws; it must never
+  //    silently return a wrong minimum.
+  const searchMinimal = (lo: number, hi: number): number | null => {
+    if (hi < lo) return null;
+    if (!meetsMode(hi)) return null;
+    let low = lo;
+    let high = hi;
+    while (low < high) {
+      const mid = Math.floor((low + high) / 2);
+      if (meetsMode(mid)) high = mid;
+      else low = mid + 1;
+    }
+    // Self-check the monotonicity assumption at the boundary.
+    if (!meetsMode(low) || (low > lo && meetsMode(low - 1))) {
+      throw new IntentionSchemaError(
+        `boost: non-monotone attention response around boost ${low} for "${targetId}" — ` +
+          `binary search cannot size a minimal boost on this graph (the flow model ` +
+          `no longer guarantees monotonicity; size the boost by hand)`,
+      );
+    }
+    return low;
+  };
+
+  const finish = (
+    recommended: number | null,
+    unreachableReason: string | null,
+  ): BoostPlan => ({
+    target: targetId,
+    target_is_candidate: targetIsCandidate,
+    target_current_rank: targetCurrentRank,
+    ranking,
+    incumbent,
+    recommended_boost: recommended,
+    resulting_rank: recommended === null ? null : probe(recommended).rank,
+    ceiling,
+    needs_ack: recommended !== null && ceiling !== null && recommended >= ceiling,
+    unreachable_reason: unreachableReason,
+  });
+
+  // A node the selector does not emit can never BE the top candidate, no matter
+  // its rank — say so instead of searching. (Rank mode is still well-defined:
+  // ranks are resolved for every goal-layer node, candidate or not.)
+  if (mode.kind === "top-candidate" && !targetIsCandidate) {
+    return finish(
+      null,
+      `"${targetId}" is not in the selector's candidate list (selectGraphTargets omits it — ` +
+        `e.g. parked via office_hours, at phase draft/done, or held by an open blocker), ` +
+        `so no boost can make it the top candidate`,
+    );
+  }
+
+  // `hi` stays strictly BELOW the rule-18 ceiling on the first pass, so the
+  // ordinary answer never needs an ACK. `hi < 1` (ceiling 1) means there is no
+  // candidate boost below the ceiling at all — fall straight through to the
+  // ceiling re-search.
+  const hi = ceiling !== null ? ceiling - 1 : maxBoost;
+  const belowCeiling = hi >= 1 ? searchMinimal(1, hi) : null;
+  if (belowCeiling !== null) return finish(belowCeiling, null);
+
+  // 8. Nothing below the ceiling works. Re-search AT and above it; the caller
+  //    decides whether the author acknowledges rule 18.
+  if (ceiling !== null) {
+    const atCeiling = searchMinimal(ceiling, ceiling * 10);
+    if (atCeiling !== null) return finish(atCeiling, null);
+  }
+
+  // Still nothing. Name WHY, distinguishing the two real causes.
+  const searchedTo = ceiling !== null ? ceiling * 10 : maxBoost;
+  // Only the top-candidate contest can be blocked structurally: a named rank is
+  // a pure threshold on the target's own value, which rises with every boost,
+  // so its only failure mode is the search bound.
+  const blockers =
+    mode.kind === "top-candidate"
+      ? constantDeltaPeers(
+          probe,
+          ranking,
+          contested,
+          targetId,
+          nodes,
+          probeRationale,
+          searchedTo,
+        )
+      : [];
+  if (blockers.length > 0) {
+    const detail = blockers.map((p) => `${p.id} (+${round(p.delta)})`).join(", ");
+    return finish(
+      null,
+      `no boost can top the list: ${detail} receive "${targetId}"'s own claim through the ` +
+        `attention flow (they sit in its subtree via parent/serves, or it lists them in ` +
+        `blocked_by), so they rise with every boost and stay ahead by a constant margin`,
+    );
+  }
+  return finish(
+    null,
+    mode.kind === "top-candidate"
+      ? `no boost up to ${searchedTo} tops the candidate list — raise the search bound (maxBoost)`
+      : `no boost up to ${searchedTo} reaches rank ${mode.value} — raise the search bound (maxBoost)`,
+  );
+}
+
+// --- Unreachability diagnosis -------------------------------------------------
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+/**
+ * Peers that stay ahead of the target by the SAME margin at two very different
+ * boosts — i.e. they receive the target's own claim and rise with it. These are
+ * the structural blockers (cause (a)); an empty list means the search simply
+ * hit its bound (cause (b)).
+ */
+function constantDeltaPeers(
+  probe: (b: number) => { rank: number },
+  ranking: RankRow[],
+  contested: (id: string) => boolean,
+  targetId: string,
+  nodes: IntentionNode[],
+  probeRationale: string,
+  hi: number,
+): { id: string; delta: number }[] {
+  const rankOfPeersAt = (b: number): Map<string, number> => {
+    const probed = nodes.map((n) =>
+      n.id === targetId
+        ? { ...n, attention: { boost: b, override: null, rationale: probeRationale } }
+        : n,
+    );
+    const attention = resolveAttention(probed);
+    return new Map([...attention].map(([id, a]) => [id, a.value]));
+  };
+
+  const lowBoost = 1;
+  const highBoost = Math.max(2, hi);
+  const low = rankOfPeersAt(lowBoost);
+  const high = rankOfPeersAt(highBoost);
+  const targetLow = probe(lowBoost).rank;
+  const targetHigh = high.get(targetId) ?? 0;
+
+  const result: { id: string; delta: number }[] = [];
+  for (const row of ranking) {
+    if (!contested(row.id)) continue;
+    const deltaLow = (low.get(row.id) ?? 0) - targetLow;
+    const deltaHigh = (high.get(row.id) ?? 0) - targetHigh;
+    if (deltaHigh >= -EPSILON && Math.abs(deltaLow - deltaHigh) < EPSILON) {
+      result.push({ id: row.id, delta: deltaHigh });
+    }
+  }
+  return result;
+}

--- a/packages/intentionsutil/src/schema.ts
+++ b/packages/intentionsutil/src/schema.ts
@@ -715,7 +715,7 @@ export function validateNode(value: unknown): IntentionNode {
  * / pace_exempt — rule 11). A missing kind node is rule 1's concern, so this
  * returns false there (no goal-layer complaint on top of the missing-kind one).
  */
-function kindIsNotGoalLayer(kind: string, byId: Map<string, IntentionNode>): boolean {
+export function kindIsNotGoalLayer(kind: string, byId: Map<string, IntentionNode>): boolean {
   const kindNode = byId.get(`kind-${kind}`);
   return kindNode !== undefined && kindNode.attributes.goal_layer !== true;
 }
@@ -908,10 +908,35 @@ function checkClarificationDates(node: IntentionNode, problems: string[]): void 
 }
 
 /**
+ * The rule-18 opt-out marker: an author places this literal substring in a
+ * node's `attention.rationale` to acknowledge that the node deliberately
+ * matches or exceeds strategy-main-health's dominant boost. Exported so a
+ * boost-planning tool can emit an ACK-carrying rationale without re-typing the
+ * literal the validator matches on.
+ */
+export const MAIN_HEALTH_DOMINANCE_ACK = "ACK: main-health-dominance";
+
+/**
+ * The rule-18 threshold: `strategy-main-health`'s own live `attention.boost`,
+ * read from the passed node set — never hardcoded. Null when the node is
+ * absent, or its `attention`/`attention.boost` is null, in which case there is
+ * no dominance to protect and the guard is inert.
+ *
+ * Exported so consumers that must respect the same ceiling (e.g. the boost
+ * planner) read it through this one definition rather than re-deriving it.
+ */
+export function dominantMainHealthBoost(nodes: IntentionNode[]): number | null {
+  const mainHealthNode = nodes.find((n) => n.id === "strategy-main-health");
+  return mainHealthNode !== undefined && mainHealthNode.attention !== null
+    ? mainHealthNode.attention.boost
+    : null;
+}
+
+/**
  * Rule 18: no node other than strategy-main-health may match or exceed its
  * dominant attention.boost via either attention.boost or attention.override.
  * Threshold (`dominantBoost`) is read live by the caller; when null the guard is
- * inert. An author may opt out with "ACK: main-health-dominance" in the node's
+ * inert. An author may opt out with `MAIN_HEALTH_DOMINANCE_ACK` in the node's
  * attention.rationale.
  */
 function checkAttentionDominance(
@@ -923,19 +948,19 @@ function checkAttentionDominance(
     dominantBoost === null ||
     node.id === "strategy-main-health" ||
     node.attention === null ||
-    node.attention.rationale.includes("ACK: main-health-dominance")
+    node.attention.rationale.includes(MAIN_HEALTH_DOMINANCE_ACK)
   ) {
     return;
   }
   const { boost, override } = node.attention;
   if (boost !== null && boost >= dominantBoost) {
     problems.push(
-      `${node.id}: attention.boost (${boost}) matches or exceeds strategy-main-health's dominant boost (${dominantBoost}) — add "ACK: main-health-dominance" to attention.rationale to override`,
+      `${node.id}: attention.boost (${boost}) matches or exceeds strategy-main-health's dominant boost (${dominantBoost}) — add "${MAIN_HEALTH_DOMINANCE_ACK}" to attention.rationale to override`,
     );
   }
   if (override !== null && override >= dominantBoost) {
     problems.push(
-      `${node.id}: attention.override (${override}) matches or exceeds strategy-main-health's dominant boost (${dominantBoost}) — add "ACK: main-health-dominance" to attention.rationale to override`,
+      `${node.id}: attention.override (${override}) matches or exceeds strategy-main-health's dominant boost (${dominantBoost}) — add "${MAIN_HEALTH_DOMINANCE_ACK}" to attention.rationale to override`,
     );
   }
 }
@@ -1048,14 +1073,9 @@ export function validateGraph(nodes: IntentionNode[]): void {
   const byId = new Map(nodes.map((n) => [n.id, n]));
   const ids = new Set(byId.keys());
   const problems: string[] = [];
-  // Rule 18 threshold: strategy-main-health's own live attention.boost. Read
-  // from the same nodes array; null when the node, its attention, or its boost
-  // is absent — in which case there is no dominance to protect (guard inert).
-  const mainHealthNode = byId.get("strategy-main-health");
-  const dominantBoost =
-    mainHealthNode !== undefined && mainHealthNode.attention !== null
-      ? mainHealthNode.attention.boost
-      : null;
+  // Rule 18 threshold: strategy-main-health's own live attention.boost, read
+  // from the same nodes array (see `dominantMainHealthBoost`).
+  const dominantBoost = dominantMainHealthBoost(nodes);
   for (const node of nodes) {
     // Rules 1-4: every referenced id exists.
     checkExistenceEdges(node, ids, problems);

--- a/packages/intentionsutil/test/boost-node.test.ts
+++ b/packages/intentionsutil/test/boost-node.test.ts
@@ -1,0 +1,323 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { readNode, writeNode } from "../src/store.js";
+import { MAIN_HEALTH_DOMINANCE_ACK } from "../src/schema.js";
+import type { Attention, IntentionNode } from "../src/schema.js";
+import { previewBoost, writeBoost } from "../scripts/boost-node.js";
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), "boost-node-"));
+}
+
+/** Minimal full IntentionNode fixture (mirrors check-node-selection.test.ts's `anode`). */
+function anode(partial: Partial<IntentionNode> & { id: string; kind: string }): IntentionNode {
+  return {
+    id: partial.id,
+    kind: partial.kind,
+    statement: partial.statement ?? `Statement for ${partial.id}`,
+    owner: partial.owner ?? "ai",
+    status: partial.status ?? "codified",
+    parent: partial.parent ?? null,
+    serves: partial.serves ?? [],
+    recovers: partial.recovers ?? [],
+    rationale: partial.rationale ?? null,
+    reading: partial.reading ?? null,
+    gap: partial.gap ?? null,
+    clarifications: partial.clarifications ?? [],
+    tooling_goals: partial.tooling_goals ?? [],
+    success_signal: partial.success_signal ?? null,
+    attention: partial.attention ?? null,
+    phase: partial.phase ?? null,
+    execution: partial.execution ?? null,
+    validates: partial.validates ?? [],
+    blocked_by: partial.blocked_by ?? [],
+    office_hours: partial.office_hours ?? null,
+    pace_exempt: partial.pace_exempt ?? false,
+    rounds: partial.rounds ?? null,
+    attributes: partial.attributes ?? {},
+  };
+}
+
+const STATUS_VOCABULARY = { raw: "Not yet started.", codified: "Complete." };
+
+/**
+ * The goal-layer declaration, WITH a status_vocabulary so validateGraph (rule
+ * 16) passes too, and a self-describing `kind-kind` node so validateGraph
+ * (rule 1) doesn't complain that `kind-strategy`/`kind-tactic` themselves
+ * reference an undeclared "kind" kind.
+ */
+const KIND_NODES: IntentionNode[] = [
+  anode({
+    id: "kind-kind",
+    kind: "kind",
+    attributes: { status_vocabulary: STATUS_VOCABULARY },
+  }),
+  anode({
+    id: "kind-strategy",
+    kind: "kind",
+    attributes: { goal_layer: true, status_vocabulary: STATUS_VOCABULARY },
+  }),
+  anode({
+    id: "kind-tactic",
+    kind: "kind",
+    attributes: { goal_layer: true, status_vocabulary: STATUS_VOCABULARY },
+  }),
+];
+
+function att(boost: number): Attention {
+  return { boost, override: null, rationale: `boost ${boost}` };
+}
+
+/** A strategy whose signal is already validated, so it is not itself a candidate. */
+function strategy(partial: Partial<IntentionNode> & { id: string }): IntentionNode {
+  return anode({ reading: "validated (2026-07-01)", ...partial, kind: "strategy" });
+}
+
+/** An in-flight tactic — a first-class selector candidate. */
+function tactic(partial: Partial<IntentionNode> & { id: string }): IntentionNode {
+  return anode({ phase: "implement", ...partial, kind: "tactic" });
+}
+
+function seed(dir: string, node: IntentionNode): void {
+  writeNode(dir, node);
+}
+
+function seedAll(dir: string, nodes: IntentionNode[]): void {
+  for (const node of nodes) seed(dir, node);
+}
+
+// Same shape as boost.test.ts's trapFixture: target inherits a claim from a
+// hot strategy; a cold-strategy incumbent carries its whole rank as an
+// authored boost. Gives a clean, low, always-reachable recommendation.
+const HOT_BOOST = 18;
+const INCUMBENT_BOOST = 20;
+function trapFixture(): IntentionNode[] {
+  return [
+    ...KIND_NODES,
+    strategy({ id: "strategy-hot", attention: att(HOT_BOOST) }),
+    strategy({ id: "strategy-cold" }),
+    tactic({ id: "tactic-target", serves: ["strategy-hot"] }),
+    tactic({ id: "tactic-incumbent", serves: ["strategy-cold"], attention: att(INCUMBENT_BOOST) }),
+  ];
+}
+
+// A fixture where topping the incumbent requires reaching the live rule-18
+// ceiling exactly (mirrors boost.test.ts's "sets needs_ack..." fixture).
+const MH_BOOST = 40;
+function ceilingFixture(): IntentionNode[] {
+  return [
+    ...KIND_NODES,
+    strategy({ id: "strategy-main-health", attention: att(MH_BOOST) }),
+    strategy({ id: "strategy-cold" }),
+    tactic({ id: "tactic-incumbent", serves: ["strategy-cold"], attention: att(MH_BOOST - 1) }),
+    tactic({ id: "tactic-target", serves: ["strategy-cold"] }),
+  ];
+}
+
+describe("previewBoost", () => {
+  it("computes a plan and writes nothing to disk", () => {
+    const dir = tempDir();
+    seedAll(dir, trapFixture());
+    const before = readFileSync(join(dir, "tactic-target.md"), "utf8");
+
+    const result = previewBoost({
+      dir,
+      nodeId: "tactic-target",
+      mode: { kind: "top-candidate" },
+      includeExempt: false,
+      json: true,
+      top: 10,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.plan?.recommended_boost).toBe(3);
+    const after = readFileSync(join(dir, "tactic-target.md"), "utf8");
+    expect(after).toBe(before);
+  });
+
+  it("renders a human-readable table by default (non-json)", () => {
+    const dir = tempDir();
+    seedAll(dir, trapFixture());
+    const result = previewBoost({
+      dir,
+      nodeId: "tactic-target",
+      mode: { kind: "top-candidate" },
+      includeExempt: false,
+      json: false,
+      top: 10,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("tactic-incumbent");
+    expect(result.stdout).toContain("recommended boost: 3");
+  });
+
+  it("exits 1 on an unknown node id", () => {
+    const dir = tempDir();
+    seedAll(dir, trapFixture());
+    const result = previewBoost({
+      dir,
+      nodeId: "tactic-does-not-exist",
+      mode: { kind: "top-candidate" },
+      includeExempt: false,
+      json: true,
+      top: 10,
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr[0]).toMatch(/no node with id/);
+  });
+});
+
+describe("writeBoost", () => {
+  it("without --rationale (null/blank) exits 2 and writes nothing", () => {
+    const dir = tempDir();
+    seedAll(dir, trapFixture());
+    const before = readFileSync(join(dir, "tactic-target.md"), "utf8");
+
+    const missing = writeBoost({
+      dir,
+      nodeId: "tactic-target",
+      mode: { kind: "top-candidate" },
+      includeExempt: false,
+      rationale: null,
+      explicitBoost: null,
+      ack: false,
+    });
+    expect(missing.exitCode).toBe(2);
+
+    const blank = writeBoost({
+      dir,
+      nodeId: "tactic-target",
+      mode: { kind: "top-candidate" },
+      includeExempt: false,
+      rationale: "   ",
+      explicitBoost: null,
+      ack: false,
+    });
+    expect(blank.exitCode).toBe(2);
+
+    const after = readFileSync(join(dir, "tactic-target.md"), "utf8");
+    expect(after).toBe(before);
+  });
+
+  it("a successful write sets exactly attention, leaving every other field identical", () => {
+    const dir = tempDir();
+    seedAll(dir, trapFixture());
+    const before = readNode(dir, "tactic-target");
+
+    const result = writeBoost({
+      dir,
+      nodeId: "tactic-target",
+      mode: { kind: "top-candidate" },
+      includeExempt: false,
+      rationale: "beat the incumbent for the sprint",
+      explicitBoost: null,
+      ack: false,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const after = readNode(dir, "tactic-target");
+    expect(after.attention).toEqual({
+      boost: 3,
+      override: null,
+      rationale: "beat the incumbent for the sprint",
+    });
+    const { attention: _beforeAttention, ...beforeRest } = before;
+    const { attention: _afterAttention, ...afterRest } = after;
+    expect(afterRest).toEqual(beforeRest);
+  });
+
+  it("needing ACK (chosen boost >= ceiling) without --ack exits 4 and writes nothing", () => {
+    const dir = tempDir();
+    seedAll(dir, ceilingFixture());
+    const before = readFileSync(join(dir, "tactic-target.md"), "utf8");
+
+    const result = writeBoost({
+      dir,
+      nodeId: "tactic-target",
+      mode: { kind: "top-candidate" },
+      includeExempt: false,
+      rationale: "top the ranking",
+      explicitBoost: null,
+      ack: false,
+    });
+
+    expect(result.exitCode).toBe(4);
+    expect(result.stderr[0]).toMatch(/would match or exceed strategy-main-health/);
+    const after = readFileSync(join(dir, "tactic-target.md"), "utf8");
+    expect(after).toBe(before);
+  });
+
+  it("with --ack the rationale carries MAIN_HEALTH_DOMINANCE_ACK and the write lands", () => {
+    const dir = tempDir();
+    seedAll(dir, ceilingFixture());
+
+    const result = writeBoost({
+      dir,
+      nodeId: "tactic-target",
+      mode: { kind: "top-candidate" },
+      includeExempt: false,
+      rationale: "top the ranking",
+      explicitBoost: null,
+      ack: true,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const after = readNode(dir, "tactic-target");
+    expect(after.attention?.boost).toBe(MH_BOOST);
+    expect(after.attention?.rationale).toContain(MAIN_HEALTH_DOMINANCE_ACK);
+    expect(after.attention?.rationale).toContain("top the ranking");
+  });
+
+  it("--boost overrides the recommendation, writing the explicit value verbatim", () => {
+    const dir = tempDir();
+    seedAll(dir, trapFixture());
+
+    const result = writeBoost({
+      dir,
+      nodeId: "tactic-target",
+      mode: { kind: "top-candidate" },
+      includeExempt: false,
+      rationale: "author wants a specific value",
+      explicitBoost: 9,
+      ack: false,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const after = readNode(dir, "tactic-target");
+    expect(after.attention?.boost).toBe(9);
+    // 9 !== the planner's recommendation (3), proving the explicit value won,
+    // not plan.recommended_boost.
+    expect(after.attention?.boost).not.toBe(3);
+  });
+
+  it("unreachable and no explicit --boost given exits 4, writing nothing", () => {
+    const dir = tempDir();
+    // A tactic the selector never emits (parked) can never top the list.
+    seedAll(dir, [
+      ...KIND_NODES,
+      strategy({ id: "strategy-cold" }),
+      tactic({
+        id: "tactic-target",
+        serves: ["strategy-cold"],
+        office_hours: { reason: "parked", since: "2026-07-01", recommendation: null, session_type: "other" },
+      }),
+    ]);
+    const before = readFileSync(join(dir, "tactic-target.md"), "utf8");
+
+    const result = writeBoost({
+      dir,
+      nodeId: "tactic-target",
+      mode: { kind: "top-candidate" },
+      includeExempt: false,
+      rationale: "try anyway",
+      explicitBoost: null,
+      ack: false,
+    });
+
+    expect(result.exitCode).toBe(4);
+    const after = readFileSync(join(dir, "tactic-target.md"), "utf8");
+    expect(after).toBe(before);
+  });
+});

--- a/packages/intentionsutil/test/boost.test.ts
+++ b/packages/intentionsutil/test/boost.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+import { planBoost } from "../src/boost.js";
+import { IntentionSchemaError } from "../src/errors.js";
+import type { Attention, IntentionNode } from "../src/schema.js";
+
+/** Minimal full IntentionNode fixture (mirrors check-node-selection.test.ts's `anode`). */
+function anode(partial: Partial<IntentionNode> & { id: string; kind: string }): IntentionNode {
+  return {
+    id: partial.id,
+    kind: partial.kind,
+    statement: partial.statement ?? `Statement for ${partial.id}`,
+    owner: partial.owner ?? "ai",
+    status: partial.status ?? "codified",
+    parent: partial.parent ?? null,
+    serves: partial.serves ?? [],
+    recovers: partial.recovers ?? [],
+    rationale: partial.rationale ?? null,
+    reading: partial.reading ?? null,
+    gap: partial.gap ?? null,
+    clarifications: partial.clarifications ?? [],
+    tooling_goals: partial.tooling_goals ?? [],
+    success_signal: partial.success_signal ?? null,
+    attention: partial.attention ?? null,
+    phase: partial.phase ?? null,
+    execution: partial.execution ?? null,
+    validates: partial.validates ?? [],
+    blocked_by: partial.blocked_by ?? [],
+    office_hours: partial.office_hours ?? null,
+    pace_exempt: partial.pace_exempt ?? false,
+    rounds: partial.rounds ?? null,
+    attributes: partial.attributes ?? {},
+  };
+}
+
+/** The goal-layer declaration: without these, nothing is attention-eligible. */
+const KIND_NODES: IntentionNode[] = [
+  anode({ id: "kind-strategy", kind: "kind", attributes: { goal_layer: true } }),
+  anode({ id: "kind-tactic", kind: "kind", attributes: { goal_layer: true } }),
+  anode({ id: "kind-delegation", kind: "kind", attributes: {} }),
+];
+
+function att(boost: number): Attention {
+  return { boost, override: null, rationale: `boost ${boost}` };
+}
+
+/**
+ * A strategy whose signal is already validated, so it is NOT itself a selector
+ * candidate and contributes no signal term — keeping the rank arithmetic in
+ * these fixtures pure authored-flow.
+ */
+function strategy(partial: Partial<IntentionNode> & { id: string }): IntentionNode {
+  return anode({
+    reading: "validated (2026-07-01)",
+    ...partial,
+    kind: "strategy",
+  });
+}
+
+/** An in-flight tactic — a first-class selector candidate. */
+function tactic(partial: Partial<IntentionNode> & { id: string }): IntentionNode {
+  return anode({ phase: "implement", ...partial, kind: "tactic" });
+}
+
+// The mis-sizing trap fixture: the target inherits a big claim (18) from the
+// hot strategy it serves; the incumbent inherits nothing and carries its whole
+// rank as an authored boost (20). Naively copying the incumbent's `boost: 20`
+// overshoots by a factor of ~7.
+const HOT_BOOST = 18;
+const INCUMBENT_BOOST = 20;
+const trapFixture = (): IntentionNode[] => [
+  ...KIND_NODES,
+  strategy({ id: "strategy-hot", attention: att(HOT_BOOST) }),
+  strategy({ id: "strategy-cold" }),
+  tactic({ id: "tactic-target", serves: ["strategy-hot"] }),
+  tactic({ id: "tactic-incumbent", serves: ["strategy-cold"], attention: att(INCUMBENT_BOOST) }),
+];
+
+describe("planBoost — the composed-vs-authored mis-sizing trap", () => {
+  it("sizes the boost against the incumbent's COMPOSED rank, not its authored boost column", () => {
+    const plan = planBoost(trapFixture(), "tactic-target", { kind: "top-candidate" });
+
+    expect(plan.target_is_candidate).toBe(true);
+    expect(plan.target_current_rank).toBe(HOT_BOOST);
+    expect(plan.incumbent?.id).toBe("tactic-incumbent");
+    expect(plan.incumbent?.rank).toBe(INCUMBENT_BOOST);
+    expect(plan.incumbent?.own_boost).toBe(INCUMBENT_BOOST);
+
+    // Beats the incumbent's composed rank...
+    expect(plan.recommended_boost).toBe(3);
+    expect(plan.resulting_rank).toBe(21);
+    expect(plan.resulting_rank as number).toBeGreaterThan(INCUMBENT_BOOST);
+    // ...and is far below the naive "match the incumbent's boost column" value.
+    expect(plan.recommended_boost as number).toBeLessThan(INCUMBENT_BOOST);
+    expect(plan.unreachable_reason).toBeNull();
+    expect(plan.needs_ack).toBe(false);
+  });
+
+  it("recommends the OWN boost, with the inherited claim composing on top", () => {
+    const plan = planBoost(trapFixture(), "tactic-target", { kind: "top-candidate" });
+    expect(plan.resulting_rank).toBe((plan.recommended_boost as number) + HOT_BOOST);
+    expect(plan.recommended_boost).not.toBe(plan.resulting_rank);
+  });
+
+  it("returns the full candidate list in selector order", () => {
+    const plan = planBoost(trapFixture(), "tactic-target", { kind: "top-candidate" });
+    expect(plan.ranking.map((r) => r.id)).toEqual(["tactic-incumbent", "tactic-target"]);
+    expect(plan.ranking.every((r) => r.exempt === false)).toBe(true);
+  });
+
+  it("reaches a named composed rank in `rank` mode", () => {
+    const plan = planBoost(trapFixture(), "tactic-target", { kind: "rank", value: 25 });
+    expect(plan.recommended_boost).toBe(7);
+    expect(plan.resulting_rank).toBe(25);
+  });
+});
+
+// Main-health fixture: main-health is itself a candidate (unvalidated signal),
+// and `tactic-mh-child` inherits its claim, so both are exempt from the
+// top-rank contest.
+const MH_BOOST = 40;
+const mainHealthFixture = (): IntentionNode[] => [
+  ...KIND_NODES,
+  // reading null → signal unvalidated → main-health is itself a candidate.
+  strategy({ id: "strategy-main-health", reading: null, attention: att(MH_BOOST) }),
+  strategy({ id: "strategy-cold" }),
+  tactic({ id: "tactic-mh-child", serves: ["strategy-main-health"] }),
+  tactic({ id: "tactic-incumbent", serves: ["strategy-cold"], attention: att(5) }),
+  tactic({ id: "tactic-target", serves: ["strategy-cold"] }),
+];
+
+describe("planBoost — main-health exemption and the rule-18 ceiling", () => {
+  it("marks main-health and its subtree exempt, and skips them when picking the incumbent", () => {
+    const plan = planBoost(mainHealthFixture(), "tactic-target", { kind: "top-candidate" });
+    const byId = new Map(plan.ranking.map((r) => [r.id, r]));
+
+    expect(byId.get("strategy-main-health")?.exempt).toBe(true);
+    expect(byId.get("tactic-mh-child")?.exempt).toBe(true);
+    expect(byId.get("tactic-incumbent")?.exempt).toBe(false);
+
+    expect(plan.incumbent?.id).toBe("tactic-incumbent");
+    expect(plan.recommended_boost).toBe(6);
+    expect(plan.needs_ack).toBe(false);
+    expect(plan.ceiling).toBe(MH_BOOST);
+  });
+
+  it("contests main-health too under includeExempt, which then needs the rule-18 ACK", () => {
+    const plan = planBoost(mainHealthFixture(), "tactic-target", { kind: "top-candidate" }, {
+      includeExempt: true,
+    });
+    expect(plan.incumbent?.id).toBe("strategy-main-health");
+    // main-health composes to its boost plus the signal term (it is its own
+    // unvalidated-signal terminal), so topping it takes one more than that.
+    expect(plan.recommended_boost).toBe((plan.incumbent?.rank as number) + 1);
+    expect(plan.needs_ack).toBe(true);
+    expect(plan.unreachable_reason).toBeNull();
+  });
+
+  it("sets needs_ack when topping the incumbent requires reaching the live ceiling", () => {
+    const nodes = [
+      ...KIND_NODES,
+      strategy({ id: "strategy-main-health", attention: att(MH_BOOST) }),
+      strategy({ id: "strategy-cold" }),
+      tactic({ id: "tactic-incumbent", serves: ["strategy-cold"], attention: att(MH_BOOST - 1) }),
+      tactic({ id: "tactic-target", serves: ["strategy-cold"] }),
+    ];
+    const plan = planBoost(nodes, "tactic-target", { kind: "top-candidate" });
+    expect(plan.ceiling).toBe(MH_BOOST);
+    expect(plan.recommended_boost).toBe(MH_BOOST);
+    expect(plan.needs_ack).toBe(true);
+    expect(plan.unreachable_reason).toBeNull();
+  });
+
+  it("reports a null ceiling when main-health carries no attention, and searches to maxBoost", () => {
+    const nodes = [
+      ...KIND_NODES,
+      strategy({ id: "strategy-main-health", attention: null }),
+      strategy({ id: "strategy-cold" }),
+      tactic({ id: "tactic-incumbent", serves: ["strategy-cold"], attention: att(3) }),
+      tactic({ id: "tactic-target", serves: ["strategy-cold"] }),
+    ];
+    const plan = planBoost(nodes, "tactic-target", { kind: "top-candidate" }, { maxBoost: 5 });
+    expect(plan.ceiling).toBeNull();
+    expect(plan.recommended_boost).toBe(4);
+    expect(plan.needs_ack).toBe(false);
+  });
+
+  it("reports the bound when maxBoost is too small to top the incumbent", () => {
+    const nodes = [
+      ...KIND_NODES,
+      strategy({ id: "strategy-cold" }),
+      tactic({ id: "tactic-incumbent", serves: ["strategy-cold"], attention: att(50) }),
+      tactic({ id: "tactic-target", serves: ["strategy-cold"] }),
+    ];
+    const plan = planBoost(nodes, "tactic-target", { kind: "top-candidate" }, { maxBoost: 5 });
+    expect(plan.recommended_boost).toBeNull();
+    expect(plan.unreachable_reason).toContain("maxBoost");
+    expect(plan.unreachable_reason).toContain("5");
+  });
+});
+
+describe("planBoost — unreachable and non-candidate targets", () => {
+  it("names the peer that rides the target's own claim and stays ahead forever", () => {
+    const nodes = [
+      ...KIND_NODES,
+      strategy({ id: "strategy-cold" }),
+      tactic({ id: "tactic-target", serves: ["strategy-cold"] }),
+      // A subtree child receives the target's claim through `parent`, so it
+      // rises with every boost and keeps its +5 authored margin.
+      tactic({ id: "tactic-rider", parent: "tactic-target", attention: att(5) }),
+    ];
+    const plan = planBoost(nodes, "tactic-target", { kind: "top-candidate" }, { maxBoost: 50 });
+    expect(plan.recommended_boost).toBeNull();
+    expect(plan.resulting_rank).toBeNull();
+    expect(plan.unreachable_reason).toContain("tactic-rider");
+    expect(plan.unreachable_reason).toContain("+5");
+  });
+
+  it("refuses top-candidate mode for a parked (non-candidate) target but still plans a rank", () => {
+    const nodes = trapFixture().map((n) =>
+      n.id === "tactic-target"
+        ? {
+            ...n,
+            office_hours: {
+              reason: "parked",
+              since: "2026-07-01",
+              recommendation: null,
+              session_type: "other" as const,
+            },
+          }
+        : n,
+    );
+
+    const top = planBoost(nodes, "tactic-target", { kind: "top-candidate" });
+    expect(top.target_is_candidate).toBe(false);
+    expect(top.recommended_boost).toBeNull();
+    expect(top.unreachable_reason).toContain("candidate list");
+    expect(top.ranking.map((r) => r.id)).toEqual(["tactic-incumbent"]);
+
+    const byRank = planBoost(nodes, "tactic-target", { kind: "rank", value: 25 });
+    expect(byRank.target_is_candidate).toBe(false);
+    expect(byRank.recommended_boost).toBe(7);
+    expect(byRank.resulting_rank).toBe(25);
+  });
+});
+
+describe("planBoost — input errors", () => {
+  it("throws on an unknown id", () => {
+    expect(() => planBoost(trapFixture(), "tactic-nope", { kind: "top-candidate" })).toThrow(
+      IntentionSchemaError,
+    );
+  });
+
+  it("throws on a non-goal-layer target (validateGraph rule 5)", () => {
+    const nodes = [
+      ...trapFixture(),
+      anode({ id: "delegation-x", kind: "delegation" }),
+    ];
+    expect(() => planBoost(nodes, "delegation-x", { kind: "top-candidate" })).toThrow(
+      /not a goal-layer kind/,
+    );
+  });
+});


### PR DESCRIPTION
## Context

Today, escalating work in the intention graph means hand-editing `attention.boost`
in a node's YAML frontmatter and eyeballing the result against the selector. The
recurring failure mode: `boost:` holds a node's OWN authored claim, but ranking
order is the COMPOSED rank `resolveAttention` produces by summing every distinct
source claim flowing into the node — a boost sized against the raw `boost:`
column of the current leader lands at #2, not #1. There is also a hard schema
ceiling (rule 18: no node's `attention.boost` may match or exceed
`strategy-main-health`'s live boost without the literal `ACK:
main-health-dominance` in its rationale), which a hand-edit discovers only when
`graph-commit` refuses the land.

This implements the ungated "boost to top rank" slice of `strategy-graph-drives-dispatch`'s
2026-07-21 clarification: a considered, author-invoked operation (never a
mechanical max+epsilon race) that shows the live ranking, computes the minimal
boost that tops it, and requires an author-supplied rationale.

Deferred, not in this PR: the tier-aware default and the distinct tier-change
script named in the tactic statement — no tier concept exists in code yet, and
`tactic-attention-tier-ranking` (PR #2997, unmerged and parked) has not shipped
the per-tier boost namespace. Both script headers state this explicitly.

## Unit 1 — pure boost planner

`packages/intentionsutil/src/boost.ts` (new): `planBoost(nodes, targetId, mode, opts?)`
computes, purely from the resolved graph, the minimal own-`attention.boost`
that tops the selector's candidate list (or reaches a named composed rank),
respecting the `strategy-main-health` exemption and the rule-18 ceiling. Uses
an integer binary search over the monotone `topsAt(b)` feasibility predicate,
self-checked at the boundary so a non-monotone graph throws rather than
silently returning a wrong minimum. Reports an honest `unreachable_reason`
(naming the claim-riding peers, or the search bound) when no boost tops the
ranking. `packages/intentionsutil/src/schema.ts` gains two small pure
extractions backing it: `kindIsNotGoalLayer` exported, and
`dominantMainHealthBoost`/`MAIN_HEALTH_DOMINANCE_ACK` factored out of
`validateGraph`'s inline rule-18 threshold read (no behavior change).

## Unit 2 — CLI

`packages/intentionsutil/scripts/boost-node.ts` (new): a thin CLI wrapping
`planBoost` with a preview mode (human-readable ranking table or `--json`) and
a `--write` mode. `--write` mandates a non-empty `--rationale` — this script
never synthesizes one — resolves the boost from `--boost` or the planner's
recommendation, and refuses (exit 4) a boost that would need the rule-18 ACK
unless `--ack` is passed, in which case it appends
`MAIN_HEALTH_DOMINANCE_ACK` to the rationale. Writes through the validated
`readNode`/`validateNode`/`validateGraph`/`writeNode` path.

## Unit 3 — landing wrapper, harness, CI

`packages/intentionsutil/scripts/boost-node` (new, executable): the
author-invoked entry point. Fetches origin/main, refreshes the local node file,
CAS-pins via an optional `--base`, writes via Unit 2's CLI, lands through
`graph-commit --base/--expect`, and post-land re-verifies the new ranking
against a fresh origin/main snapshot. A failed write or a stale `--base`
rolls back to the pristine origin/main content via an EXIT trap; a failed
post-land assertion (exit 6) reports the landed state without attempting any
rollback, since the write already landed. `packages/intentionsutil/scripts/test-boost-node.sh`
(new) is a 7-case functional harness (preview no-op, successful landing,
missing-rationale refusal, `--base` staleness, byte-identical rollback on a
`graph-commit` failure, and the rule-18 ACK gate), wired into
`.github/workflows/unit-tests.yml` immediately after the `park-node` CAS-guard
step.

## Verification

- `npx vitest run --project packages/intentionsutil --root .` — 741/741 tests
  pass (40 files), including 13 new `boost.test.ts` cases and the
  `boost-node.test.ts` CLI cases.
- `npx tsc -p packages/intentionsutil/tsconfig.json --noEmit` — clean.
- `run-lint.sh --app packages/intentionsutil --prose` — clean.
- `packages/intentionsutil/scripts/test-boost-node.sh` — 7/7 pass.
- `npx tsx packages/intentionsutil/scripts/validate-graph.ts intentions` — ok,
  468 nodes.

Manual verification (preview against the live graph, honest refusals, one real
landing observed end to end) is called out in the plan as a judgment check for
office hours / QA — not run autonomously in this session.

Graph node: `tactic-attention-boost-scripts`
