### PR TITLE
dispatch watchdog installers: honor a manual disable across reseed cycles

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-test-fixture.sh
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-test-fixture.sh
@@ -158,6 +158,11 @@ chmod +x "$DISPATCH_GUARD_BIN_DIR/systemctl"
 # Prepend BEFORE SAVED_PATH is captured, so teardown's PATH restore keeps it.
 export PATH="$DISPATCH_GUARD_BIN_DIR:$PATH"
 
+# Every suite reads the unit-disable sentinel through lib-unit-disable-state.sh.
+# Pin it at a path that is never created, so no suite can be perturbed by a
+# timer the developer running the suite has genuinely disabled on this host.
+export DISPATCH_UNIT_DISABLE_DIR="$DISPATCH_GUARD_BIN_DIR/no-disabled-units"
+
 _DISPATCH_HOST_UNIT_FINGERPRINT_BEFORE="$(_dispatch_host_unit_fingerprint)"
 _DISPATCH_HOST_GUARD_DONE=0
 

--- a/.claude/skills/dispatch-propagate/scripts/lib-unit-disable-state.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-unit-disable-state.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# lib-unit-disable-state.sh — the single read point for a PER-UNIT manual-disable
+# sentinel: a per-timer marker file an operator creates to say "leave this
+# systemd unit alone", read by anything that installs/re-arms dispatch's
+# systemd timer units (ensure_healer_units, ensure_watcher_units, and any
+# future ensure_*_units installer in lib.sh) before it unconditionally
+# re-enables a timer a human deliberately turned off.
+#
+# This is the per-UNIT sibling of lib-pause-state.sh's global pause sentinel:
+# that file gates whether dispatch SCHEDULES WORK at all; this file gates
+# whether a specific systemd timer unit should be left disabled across a
+# reseed. They are deliberately separate files/sentinels — a global pause and
+# a per-unit disable are independent axes (an operator can disable one timer
+# while dispatch keeps scheduling everything else).
+#
+# The tri-state (disabled / not-disabled / unknown) mirrors
+# lib-pause-state.sh's rationale exactly: for an INSTRUMENT (as opposed to a
+# GATE), an unreadable sentinel state must surface as its own distinct value,
+# UNKNOWN, rather than collapsing into either "definitely disabled" or
+# "definitely not disabled" — either collapse would misreport what is not
+# actually known. See lib-pause-state.sh's header for the fuller argument;
+# it applies here unchanged.
+#
+# Usage: source this file, then call:
+#   dispatch_unit_disable_sentinel_path <timer-unit-name>
+#   dispatch_unit_disable_state <timer-unit-name>
+#
+# dispatch_unit_disable_sentinel_path <unit>
+#   Prints the absolute sentinel path for <unit> to stdout and ALWAYS returns
+#   0. Does not check whether the path exists — this is a pure path
+#   computation, used by callers (and by ensure_*_units installers) that need
+#   the path itself rather than the tri-state read.
+#
+# dispatch_unit_disable_state <unit>
+#   Prints exactly one of three tokens to stdout and ALWAYS returns 0 — the
+#   token, not the exit code, is the contract. A caller that reads only `$?`
+#   cannot distinguish `unknown` from `not-disabled` from `disabled`; it must
+#   read stdout.
+#     disabled      — the sentinel directory exists, is searchable, and the
+#                      per-unit marker file exists inside it.
+#     not-disabled  — a definite negative: either the sentinel directory does
+#                      not exist at all (no unit has ever been manually
+#                      disabled here, so the marker is definitely absent), or
+#                      the directory exists, is searchable, and the marker is
+#                      absent from it.
+#     unknown       — the sentinel directory exists but cannot be searched
+#                      (e.g. mode 000), so the marker's presence cannot be
+#                      determined either way; OR the <unit> argument fails
+#                      validation (empty, contains `/`, or is `.`/`..`) — an
+#                      unvalidated argument must never be used to build a
+#                      path, so a bad argument reads as "cannot be
+#                      determined" rather than silently reading some other
+#                      file.
+#
+#   The searchability test is applied to the sentinel's PARENT DIRECTORY, not
+#   the marker file itself: a directory without execute (search) permission
+#   cannot be traversed to find the file inside it — regardless of the file's
+#   own permissions — and a bare `[[ -e "$dir/$unit" ]]` on such a directory
+#   fails with a permission error indistinguishable from "just not there"
+#   unless the directory's own searchability is checked first.
+#
+# Environment:
+#   DISPATCH_UNIT_DISABLE_DIR   The sentinel directory. A test override or an
+#                                operator override applies uniformly. Default:
+#                                ${XDG_DATA_HOME:-$HOME/.local/share}/commons-dispatch/disabled
+#
+# Operator procedure — disable a timer so reseed stops re-arming it (create
+# the sentinel FIRST — a reseed landing between the disable and the sentinel
+# re-arms the timer):
+#   mkdir -p ~/.local/share/commons-dispatch/disabled
+#   touch    ~/.local/share/commons-dispatch/disabled/dispatch-fleet-watch.timer
+#   systemctl --user disable --now dispatch-fleet-watch.timer
+#
+# Re-enable:
+#   rm ~/.local/share/commons-dispatch/disabled/dispatch-fleet-watch.timer
+#   systemctl --user enable --now dispatch-fleet-watch.timer   # or wait for the next reseed
+#
+# Safe to source multiple times. Does NOT use set -e (must return, not exit).
+#
+# CRITICAL DIVERGENCE from lib-pause-state.sh: that file sets `set -uo
+# pipefail` in its load guard. This file deliberately does NOT set any shell
+# options on the sourcing shell, because lib.sh sources this file and lib.sh
+# is itself sourced by dozens of scripts that are not written under `set -u`
+# — imposing it here would change behavior far outside this file's own
+# functions. Instead, every function below is written to be `set -u`-safe on
+# its own: every parameter expansion uses `${VAR:-default}` or a
+# `${1:-}`-guarded positional parameter, so the functions behave correctly
+# whether or not the calling shell already has `set -u` active.
+
+if [[ -z "${_LIB_UNIT_DISABLE_STATE_LOADED:-}" ]]; then
+  _LIB_UNIT_DISABLE_STATE_LOADED=1
+
+  # dispatch_unit_disable_sentinel_path — print the absolute sentinel path for
+  # <unit>. ALWAYS returns 0. Pure path computation; does not validate <unit>
+  # or check existence.
+  dispatch_unit_disable_sentinel_path() {
+    local unit="${1:-}"
+    local dir="${DISPATCH_UNIT_DISABLE_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/commons-dispatch/disabled}"
+    printf '%s/%s\n' "$dir" "$unit"
+    return 0
+  }
+
+  # dispatch_unit_disable_state — print disabled|not-disabled|unknown for
+  # <unit>. See the header comment for the full contract. ALWAYS returns 0.
+  dispatch_unit_disable_state() {
+    local unit="${1:-}"
+
+    # Defensive boundary check: never build a path from an unvalidated
+    # component. An empty argument, a path-separator-bearing argument, or a
+    # `.`/`..` argument could escape the sentinel directory or collide with
+    # it; refuse to guess and report unknown instead.
+    if [[ -z "$unit" || "$unit" == *"/"* || "$unit" == "." || "$unit" == ".." ]]; then
+      echo "WARNING: dispatch_unit_disable_state: invalid unit argument: '${unit}'" >&2
+      printf 'unknown\n'
+      return 0
+    fi
+
+    local dir="${DISPATCH_UNIT_DISABLE_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/commons-dispatch/disabled}"
+    local marker="$dir/$unit"
+
+    # No sentinel directory at all → no unit has ever been manually disabled
+    # here, so the marker is definitely absent.
+    if [[ ! -d "$dir" ]]; then
+      printf 'not-disabled\n'
+      return 0
+    fi
+
+    # The directory exists but cannot be searched (traversed) → the marker's
+    # presence cannot be determined either way, whatever its own permissions
+    # might otherwise allow.
+    if [[ ! -x "$dir" ]]; then
+      printf 'unknown\n'
+      return 0
+    fi
+
+    # Directory exists and is searchable: a direct existence test is now
+    # authoritative.
+    if [[ -e "$marker" ]]; then
+      printf 'disabled\n'
+    else
+      printf 'not-disabled\n'
+    fi
+    return 0
+  }
+
+fi

--- a/.claude/skills/dispatch-propagate/scripts/lib.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib.sh
@@ -2760,6 +2760,45 @@ cleanup_stale_unit_pair() {
   "$systemctl_cmd" --user disable --now "$timer_unit" "$service_unit" || true
 }
 
+# Report whether a dispatch-managed timer has been marked manually-disabled by
+# the operator, so an installer can skip its `enable --now` instead of silently
+# undoing a deliberate `systemctl --user disable --now` on the next reseed.
+#
+# One implementation, called from thin per-installer sites — the same shape as
+# cleanup_stale_unit_pair above — so the check cannot be fixed for one timer and
+# missed for its structurally identical twin.
+#
+# Args: $1 = timer unit name, $2 = caller name for message prefixes
+# Returns 0 when the unit is marked manually-disabled (caller must skip enable),
+#         1 otherwise.
+# An indeterminate state (unreadable sentinel dir, or an unsourceable reader)
+# returns 1 — proceed with enable — after a WARNING naming the cause. Failing
+# the other way would tear the fleet's own watchdog down on an unreadable file,
+# and the watchdog is what would otherwise report its own absence.
+unit_manually_disabled() {
+  local unit="$1"
+  local caller="$2"
+
+  if ! declare -f dispatch_unit_disable_state >/dev/null 2>&1; then
+    # shellcheck source=lib-unit-disable-state.sh
+    if ! source "$(dirname "${BASH_SOURCE[0]}")/lib-unit-disable-state.sh" 2>/dev/null; then
+      echo "WARNING: $caller: cannot source lib-unit-disable-state.sh; a manual disable of $unit cannot be honored; proceeding to enable" >&2
+      return 1
+    fi
+  fi
+
+  local state
+  state=$(dispatch_unit_disable_state "$unit")
+  case "$state" in
+    disabled)     return 0 ;;
+    not-disabled) return 1 ;;
+    *)
+      echo "WARNING: $caller: unit-disable sentinel state for $unit is unknown ($(dispatch_unit_disable_sentinel_path "$unit") is unreadable); proceeding to enable — a manual disable may not be honored" >&2
+      return 1
+      ;;
+  esac
+}
+
 # Disable a stale sweep timer/service whose installed unit points at a
 # different main-worktree path than the current one, mirroring
 # cleanup_stale_heartbeat_units below. Thin wrapper over
@@ -3008,6 +3047,12 @@ cleanup_stale_healer_units() {
 # launcher), so we warn to stderr and return non-zero — never `exit`. A missing
 # timer just means the unit-poisoning healer falls back to on-demand-only
 # invocation.
+#
+# Honors the per-unit manual-disable sentinel: when it is set for
+# dispatch-heal.timer the unit files are still kept current on disk but
+# `enable --now` is skipped, so a deliberate `systemctl --user disable --now`
+# survives every reseed — see lib-unit-disable-state.sh for the sentinel path
+# and the operator procedure.
 # Args: $1 = main worktree path
 ensure_healer_units() {
   local main_worktree="$1"
@@ -3114,11 +3159,22 @@ WantedBy=timers.target
 EOF
 )
 
+  # Read the manual-disable marker ONCE per call: it is consulted twice below
+  # (steady-state short-circuit, and the enable decision) and must not disagree
+  # with itself between them.
+  local manually_disabled=0
+  if unit_manually_disabled dispatch-heal.timer ensure_healer_units; then
+    manually_disabled=1
+  fi
+
   # Steady-state hot path: if BOTH installed units already match byte-for-byte
-  # AND the timer is active (armed), skip the write/reload/enable entirely.
+  # AND the timer is active (armed) — or the operator has manually disabled it,
+  # in which case an inactive timer IS the requested steady state — skip the
+  # write/reload/enable entirely. The manually-disabled test comes first so a
+  # disabled timer costs zero `systemctl` invocations in steady state.
   if [ -f "$SERVICE_PATH" ] && [ "$(cat "$SERVICE_PATH")" = "$desired_service" ] \
      && [ -f "$TIMER_PATH" ] && [ "$(cat "$TIMER_PATH")" = "$desired_timer" ] \
-     && "$SYSTEMCTL_CMD" --user is-active --quiet dispatch-heal.timer; then
+     && { [ "$manually_disabled" -eq 1 ] || "$SYSTEMCTL_CMD" --user is-active --quiet dispatch-heal.timer; }; then
     return 0
   fi
 
@@ -3187,6 +3243,15 @@ EOF
     return 1
   fi
 
+  # Honor a deliberate operator disable: the unit files above are kept current,
+  # but arming the timer is skipped. NOT a WARNING and NOT an error — this is
+  # the requested state, and the caller's `|| true` must not be the only thing
+  # separating "we did what you asked" from "something went wrong".
+  if [ "$manually_disabled" -eq 1 ]; then
+    echo "ensure_healer_units: dispatch-heal.timer is marked manually disabled ($(dispatch_unit_disable_sentinel_path dispatch-heal.timer)); unit files updated, skipping enable --now" >&2
+    return 0
+  fi
+
   # Install + activate the TIMER (not the oneshot service): enable symlinks it
   # under WantedBy=timers.target (so it re-arms on every user-session start) and
   # --now arms it immediately. A .timer does nothing until this enable --now;
@@ -3231,6 +3296,12 @@ cleanup_stale_watcher_units() {
 # Best-effort: a failure here must not abort the caller (a tick/reseed
 # launcher), so we warn to stderr and return non-zero — never `exit`. A missing
 # timer just means the fleet watchdog falls back to on-demand-only invocation.
+#
+# Honors the per-unit manual-disable sentinel: when it is set for
+# dispatch-fleet-watch.timer the unit files are still kept current on disk but
+# `enable --now` is skipped, so a deliberate `systemctl --user disable --now`
+# survives every reseed — see lib-unit-disable-state.sh for the sentinel path
+# and the operator procedure.
 # Args: $1 = main worktree path
 ensure_watcher_units() {
   local main_worktree="$1"
@@ -3339,11 +3410,22 @@ WantedBy=timers.target
 EOF
 )
 
+  # Read the manual-disable marker ONCE per call: it is consulted twice below
+  # (steady-state short-circuit, and the enable decision) and must not disagree
+  # with itself between them.
+  local manually_disabled=0
+  if unit_manually_disabled dispatch-fleet-watch.timer ensure_watcher_units; then
+    manually_disabled=1
+  fi
+
   # Steady-state hot path: if BOTH installed units already match byte-for-byte
-  # AND the timer is active (armed), skip the write/reload/enable entirely.
+  # AND the timer is active (armed) — or the operator has manually disabled it,
+  # in which case an inactive timer IS the requested steady state — skip the
+  # write/reload/enable entirely. The manually-disabled test comes first so a
+  # disabled timer costs zero `systemctl` invocations in steady state.
   if [ -f "$SERVICE_PATH" ] && [ "$(cat "$SERVICE_PATH")" = "$desired_service" ] \
      && [ -f "$TIMER_PATH" ] && [ "$(cat "$TIMER_PATH")" = "$desired_timer" ] \
-     && "$SYSTEMCTL_CMD" --user is-active --quiet dispatch-fleet-watch.timer; then
+     && { [ "$manually_disabled" -eq 1 ] || "$SYSTEMCTL_CMD" --user is-active --quiet dispatch-fleet-watch.timer; }; then
     return 0
   fi
 
@@ -3410,6 +3492,15 @@ EOF
   if ! "$SYSTEMCTL_CMD" --user daemon-reload; then
     echo "WARNING: ensure_watcher_units: systemctl --user daemon-reload failed; fleet watchdog unavailable" >&2
     return 1
+  fi
+
+  # Honor a deliberate operator disable: the unit files above are kept current,
+  # but arming the timer is skipped. NOT a WARNING and NOT an error — this is
+  # the requested state, and the caller's `|| true` must not be the only thing
+  # separating "we did what you asked" from "something went wrong".
+  if [ "$manually_disabled" -eq 1 ]; then
+    echo "ensure_watcher_units: dispatch-fleet-watch.timer is marked manually disabled ($(dispatch_unit_disable_sentinel_path dispatch-fleet-watch.timer)); unit files updated, skipping enable --now" >&2
+    return 0
   fi
 
   # Install + activate the TIMER (not the oneshot service): enable symlinks it

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-systemd-units.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-systemd-units.sh
@@ -792,6 +792,168 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: cleanup_stale_healer_units ran disable with no WorkingDirectory="
 fi
 
+# --- 5. Manual-disable sentinel: enable --now is skipped, per-unit, honored --
+# (tactic-ensure-units-respect-manual-disable) Reuses the cold-path scaffolding
+# above (ehl_tmp/ehl_unit_dir/ehl_svc/ehl_tmr/ehl_log, the recording systemctl
+# stub). DISPATCH_UNIT_DISABLE_DIR is overridden per sub-case to a scratch dir
+# under ehl_tmp — the fixture already pins the ambient DISPATCH_UNIT_DISABLE_DIR
+# to a never-created path, so these overrides do not leak.
+ehl_disable_dir="$ehl_tmp/disabled"
+
+# --- 5a. cold path, marker present: unit files written, enable --now skipped -
+rm -f "$ehl_svc" "$ehl_tmr"
+mkdir -p "$ehl_disable_dir"
+: > "$ehl_disable_dir/dispatch-heal.timer"
+: > "$ehl_log"
+ehl_5a_err="$ehl_tmp/5a-stderr"
+ehl_5a_rc=0
+(
+  export DISPATCH_HEALER_UNIT_DIR="$ehl_unit_dir"
+  export DISPATCH_HEALER_SYSTEMCTL_CMD="$ehl_tmp/bin/systemctl"
+  export STUB_LOG="$ehl_log"
+  export STUB_IS_ACTIVE_RC=1
+  export DISPATCH_UNIT_DISABLE_DIR="$ehl_disable_dir"
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_healer_units "$ehl_tmp/main-worktree"
+) >/dev/null 2>"$ehl_5a_err" || ehl_5a_rc=$?
+assert_eq "5a: ensure_healer_units returns 0 (cold path, marker present)" "0" "$ehl_5a_rc"
+TOTAL=$((TOTAL + 1))
+if [ -f "$ehl_svc" ] && [ -f "$ehl_tmr" ]; then
+  PASS=$((PASS + 1)); echo "  PASS: 5a wrote both unit files"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 5a did not write both unit files"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q 'daemon-reload' "$ehl_log"; then
+  PASS=$((PASS + 1)); echo "  PASS: 5a ran daemon-reload"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 5a did not run daemon-reload"
+fi
+TOTAL=$((TOTAL + 1))
+if ! grep -q 'enable --now dispatch-heal.timer' "$ehl_log"; then
+  PASS=$((PASS + 1)); echo "  PASS: 5a did not run enable --now dispatch-heal.timer"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 5a ran enable --now dispatch-heal.timer despite the marker"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q 'skipping enable --now' "$ehl_5a_err"; then
+  PASS=$((PASS + 1)); echo "  PASS: 5a stderr mentions skipping enable --now"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 5a stderr missing 'skipping enable --now'"
+fi
+TOTAL=$((TOTAL + 1))
+if ! grep -q 'WARNING' "$ehl_5a_err"; then
+  PASS=$((PASS + 1)); echo "  PASS: 5a stderr has no WARNING"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 5a stderr unexpectedly contains WARNING"
+fi
+
+# --- 5b. steady state, marker present, unit files already current ------------
+# Reuses the SAME unit files 5a just wrote (no removal) — proves the hot-path
+# extension short-circuits before touching systemctl at all.
+: > "$ehl_log"
+ehl_5b_rc=0
+(
+  export DISPATCH_HEALER_UNIT_DIR="$ehl_unit_dir"
+  export DISPATCH_HEALER_SYSTEMCTL_CMD="$ehl_tmp/bin/systemctl"
+  export STUB_LOG="$ehl_log"
+  export STUB_IS_ACTIVE_RC=1
+  export DISPATCH_UNIT_DISABLE_DIR="$ehl_disable_dir"
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_healer_units "$ehl_tmp/main-worktree"
+) >/dev/null 2>&1 || ehl_5b_rc=$?
+assert_eq "5b: ensure_healer_units returns 0 (steady state, marker present)" "0" "$ehl_5b_rc"
+assert_eq "5b: stub log empty (no daemon-reload/enable/is-active call)" "" "$(cat "$ehl_log")"
+
+# --- 5c. marker absent → unchanged cold-path behavior (regression guard) -----
+rm -f "$ehl_svc" "$ehl_tmr"
+rm -rf "$ehl_disable_dir"
+mkdir -p "$ehl_disable_dir"
+: > "$ehl_log"
+ehl_5c_rc=0
+(
+  export DISPATCH_HEALER_UNIT_DIR="$ehl_unit_dir"
+  export DISPATCH_HEALER_SYSTEMCTL_CMD="$ehl_tmp/bin/systemctl"
+  export STUB_LOG="$ehl_log"
+  export STUB_IS_ACTIVE_RC=1
+  export DISPATCH_UNIT_DISABLE_DIR="$ehl_disable_dir"
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_healer_units "$ehl_tmp/main-worktree"
+) >/dev/null 2>&1 || ehl_5c_rc=$?
+assert_eq "5c: ensure_healer_units returns 0 (no marker)" "0" "$ehl_5c_rc"
+TOTAL=$((TOTAL + 1))
+if grep -q 'enable --now dispatch-heal.timer' "$ehl_log"; then
+  PASS=$((PASS + 1)); echo "  PASS: 5c ran enable --now dispatch-heal.timer (no marker → unchanged behavior)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 5c did not run enable --now dispatch-heal.timer"
+fi
+
+# --- 5d. marker present for a DIFFERENT unit → per-unit granularity ----------
+rm -f "$ehl_svc" "$ehl_tmr"
+rm -rf "$ehl_disable_dir"
+mkdir -p "$ehl_disable_dir"
+: > "$ehl_disable_dir/dispatch-fleet-watch.timer"
+: > "$ehl_log"
+ehl_5d_rc=0
+(
+  export DISPATCH_HEALER_UNIT_DIR="$ehl_unit_dir"
+  export DISPATCH_HEALER_SYSTEMCTL_CMD="$ehl_tmp/bin/systemctl"
+  export STUB_LOG="$ehl_log"
+  export STUB_IS_ACTIVE_RC=1
+  export DISPATCH_UNIT_DISABLE_DIR="$ehl_disable_dir"
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_healer_units "$ehl_tmp/main-worktree"
+) >/dev/null 2>&1 || ehl_5d_rc=$?
+assert_eq "5d: ensure_healer_units returns 0 (other-unit marker)" "0" "$ehl_5d_rc"
+TOTAL=$((TOTAL + 1))
+if grep -q 'enable --now dispatch-heal.timer' "$ehl_log"; then
+  PASS=$((PASS + 1)); echo "  PASS: 5d ran enable --now dispatch-heal.timer (marker names a different unit)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 5d did not run enable --now dispatch-heal.timer despite an other-unit marker"
+fi
+
+# --- 5e. unit-disable sentinel dir unreadable → unknown, proceed + WARNING ---
+# chmod 000 does not deny root, so root would spuriously see this as
+# searchable. Skip-but-count as PASS in that case, matching the root-invariant
+# permission-test idiom in test-lib-pause-state.sh.
+if [[ "$(id -u)" == "0" ]]; then
+  echo "  (running as root — mode bits do not deny search; skipping 5e, counted as pass)"
+  TOTAL=$((TOTAL + 2))
+  PASS=$((PASS + 2))
+else
+  rm -f "$ehl_svc" "$ehl_tmr"
+  ehl_disable_dir_5e="$ehl_tmp/disabled-5e"
+  mkdir -p "$ehl_disable_dir_5e"
+  chmod 000 "$ehl_disable_dir_5e"
+  : > "$ehl_log"
+  ehl_5e_err="$ehl_tmp/5e-stderr"
+  ehl_5e_rc=0
+  (
+    export DISPATCH_HEALER_UNIT_DIR="$ehl_unit_dir"
+    export DISPATCH_HEALER_SYSTEMCTL_CMD="$ehl_tmp/bin/systemctl"
+    export STUB_LOG="$ehl_log"
+    export STUB_IS_ACTIVE_RC=1
+    export DISPATCH_UNIT_DISABLE_DIR="$ehl_disable_dir_5e"
+    source "$SCRIPT_DIR/lib.sh"
+    ensure_healer_units "$ehl_tmp/main-worktree"
+  ) >/dev/null 2>"$ehl_5e_err" || ehl_5e_rc=$?
+  chmod -R u+rwx "$ehl_disable_dir_5e"
+  TOTAL=$((TOTAL + 1))
+  if grep -q 'enable --now dispatch-heal.timer' "$ehl_log"; then
+    PASS=$((PASS + 1)); echo "  PASS: 5e ran enable --now dispatch-heal.timer (unreadable sentinel dir → unknown, proceed)"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: 5e did not run enable --now dispatch-heal.timer"
+  fi
+  TOTAL=$((TOTAL + 1))
+  if grep -q 'WARNING' "$ehl_5e_err"; then
+    PASS=$((PASS + 1)); echo "  PASS: 5e stderr contains WARNING"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: 5e stderr missing WARNING"
+  fi
+  rm -rf "$ehl_disable_dir_5e"
+fi
+
+rm -rf "$ehl_disable_dir"
 rm -rf "$ehl_tmp"
 
 # ============================================================================
@@ -1015,6 +1177,167 @@ else
   FAIL=$((FAIL + 1)); echo "  FAIL: cleanup_stale_watcher_units ran disable with no WorkingDirectory="
 fi
 
+# --- 5. Manual-disable sentinel: enable --now is skipped, per-unit, honored --
+# (tactic-ensure-units-respect-manual-disable) Mirrors ensure_healer_units'
+# case 5 above — both timers must respect a manual disable, not just one.
+# Reuses the cold-path scaffolding above (ewa_tmp/ewa_unit_dir/ewa_svc/ewa_tmr/
+# ewa_log, the recording systemctl stub).
+ewa_disable_dir="$ewa_tmp/disabled"
+
+# --- 5a. cold path, marker present: unit files written, enable --now skipped -
+rm -f "$ewa_svc" "$ewa_tmr"
+mkdir -p "$ewa_disable_dir"
+: > "$ewa_disable_dir/dispatch-fleet-watch.timer"
+: > "$ewa_log"
+ewa_5a_err="$ewa_tmp/5a-stderr"
+ewa_5a_rc=0
+(
+  export DISPATCH_WATCHER_UNIT_DIR="$ewa_unit_dir"
+  export DISPATCH_WATCHER_SYSTEMCTL_CMD="$ewa_tmp/bin/systemctl"
+  export STUB_LOG="$ewa_log"
+  export STUB_IS_ACTIVE_RC=1
+  export DISPATCH_UNIT_DISABLE_DIR="$ewa_disable_dir"
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_watcher_units "$ewa_tmp/main-worktree"
+) >/dev/null 2>"$ewa_5a_err" || ewa_5a_rc=$?
+assert_eq "5a: ensure_watcher_units returns 0 (cold path, marker present)" "0" "$ewa_5a_rc"
+TOTAL=$((TOTAL + 1))
+if [ -f "$ewa_svc" ] && [ -f "$ewa_tmr" ]; then
+  PASS=$((PASS + 1)); echo "  PASS: 5a wrote both unit files"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 5a did not write both unit files"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q 'daemon-reload' "$ewa_log"; then
+  PASS=$((PASS + 1)); echo "  PASS: 5a ran daemon-reload"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 5a did not run daemon-reload"
+fi
+TOTAL=$((TOTAL + 1))
+if ! grep -q 'enable --now dispatch-fleet-watch.timer' "$ewa_log"; then
+  PASS=$((PASS + 1)); echo "  PASS: 5a did not run enable --now dispatch-fleet-watch.timer"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 5a ran enable --now dispatch-fleet-watch.timer despite the marker"
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q 'skipping enable --now' "$ewa_5a_err"; then
+  PASS=$((PASS + 1)); echo "  PASS: 5a stderr mentions skipping enable --now"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 5a stderr missing 'skipping enable --now'"
+fi
+TOTAL=$((TOTAL + 1))
+if ! grep -q 'WARNING' "$ewa_5a_err"; then
+  PASS=$((PASS + 1)); echo "  PASS: 5a stderr has no WARNING"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 5a stderr unexpectedly contains WARNING"
+fi
+
+# --- 5b. steady state, marker present, unit files already current ------------
+# Reuses the SAME unit files 5a just wrote (no removal) — proves the hot-path
+# extension short-circuits before touching systemctl at all.
+: > "$ewa_log"
+ewa_5b_rc=0
+(
+  export DISPATCH_WATCHER_UNIT_DIR="$ewa_unit_dir"
+  export DISPATCH_WATCHER_SYSTEMCTL_CMD="$ewa_tmp/bin/systemctl"
+  export STUB_LOG="$ewa_log"
+  export STUB_IS_ACTIVE_RC=1
+  export DISPATCH_UNIT_DISABLE_DIR="$ewa_disable_dir"
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_watcher_units "$ewa_tmp/main-worktree"
+) >/dev/null 2>&1 || ewa_5b_rc=$?
+assert_eq "5b: ensure_watcher_units returns 0 (steady state, marker present)" "0" "$ewa_5b_rc"
+assert_eq "5b: stub log empty (no daemon-reload/enable/is-active call)" "" "$(cat "$ewa_log")"
+
+# --- 5c. marker absent → unchanged cold-path behavior (regression guard) -----
+rm -f "$ewa_svc" "$ewa_tmr"
+rm -rf "$ewa_disable_dir"
+mkdir -p "$ewa_disable_dir"
+: > "$ewa_log"
+ewa_5c_rc=0
+(
+  export DISPATCH_WATCHER_UNIT_DIR="$ewa_unit_dir"
+  export DISPATCH_WATCHER_SYSTEMCTL_CMD="$ewa_tmp/bin/systemctl"
+  export STUB_LOG="$ewa_log"
+  export STUB_IS_ACTIVE_RC=1
+  export DISPATCH_UNIT_DISABLE_DIR="$ewa_disable_dir"
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_watcher_units "$ewa_tmp/main-worktree"
+) >/dev/null 2>&1 || ewa_5c_rc=$?
+assert_eq "5c: ensure_watcher_units returns 0 (no marker)" "0" "$ewa_5c_rc"
+TOTAL=$((TOTAL + 1))
+if grep -q 'enable --now dispatch-fleet-watch.timer' "$ewa_log"; then
+  PASS=$((PASS + 1)); echo "  PASS: 5c ran enable --now dispatch-fleet-watch.timer (no marker → unchanged behavior)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 5c did not run enable --now dispatch-fleet-watch.timer"
+fi
+
+# --- 5d. marker present for a DIFFERENT unit → per-unit granularity ----------
+rm -f "$ewa_svc" "$ewa_tmr"
+rm -rf "$ewa_disable_dir"
+mkdir -p "$ewa_disable_dir"
+: > "$ewa_disable_dir/dispatch-heal.timer"
+: > "$ewa_log"
+ewa_5d_rc=0
+(
+  export DISPATCH_WATCHER_UNIT_DIR="$ewa_unit_dir"
+  export DISPATCH_WATCHER_SYSTEMCTL_CMD="$ewa_tmp/bin/systemctl"
+  export STUB_LOG="$ewa_log"
+  export STUB_IS_ACTIVE_RC=1
+  export DISPATCH_UNIT_DISABLE_DIR="$ewa_disable_dir"
+  source "$SCRIPT_DIR/lib.sh"
+  ensure_watcher_units "$ewa_tmp/main-worktree"
+) >/dev/null 2>&1 || ewa_5d_rc=$?
+assert_eq "5d: ensure_watcher_units returns 0 (other-unit marker)" "0" "$ewa_5d_rc"
+TOTAL=$((TOTAL + 1))
+if grep -q 'enable --now dispatch-fleet-watch.timer' "$ewa_log"; then
+  PASS=$((PASS + 1)); echo "  PASS: 5d ran enable --now dispatch-fleet-watch.timer (marker names a different unit)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: 5d did not run enable --now dispatch-fleet-watch.timer despite an other-unit marker"
+fi
+
+# --- 5e. unit-disable sentinel dir unreadable → unknown, proceed + WARNING ---
+# chmod 000 does not deny root, so root would spuriously see this as
+# searchable. Skip-but-count as PASS in that case, matching the root-invariant
+# permission-test idiom in test-lib-pause-state.sh.
+if [[ "$(id -u)" == "0" ]]; then
+  echo "  (running as root — mode bits do not deny search; skipping 5e, counted as pass)"
+  TOTAL=$((TOTAL + 2))
+  PASS=$((PASS + 2))
+else
+  rm -f "$ewa_svc" "$ewa_tmr"
+  ewa_disable_dir_5e="$ewa_tmp/disabled-5e"
+  mkdir -p "$ewa_disable_dir_5e"
+  chmod 000 "$ewa_disable_dir_5e"
+  : > "$ewa_log"
+  ewa_5e_err="$ewa_tmp/5e-stderr"
+  ewa_5e_rc=0
+  (
+    export DISPATCH_WATCHER_UNIT_DIR="$ewa_unit_dir"
+    export DISPATCH_WATCHER_SYSTEMCTL_CMD="$ewa_tmp/bin/systemctl"
+    export STUB_LOG="$ewa_log"
+    export STUB_IS_ACTIVE_RC=1
+    export DISPATCH_UNIT_DISABLE_DIR="$ewa_disable_dir_5e"
+    source "$SCRIPT_DIR/lib.sh"
+    ensure_watcher_units "$ewa_tmp/main-worktree"
+  ) >/dev/null 2>"$ewa_5e_err" || ewa_5e_rc=$?
+  chmod -R u+rwx "$ewa_disable_dir_5e"
+  TOTAL=$((TOTAL + 1))
+  if grep -q 'enable --now dispatch-fleet-watch.timer' "$ewa_log"; then
+    PASS=$((PASS + 1)); echo "  PASS: 5e ran enable --now dispatch-fleet-watch.timer (unreadable sentinel dir → unknown, proceed)"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: 5e did not run enable --now dispatch-fleet-watch.timer"
+  fi
+  TOTAL=$((TOTAL + 1))
+  if grep -q 'WARNING' "$ewa_5e_err"; then
+    PASS=$((PASS + 1)); echo "  PASS: 5e stderr contains WARNING"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: 5e stderr missing WARNING"
+  fi
+  rm -rf "$ewa_disable_dir_5e"
+fi
+
+rm -rf "$ewa_disable_dir"
 rm -rf "$ewa_tmp"
 
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-unit-disable-state.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-unit-disable-state.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Tests for lib-unit-disable-state.sh — the tri-state
+# (disabled/not-disabled/unknown) instrument read of a per-unit manual-disable
+# sentinel, plus its sentinel-path helper.
+#
+# Every case points DISPATCH_UNIT_DISABLE_DIR at a scratch mktemp -d sandbox
+# so the suite never touches the real
+# ~/.local/share/commons-dispatch/disabled.
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=dispatch-test-fixture.sh
+source "$FIXTURE_DIR/dispatch-test-fixture.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib-unit-disable-state.sh"
+
+echo "=== lib-unit-disable-state.sh ==="
+
+UDS_DIR=""
+
+uds_setup() {
+  UDS_DIR=$(mktemp -d)
+}
+
+uds_teardown() {
+  # Restore search permission before rm -rf: an unsearchable dir would make
+  # the recursive removal itself unpredictable.
+  [[ -n "$UDS_DIR" ]] && chmod -R u+rwx "$UDS_DIR" 2>/dev/null || true
+  rm -rf "$UDS_DIR"
+  UDS_DIR=""
+  unset DISPATCH_UNIT_DISABLE_DIR || true
+}
+
+# --- Test 1: marker present ---------------------------------------------------
+
+echo "Test: marker present reports disabled"
+uds_setup
+mkdir -p "$UDS_DIR/state"
+: > "$UDS_DIR/state/dispatch-fleet-watch.timer"
+DISPATCH_UNIT_DISABLE_DIR="$UDS_DIR/state"
+assert_eq "present: reports disabled" "disabled" \
+  "$(dispatch_unit_disable_state dispatch-fleet-watch.timer)"
+assert_eq "present: always returns 0" "0" \
+  "$(dispatch_unit_disable_state dispatch-fleet-watch.timer >/dev/null; echo $?)"
+uds_teardown
+
+# --- Test 2: dir present, marker absent ---------------------------------------
+
+echo "Test: state dir present but marker absent reports not-disabled"
+uds_setup
+mkdir -p "$UDS_DIR/state"
+DISPATCH_UNIT_DISABLE_DIR="$UDS_DIR/state"
+assert_eq "dir-only: reports not-disabled" "not-disabled" \
+  "$(dispatch_unit_disable_state dispatch-fleet-watch.timer)"
+uds_teardown
+
+# --- Test 3: state dir absent entirely ----------------------------------------
+
+echo "Test: state dir absent entirely reports not-disabled"
+uds_setup
+DISPATCH_UNIT_DISABLE_DIR="$UDS_DIR/no-such-dir"
+assert_eq "no-dir: reports not-disabled" "not-disabled" \
+  "$(dispatch_unit_disable_state dispatch-fleet-watch.timer)"
+uds_teardown
+
+# --- Test 4: state dir present but unsearchable (mode 000) -------------------
+# chmod 000 does not deny root, so root would see this case as searchable
+# (spuriously observing disabled/not-disabled instead of unknown). Skip-but-
+# count as PASS in that case, matching how other suites in this directory
+# handle root-invariant permission tests.
+
+echo "Test: state dir present but unsearchable reports unknown"
+if [[ "$(id -u)" == "0" ]]; then
+  echo "  (running as root — mode bits do not deny search; skipping, counted as pass)"
+  TOTAL=$((TOTAL + 1))
+  PASS=$((PASS + 1))
+else
+  uds_setup
+  mkdir -p "$UDS_DIR/state"
+  : > "$UDS_DIR/state/dispatch-fleet-watch.timer"
+  chmod 000 "$UDS_DIR/state"
+  DISPATCH_UNIT_DISABLE_DIR="$UDS_DIR/state"
+  assert_eq "unsearchable: reports unknown" "unknown" \
+    "$(dispatch_unit_disable_state dispatch-fleet-watch.timer)"
+  uds_teardown
+fi
+
+# --- Test 5: marker for a DIFFERENT unit present ------------------------------
+
+echo "Test: marker for a different unit does not affect the target unit"
+uds_setup
+mkdir -p "$UDS_DIR/state"
+: > "$UDS_DIR/state/dispatch-heal.timer"
+DISPATCH_UNIT_DISABLE_DIR="$UDS_DIR/state"
+assert_eq "per-unit granularity: target unit reports not-disabled" "not-disabled" \
+  "$(dispatch_unit_disable_state dispatch-fleet-watch.timer)"
+uds_teardown
+
+# --- Test 6: invalid argument --------------------------------------------------
+
+echo "Test: invalid unit arguments report unknown"
+uds_setup
+mkdir -p "$UDS_DIR/state"
+DISPATCH_UNIT_DISABLE_DIR="$UDS_DIR/state"
+assert_eq "empty argument: reports unknown" "unknown" \
+  "$(dispatch_unit_disable_state "" 2>/dev/null)"
+assert_eq "slash-bearing argument: reports unknown" "unknown" \
+  "$(dispatch_unit_disable_state "a/b" 2>/dev/null)"
+assert_eq "dotdot argument: reports unknown" "unknown" \
+  "$(dispatch_unit_disable_state ".." 2>/dev/null)"
+uds_teardown
+
+# --- Test 7: sentinel path helper ---------------------------------------------
+
+echo "Test: dispatch_unit_disable_sentinel_path prints the expected path"
+uds_setup
+DISPATCH_UNIT_DISABLE_DIR="$UDS_DIR/state"
+assert_eq "sentinel path: dir/unit" "$UDS_DIR/state/dispatch-heal.timer" \
+  "$(dispatch_unit_disable_sentinel_path dispatch-heal.timer)"
+uds_teardown
+
+report_results


### PR DESCRIPTION
## What

`ensure_healer_units` and `ensure_watcher_units` (in
`.claude/skills/dispatch-propagate/scripts/lib.sh`) each end with an
unconditional `systemctl --user enable --now <timer>`, and both run on every
reseed cycle (~15-30 min). A deliberate `systemctl --user disable --now
dispatch-heal.timer` / `dispatch-fleet-watch.timer` — e.g. to silence a noisy
watchdog or debug the fleet — was silently undone within one cycle, with no
sentinel or opt-out.

This adds a declarative per-unit disable sentinel, honored by both installers:

- **`lib-unit-disable-state.sh`** (new) — a tri-state reader,
  `dispatch_unit_disable_state <unit>` → `disabled` / `not-disabled` /
  `unknown`, modeled byte-for-byte on the existing pause-state sentinel
  (`lib-pause-state.sh`). Deliberately does not set any shell options, since
  `lib.sh` sources it and is itself sourced by scripts not written under
  `set -u`.
- **`unit_manually_disabled <unit> <caller>`** (new, in `lib.sh`, next to
  `cleanup_stale_unit_pair`) — the shared consumer helper both installers call.
- **`ensure_healer_units` / `ensure_watcher_units`** — each now reads the
  sentinel once per call, extends its hot-path steady-state check so a
  disabled timer with current unit files short-circuits before touching
  `systemctl` at all, and skips `enable --now` (informational stderr line, not
  a WARNING, `return 0`) right after `daemon-reload` when the sentinel is set
  — so unit files stay converged on disk while disabled, and a later re-enable
  arms a correct unit. `unknown` (unreadable sentinel dir) proceeds with
  `enable`, loudly (`WARNING:` on stderr) — the watchdog is what would
  otherwise report its own absence, so failing closed here is
  self-concealing.
- The sentinel only ever blocks `enable`; it never runs `disable` or `stop`
  itself. The operator's own `disable --now` does the stopping; the sentinel
  makes it stick.

Out of scope (same latent defect, deliberately not touched here):
`ensure_recover_unit`, `ensure_sweep_timer`, `ensure_heartbeat_units`, and the
three reseed-script call sites (`dispatch-schedule-reseed`,
`dispatch-schedule-convergence-reseed`, `dispatch-heal-units`) — the guard
lives inside the two installer functions precisely so all three call sites
inherit it with no wiring change.

## Testing

- `test-lib-unit-disable-state.sh` (new) — 7 cases: marker present/absent,
  directory absent, unsearchable directory (unknown), per-unit granularity,
  invalid arguments, sentinel-path helper.
- `test-lib-systemd-units.sh` — new case 5 (5a-5e) in both the
  `ensure_healer_units` and `ensure_watcher_units` sections: cold-path skip
  with marker, steady-state short-circuit (stub log fully empty), marker
  absent (regression guard — unchanged cold-install behavior), marker for the
  *other* unit only (per-unit granularity), and unreadable sentinel dir
  (`unknown` → proceeds with `enable`, `WARNING` on stderr).
- `dispatch-test-fixture.sh` — pinned `DISPATCH_UNIT_DISABLE_DIR` at a
  never-created path so no suite is perturbed by a timer a developer has
  genuinely disabled on their own host.
- Regression: `test-dispatch-heal-units.sh` and
  `test-dispatch-schedule-reseed.sh` stay green — the poisoning-healer's
  installer fan-out and the reseed scheduler are unaffected.

## Verification

```verify
.claude/skills/dispatch-propagate/scripts/test-lib-unit-disable-state.sh
```

```verify
.claude/skills/dispatch-propagate/scripts/test-lib-systemd-units.sh
```

```verify
.claude/skills/dispatch-propagate/scripts/test-dispatch-heal-units.sh
```

```verify
.claude/skills/dispatch-propagate/scripts/test-dispatch-schedule-reseed.sh
```

```verify
.claude/skills/dispatch-propagate/scripts/run-lint.sh
```

Manual (needs a live `systemd --user` session and a real reseed cycle — not
auto-runnable): disable a timer with the new sentinel present, wait out at
least two reseed cycles, and confirm it stays disabled with no `WARNING` in
the journal for that unit.
