### PR TITLE
Collapse the blog prerender to the PageShell single-root injection path

### DIFF
--- a/fellspiral/index.html
+++ b/fellspiral/index.html
@@ -11,17 +11,7 @@
     <link rel="webmention" href="https://fellspiral.commons.systems/api/webmention">
   </head>
   <body>
-    <div class="page">
-      <header>
-        <h1>fellspiral</h1>
-        <nav><app-nav id="nav"></app-nav><button id="panel-toggle" class="panel-toggle" aria-label="Toggle info panel" aria-expanded="false">&#9656;</button></nav>
-      </header>
-      <div class="content-grid">
-        <main id="app"></main>
-        <aside id="info-panel" class="sidebar"></aside>
-      </div>
-      <footer><app-footer></app-footer></footer>
-    </div>
+    <div id="root"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/fellspiral/package.json
+++ b/fellspiral/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@commons-systems/analyticsutil": "*",
     "@commons-systems/components": "*",
+    "@commons-systems/ds": "file:../packages/ds",
     "@commons-systems/errorutil": "*",
     "@commons-systems/authutil": "*",
     "@commons-systems/blog": "*",
@@ -26,9 +27,13 @@
     "dompurify": "^3.3.1",
     "firebase": "^12.9.0",
     "marked": "^15",
-    "missing.css": "^1.1.3"
+    "missing.css": "^1.1.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
     "vite": "^6.4.3"
   }
 }

--- a/fellspiral/scripts/prerender.ts
+++ b/fellspiral/scripts/prerender.ts
@@ -3,7 +3,6 @@ import { prerenderPosts } from "@commons-systems/blog/prerender";
 import { generateFeedXml } from "@commons-systems/blog/feed";
 import { generateSitemapXml } from "@commons-systems/blog/sitemap";
 import { FEED_REGISTRY } from "@commons-systems/blog/blog-roll/feed-registry";
-import { FOOTER_HTML } from "@commons-systems/components/footer";
 import appSeed from "../seeds/firestore.js";
 import {
   NAV_LINKS,
@@ -44,7 +43,15 @@ try {
     organization: ORGANIZATION,
     author: AUTHOR,
     relMe: REL_ME,
-    footerHtml: FOOTER_HTML,
+    // Single PageShell root. Must stay byte-identical to the `shell` config in
+    // fellspiral/src/main.ts, or the client's hydrateRoot mismatches. The shell
+    // renders the ds <Footer/> itself, so no footer markup is injected here (the
+    // ds Footer is the same markup @commons-systems/components/footer re-exports).
+    shell: {
+      mount: "root",
+      wordmark: "fellspiral",
+      panelAriaLabel: "Info",
+    },
     showHomeLink: true,
   });
 } catch (err) {

--- a/fellspiral/src/main.ts
+++ b/fellspiral/src/main.ts
@@ -1,7 +1,10 @@
 import "missing.css";
+import "@commons-systems/ds/tokens/colors.css";
+import "@commons-systems/ds/tokens/typography.css";
+import "@commons-systems/ds/tokens/spacing.css";
+import "@commons-systems/ds/tokens/effects.css";
+import "@commons-systems/ds/context-panel.css";
 import "./style/theme.css";
-
-import "@commons-systems/components/footer";
 
 import { createBlogApp } from "@commons-systems/blog/create-blog-app";
 import { ADMIN_GROUP_ID } from "@commons-systems/authutil/groups";
@@ -29,6 +32,14 @@ createBlogApp({
   strategies: createStrategies(),
   firebase: { db, namespace: NAMESPACE, trackPageView, initAppCheck, signIn, signOut, onAuthStateChanged },
   adminGroupId: ADMIN_GROUP_ID,
+  // Single PageShell root (the ds chrome seam). Must stay byte-identical to the
+  // `shell` config in fellspiral/scripts/prerender.ts, or hydrateRoot mismatches.
+  // No tagline and no hero: fellspiral has neither.
+  shell: {
+    mount: "root",
+    wordmark: "fellspiral",
+    panelAriaLabel: "Info",
+  },
   useScrollIndicator: true,
   rehydrateOnAppCheck: true,
 });

--- a/fellspiral/test/prerender.test.ts
+++ b/fellspiral/test/prerender.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+const appDir = join(dirname(new URL(import.meta.url).pathname), "..");
+const read = (rel: string): string => readFileSync(join(appDir, rel), "utf-8");
+
+const indexHtml = read("index.html");
+const mainTs = read("src/main.ts");
+const prerenderTs = read("scripts/prerender.ts");
+
+// The single PageShell mount id, and the shell config both sides must agree on.
+const MOUNT = "root";
+
+describe("fellspiral single-injection (PageShell) template", () => {
+  it("ships exactly one empty PageShell mount in <body>", () => {
+    expect(indexHtml).toContain(`<div id="${MOUNT}"></div>`);
+    expect(indexHtml.match(new RegExp(`<div id="${MOUNT}">`, "g"))).toHaveLength(1);
+  });
+
+  it.each([
+    '<app-nav id="nav">',
+    '<aside id="info-panel"',
+    '<main id="app">',
+    "<app-footer>",
+    '<section class="landing-hero"',
+    'id="panel-toggle"',
+  ])("carries no legacy per-region injection marker: %s", (marker) => {
+    expect(indexHtml).not.toContain(marker);
+  });
+});
+
+describe("fellspiral shell config parity (hydration contract)", () => {
+  // The prerendered HTML must byte-match the client's first render, so the
+  // `shell` object passed to prerenderPosts and to createBlogApp must agree on
+  // every field that affects rendered output.
+  const shellBlock = (src: string): string => {
+    const start = src.indexOf("shell: {");
+    expect(start).toBeGreaterThan(-1);
+    const end = src.indexOf("}", start);
+    return src
+      .slice(start, end + 1)
+      .replace(/\s+/g, " ")
+      .trim();
+  };
+
+  it("client and prerender pass identical shell config", () => {
+    expect(shellBlock(prerenderTs)).toBe(shellBlock(mainTs));
+  });
+
+  it("mounts at the template's mount id, with no hero and no tagline", () => {
+    const shell = shellBlock(mainTs);
+    expect(shell).toContain(`mount: "${MOUNT}"`);
+    expect(shell).toContain(`wordmark: "fellspiral"`);
+    expect(shell).not.toContain("hero:");
+    expect(shell).not.toContain("tagline:");
+  });
+
+  it("drops the legacy footerHtml option (the shell renders the ds Footer)", () => {
+    expect(prerenderTs).not.toContain("footerHtml");
+    expect(prerenderTs).not.toContain("FOOTER_HTML");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,6 +145,7 @@
         "@commons-systems/blog": "*",
         "@commons-systems/components": "*",
         "@commons-systems/criticalcssutil": "*",
+        "@commons-systems/ds": "file:../packages/ds",
         "@commons-systems/errorutil": "*",
         "@commons-systems/firebaseutil": "*",
         "@commons-systems/firestoreutil": "*",
@@ -154,9 +155,13 @@
         "dompurify": "^3.3.1",
         "firebase": "^12.9.0",
         "marked": "^15",
-        "missing.css": "^1.1.3"
+        "missing.css": "^1.1.3",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
         "vite": "^6.4.3"
       }
     },

--- a/packages/blog/src/create-blog-app.ts
+++ b/packages/blog/src/create-blog-app.ts
@@ -116,7 +116,8 @@ export interface CreateBlogAppConfig {
    * Opt-in ds-chrome seam. When present, the renderer mounts a SINGLE ds
    * `<PageShell>` root (via BlogPageShell) into `#${mount}` instead of the
    * legacy three-root (`#nav` / `#app` / `#info-panel`) + static-markup path.
-   * Absent (the default — fellspiral) runs the legacy path VERBATIM.
+   * Absent runs the legacy path VERBATIM. Both in-repo apps (landing and
+   * fellspiral) now pass `shell`; the prerender side has no legacy path left.
    */
   shell?: {
     mount: string;

--- a/packages/blog/src/prerender.ts
+++ b/packages/blog/src/prerender.ts
@@ -5,7 +5,7 @@ import { renderToString } from "react-dom/server";
 import { escapeHtml } from "@commons-systems/htmlutil";
 import type { SeedSpec } from "@commons-systems/firestoreutil/seed";
 import { ContextPanelToggle } from "@commons-systems/ds";
-import { BlogNav, BlogNavEnd } from "./components/BlogNav.tsx";
+import { BlogNavEnd } from "./components/BlogNav.tsx";
 import { BlogPageShell } from "./components/BlogPageShell.tsx";
 import type { InfoPanelData } from "./components/info-panel.ts";
 import { InfoPanelRegion } from "./components/InfoPanelRegion.tsx";
@@ -36,13 +36,11 @@ import type { NavLink } from "@commons-systems/ds";
 
 export type { NavLink };
 
-/** Opt-in ds-chrome seam — the SSR/prerender counterpart of create-blog-app's
- *  client `shell` config. When present, prerender renders a SINGLE ds
- *  `<PageShell>` root (via BlogPageShell) into `#${mount}` instead of the legacy
- *  `#nav` / `#app` / `#info-panel` + static-markup injectors, so the prerendered
- *  HTML byte-matches what the client hydrates. Absent (fellspiral) keeps the
- *  legacy regex-injection path verbatim. Mirrors the client `shell` shape in
- *  create-blog-app.ts. */
+/** The ds-chrome seam — the SSR/prerender counterpart of create-blog-app's
+ *  client `shell` config. Prerender renders a SINGLE ds `<PageShell>` root (via
+ *  BlogPageShell) into `#${mount}`, so the prerendered HTML byte-matches what
+ *  the client hydrates. This is the only injection path. Mirrors the client
+ *  `shell` shape in create-blog-app.ts. */
 export interface PrerenderShellConfig {
   mount: string;
   wordmark: ReactNode;
@@ -64,26 +62,16 @@ export interface PrerenderConfig {
   organization?: Organization;
   author?: Author;
   relMe?: string[];
-  /** When provided, also set `homeExtraHtml` so JSON-LD apps have a visual representation on the page. */
+  /** Emitted as SoftwareApplication JSON-LD on the root page. Pair with a
+   *  `shell.hero` so the apps also have a visual representation on the page. */
   softwareApplications?: SoftwareApplication[];
-  /** Replaces the `<section class="landing-hero">` block when rendering the root page.
-   *  When set, per-post pages also strip the `landing-hero` section.
-   *  Throws if the marker is absent from the template. */
-  homeExtraHtml?: string;
   /** Whether to include the `commons.systems` home link in the prerendered nav.
    *  Defaults to `false`. */
   showHomeLink?: boolean;
-  /** When provided, inject this HTML into the template's `<footer></footer>`
-   *  element (root index + every post page). Throws if the `<footer>` marker is
-   *  absent. */
-  footerHtml?: string;
-  /** Opt-in ds-chrome seam — see PrerenderShellConfig. When set, the root index
-   *  and every post page render through BlogPageShell into `#${mount}`; the
-   *  legacy `injectMain`/`injectInfoPanel`/`injectNav`/`injectFooter`/
-   *  `injectHomeExtra`/`stripHomeExtra` injectors are skipped (the shell already
-   *  carries nav, panel, hero, and footer). The `<head>` SEO injectors run
-   *  regardless. */
-  shell?: PrerenderShellConfig;
+  /** The ds-chrome seam — see PrerenderShellConfig. The root index and every
+   *  post page render through BlogPageShell into `#${mount}` (the shell carries
+   *  nav, panel, hero, and footer). The `<head>` SEO injectors run on top. */
+  shell: PrerenderShellConfig;
 }
 
 export interface StaticPageConfig {
@@ -93,36 +81,27 @@ export interface StaticPageConfig {
   /** Page metadata; `page.url` is also the output path (e.g. "/about" — leading
    *  slash required, no trailing slash). */
   page: StaticPageMeta;
-  /** A ReactNode server-rendered (wrapped in a `<div>`) into `<main id="app">`,
+  /** A ReactNode server-rendered (wrapped in a `<div>`) as the shell's children,
    *  byte-matching the client's `createElement("div", null, node)` entry-hydration
-   *  wrapper in create-blog-app.ts so `#app` hydrates without a mismatch. */
+   *  wrapper in create-blog-app.ts so the page hydrates without a mismatch. */
   body: ReactNode;
   navLinks: NavLink[];
-  /** Pre-rendered info panel HTML — produced by `loadPostsForPrerender`.
-   *  Used only when `aboutContent` is not set; ignored otherwise. */
-  panelHtml?: string;
-  /** A ReactNode for an About-style panel. When set, the panel is
-   *  server-rendered through `InfoPanelRegion` (matching the client's
-   *  `panelElement()` aboutContent branch) instead of using `panelHtml`, so the
-   *  prerendered `#info-panel` hydrates without a mismatch. */
+  /** A ReactNode for an About-style panel. The panel is server-rendered through
+   *  `InfoPanelRegion` (matching the client's `panelElement()` aboutContent
+   *  branch), so the prerendered `#info-panel` hydrates without a mismatch.
+   *  Required — a static page's panel has no other source. */
   aboutContent?: ReactNode;
   jsonLdBlocks?: Record<string, unknown>[];
   relMe?: string[];
-  /** Defaults to true. Set false to keep the landing-hero block in this static page. */
-  stripHero?: boolean;
   /** Whether to include the `commons.systems` home link in the prerendered nav.
    *  Defaults to `false`. */
   showHomeLink?: boolean;
-  /** When provided, inject this HTML into the template's `<footer></footer>`
-   *  element. Throws if the `<footer>` marker is absent. */
-  footerHtml?: string;
-  /** Opt-in ds-chrome seam — see PrerenderShellConfig. When set, the page renders
-   *  through BlogPageShell into `#${mount}`; the legacy injectors and
-   *  `stripHomeExtra` are skipped (the shell carries nav, panel, and footer).
-   *  Shell mode requires `aboutContent` (the panel ReactNode) — the client
-   *  hydrates a static page's panel from `infoPanelContentForPath`. The `<head>`
-   *  SEO injectors run regardless. */
-  shell?: PrerenderShellConfig;
+  /** The ds-chrome seam — see PrerenderShellConfig. The page renders through
+   *  BlogPageShell into `#${mount}` (the shell carries nav, panel, and footer).
+   *  Requires `aboutContent` (the panel ReactNode) — the client hydrates a
+   *  static page's panel from `infoPanelContentForPath`. The `<head>` SEO
+   *  injectors run on top. */
+  shell: PrerenderShellConfig;
 }
 
 export interface PostsArtifacts {
@@ -152,53 +131,22 @@ function ogTagsToHtml(entries: OgTagEntry[]): string {
     .join("\n    ");
 }
 
-// Render the nav anonymously (showAuth=false, user=null) so no stray "Login"
-// control leaks into the static HTML. showHomeLink comes from the caller's
-// config and defaults to false. renderToString (not renderToStaticMarkup) so the
-// prerendered nav carries the hydration markers `hydrateRoot` reuses.
-function renderNavHtml(links: NavLink[], showHomeLink: boolean = false): string {
-  return renderToString(
-    createElement(BlogNav, {
-      links,
-      showHomeLink,
-      showAuth: false,
-      user: null,
-      onSignIn: () => {},
-      onSignOut: () => {},
-    }),
-  );
-}
-
 // Server-render the info panel through InfoPanelRegion — the SAME component the
 // client hydrates #info-panel with — so the prerendered markup matches and
 // hydrateRoot reuses it. strategies is unused during SSR render (the blogroll
-// fetch effect runs only on the client), so an empty Map is fine. When
-// aboutContent is set, InfoPanelRegion ignores `data` and renders the About
-// ReactNode (matching the client's panelElement() aboutContent branch).
-export function renderPanelHtml(data: InfoPanelData, aboutContent?: ReactNode): string {
-  return renderToString(
-    createElement(InfoPanelRegion, { data, strategies: new Map(), aboutContent }),
-  );
+// fetch effect runs only on the client), so an empty Map is fine.
+export function renderPanelHtml(data: InfoPanelData): string {
+  return renderToString(createElement(InfoPanelRegion, { data, strategies: new Map() }));
 }
 
 interface RenderedPost {
   meta: PublishedPost;
 }
 
-function injectMain(html: string, innerHtml: string): string {
-  const result = html.replace(
-    /<main id="app">.*?<\/main>/s,
-    () => `<main id="app">${innerHtml}</main>`,
-  );
-  if (result === html) throw new Error('<main id="app"> marker not found in template');
-  return result;
-}
-
-// Shell-path counterpart of injectMain: replace the empty
-// `<div id="${mount}"></div>` PageShell mount placeholder with the SSR-rendered
-// shell string. The template ships an empty mount div (the Unit-5 caller's
-// contract); a function replacement avoids `$`-sequence interpretation in the
-// rendered HTML.
+// The single injection path: replace the empty `<div id="${mount}"></div>`
+// PageShell mount placeholder with the SSR-rendered shell string. The template
+// ships an empty mount div (the caller's contract); a function replacement
+// avoids `$`-sequence interpretation in the rendered HTML.
 function injectRoot(html: string, mount: string, rendered: string): string {
   const re = new RegExp(`<div id="${mount}">.*?</div>`, "s");
   const result = html.replace(re, () => `<div id="${mount}">${rendered}</div>`);
@@ -207,7 +155,7 @@ function injectRoot(html: string, mount: string, rendered: string): string {
 }
 
 // The PageShell `navEnd` slot at SSR, mirroring create-blog-app's navEndNode():
-// the legacy nav-end chrome (BlogNavEnd) then the panel toggle, wrapped in a
+// the nav-end chrome (BlogNavEnd) then the panel toggle, wrapped in a
 // Fragment. Auth is never shown at prerender (showAuth=false, user=null), and
 // the toggle starts closed (open=false) — both matching the client's first
 // render for a non-/admin entry.
@@ -228,48 +176,6 @@ function shellNavEnd(showHomeLink: boolean, panelId: string): ReactNode {
       onToggle: () => {},
     }),
   );
-}
-
-function injectInfoPanel(html: string, panelHtml: string): string {
-  const result = html.replace(
-    /<aside id="info-panel" class="sidebar">.*?<\/aside>/s,
-    () => `<aside id="info-panel" class="sidebar">${panelHtml}</aside>`,
-  );
-  if (result === html) throw new Error('<aside id="info-panel"> marker not found in template');
-  return result;
-}
-
-function injectNav(html: string, navHtml: string): string {
-  const result = html.replace(
-    /<app-nav id="nav">.*?<\/app-nav>/s,
-    () => `<app-nav id="nav">${navHtml}</app-nav>`,
-  );
-  if (result === html) throw new Error('<app-nav id="nav"> marker not found in template');
-  return result;
-}
-
-function injectFooter(html: string, footerHtml: string): string {
-  const result = html.replace(
-    /<footer[^>]*>.*?<\/footer>/s,
-    () => `<footer>${footerHtml}</footer>`,
-  );
-  if (result === html) throw new Error('<footer> marker not found in template');
-  return result;
-}
-
-function injectHomeExtra(html: string, extraHtml: string): string {
-  const result = html.replace(
-    /<section class="landing-hero"[^>]*>.*?<\/section>/s,
-    () => extraHtml,
-  );
-  if (result === html) throw new Error('<section class="landing-hero"> marker not found in template');
-  return result;
-}
-
-function stripHomeExtra(html: string): string {
-  const result = html.replace(/<section class="landing-hero"[^>]*>.*?<\/section>\s*/s, "");
-  if (result === html) throw new Error('<section class="landing-hero"> marker not found in template');
-  return result;
 }
 
 function injectBeforeHead(html: string, block: string, context: string): string {
@@ -324,8 +230,9 @@ export async function loadPostsForPrerender(args: {
 // Build-time counterpart of og-meta.ts. Generates per-post HTML files with
 // OG tags, <meta name="description">, <title>, canonical link, JSON-LD
 // structured data (Organization on the root, BlogPosting per post), and
-// optional rel=me links, plus injects rendered blog content, info panel, and
-// nav — enabling crawlers to see full content without executing JS. Each post
+// optional rel=me links, plus injects the server-rendered PageShell (nav, hero,
+// blog content, info panel, footer) into the template's mount div — enabling
+// crawlers to see full content without executing JS. Each post
 // page includes all published articles (matching the root index) so the
 // client hydrates without a visible content shift.
 export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
@@ -342,23 +249,19 @@ export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
     author,
     relMe,
     softwareApplications,
-    homeExtraHtml,
     showHomeLink,
-    footerHtml,
     shell,
   } = config;
 
   const template = fs.readFileSync(join(distDir, "index.html"), "utf-8");
 
-  const { panelHtml, bodyHtml, homeBody, topPosts, rendered } = await loadPostsForPrerender({
+  const { homeBody, topPosts, rendered } = await loadPostsForPrerender({
     seed,
     postDir,
     infoPanel,
   });
 
-  const navHtml = renderNavHtml(navLinks, showHomeLink);
-
-  // Shell path: render the whole ds <PageShell> (nav + hero + body + panel +
+  // Render the whole ds <PageShell> (nav + hero + body + panel +
   // footer) as ONE renderToString so the prerendered HTML byte-matches the
   // single shell root the client hydrates. The panel data and home body mirror
   // create-blog-app's panelElement()/homeElement() exactly. hero is gated by
@@ -368,18 +271,18 @@ export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
   // the client, which hydrates the build-time metadata feed on home and post
   // pages alike).
   const renderShellHtml = (current: string): string => {
-    const panelId = shell!.panelId ?? "info-panel"; // type-safety-ok: renderShellHtml is only called inside if (shell) guards
+    const panelId = shell.panelId ?? "info-panel";
     return renderToString(
       createElement(BlogPageShell, {
-        wordmark: shell!.wordmark, // type-safety-ok: renderShellHtml is only called inside if (shell) guards
-        tagline: shell!.tagline, // type-safety-ok: renderShellHtml is only called inside if (shell) guards
+        wordmark: shell.wordmark,
+        tagline: shell.tagline,
         navLinks,
         current,
         navEnd: shellNavEnd(showHomeLink ?? false, panelId),
-        hero: current === "/" ? shell!.hero : undefined, // type-safety-ok: renderShellHtml is only called inside if (shell) guards
+        hero: current === "/" ? shell.hero : undefined,
         panelOpen: false,
         panelId,
-        panelAriaLabel: shell!.panelAriaLabel, // type-safety-ok: renderShellHtml is only called inside if (shell) guards
+        panelAriaLabel: shell.panelAriaLabel,
         panel: createElement(InfoPanelRegion, {
           data: { ...infoPanel, topPosts, postLinkPrefix: "/post/" },
           strategies: new Map(),
@@ -402,20 +305,7 @@ export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
     relMeHtml,
   ]);
 
-  let rootHtml: string;
-  if (shell) {
-    rootHtml = injectRoot(template, shell.mount, renderShellHtml("/"));
-  } else {
-    rootHtml = injectMain(template, bodyHtml);
-    rootHtml = injectInfoPanel(rootHtml, panelHtml);
-    rootHtml = injectNav(rootHtml, navHtml);
-    if (footerHtml !== undefined) {
-      rootHtml = injectFooter(rootHtml, footerHtml);
-    }
-    if (homeExtraHtml !== undefined) {
-      rootHtml = injectHomeExtra(rootHtml, homeExtraHtml);
-    }
-  }
+  let rootHtml = injectRoot(template, shell.mount, renderShellHtml("/"));
   if (siteDefaults) {
     rootHtml = rootHtml.replace(/\s*<meta name="description"[^>]*>/, "");
     const rootOgTags = ogTagsToHtml(siteDefaultOgEntries(siteUrl, siteDefaults));
@@ -442,19 +332,7 @@ export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
     html = html.replace(/<title>.*?<\/title>/, () => `<title>${escapeHtml(formatPageTitle(titleSuffix, meta.title))}</title>`);
     if (html === beforeTitle) throw new Error(`<title> tag not found in template`);
 
-    if (shell) {
-      html = injectRoot(html, shell.mount, renderShellHtml(`/post/${meta.id}`));
-    } else {
-      html = injectMain(html, bodyHtml);
-      html = injectInfoPanel(html, panelHtml);
-      html = injectNav(html, navHtml);
-      if (footerHtml !== undefined) {
-        html = injectFooter(html, footerHtml);
-      }
-      if (homeExtraHtml !== undefined) {
-        html = stripHomeExtra(html);
-      }
-    }
+    html = injectRoot(html, shell.mount, renderShellHtml(`/post/${meta.id}`));
 
     const outDir = join(distDir, "post", meta.id);
     fs.mkdirSync(outDir, { recursive: true });
@@ -464,8 +342,8 @@ export async function prerenderPosts(config: PrerenderConfig): Promise<void> {
 }
 
 /** Emit a static page (e.g. `/about`) with full SEO parity to `prerenderPosts`.
- *  The caller supplies a pre-rendered info panel via `panelHtml` — typically
- *  obtained from `loadPostsForPrerender` — so posts are loaded only once. */
+ *  The page renders through the same single BlogPageShell root; the caller
+ *  supplies the panel body as `aboutContent`. */
 export function prerenderStaticPage(config: StaticPageConfig): void {
   const {
     siteUrl,
@@ -474,13 +352,10 @@ export function prerenderStaticPage(config: StaticPageConfig): void {
     page,
     body,
     navLinks,
-    panelHtml,
     aboutContent,
     jsonLdBlocks,
     relMe,
-    stripHero,
     showHomeLink,
-    footerHtml,
     shell,
   } = config;
 
@@ -510,69 +385,38 @@ export function prerenderStaticPage(config: StaticPageConfig): void {
   html = injectBeforeHead(html, ogBlock, "static page template");
   html = injectBeforeHead(html, seoHead, "static page template");
 
-  if (shell) {
-    // Shell path: render the whole ds <PageShell> as ONE renderToString so the
-    // prerendered HTML byte-matches the single shell root the client hydrates.
-    // A static page's panel mirrors the client's panelElement() aboutContent
-    // branch (infoPanelContentForPath), so shell mode requires `aboutContent`.
-    // hero is gated by page.url === "/" — only the home root carries the hero;
-    // a static page like /about gets no hero, matching the client's gate and the
-    // legacy prerender. children
-    // preserves the existing <div>-wrapped body so it byte-matches the client's
-    // entry-hydration wrapper createElement("div", null, node).
-    if (aboutContent === undefined) {
-      throw new Error("prerenderStaticPage shell mode requires aboutContent for the panel");
-    }
-    const panelId = shell.panelId ?? "info-panel";
-    const shellHtml = renderToString(
-      createElement(BlogPageShell, {
-        wordmark: shell.wordmark,
-        tagline: shell.tagline,
-        navLinks,
-        current: page.url,
-        navEnd: shellNavEnd(showHomeLink ?? false, panelId),
-        hero: page.url === "/" ? shell.hero : undefined,
-        panelOpen: false,
-        panelId,
-        panelAriaLabel: shell.panelAriaLabel,
-        panel: createElement(InfoPanelRegion, {
-          data: { linkSections: [], topPosts: [], blogRoll: [] },
-          strategies: new Map(),
-          aboutContent,
-        }),
-        children: createElement("div", null, body),
-      }),
-    );
-    html = injectRoot(html, shell.mount, shellHtml);
-  } else {
-    // When aboutContent is set, server-render the panel through InfoPanelRegion's
-    // aboutContent branch — matching the client's panelElement(), which hydrates
-    // #info-panel with InfoPanelRegion(aboutContent=…) on a deep /about entry. The
-    // data object is ignored in that branch, so a minimal one suffices. Otherwise
-    // fall back to the caller-supplied pre-rendered panelHtml.
-    let renderedPanel: string;
-    if (aboutContent !== undefined) {
-      renderedPanel = renderPanelHtml({ linkSections: [], topPosts: [], blogRoll: [] }, aboutContent);
-    } else if (panelHtml !== undefined) {
-      renderedPanel = panelHtml;
-    } else {
-      throw new Error("prerenderStaticPage requires either aboutContent or panelHtml");
-    }
-
-    // Server-render the body wrapped in a <div> so it byte-matches the client's
-    // entry-hydration wrapper createElement("div", null, node) in create-blog-app.ts.
-    const bodyHtml = renderToString(createElement("div", null, body));
-    html = injectMain(html, bodyHtml);
-    html = injectInfoPanel(html, renderedPanel);
-    html = injectNav(html, renderNavHtml(navLinks, showHomeLink));
-    if (footerHtml !== undefined) {
-      html = injectFooter(html, footerHtml);
-    }
-
-    if (stripHero !== false) {
-      html = stripHomeExtra(html);
-    }
+  // Render the whole ds <PageShell> as ONE renderToString so the prerendered
+  // HTML byte-matches the single shell root the client hydrates. A static page's
+  // panel mirrors the client's panelElement() aboutContent branch
+  // (infoPanelContentForPath), so `aboutContent` is required. hero is gated by
+  // page.url === "/" — only the home root carries the hero; a static page like
+  // /about gets no hero, matching the client's gate. children preserves the
+  // <div>-wrapped body so it byte-matches the client's entry-hydration wrapper
+  // createElement("div", null, node).
+  if (aboutContent === undefined) {
+    throw new Error("prerenderStaticPage shell mode requires aboutContent for the panel");
   }
+  const panelId = shell.panelId ?? "info-panel";
+  const shellHtml = renderToString(
+    createElement(BlogPageShell, {
+      wordmark: shell.wordmark,
+      tagline: shell.tagline,
+      navLinks,
+      current: page.url,
+      navEnd: shellNavEnd(showHomeLink ?? false, panelId),
+      hero: page.url === "/" ? shell.hero : undefined,
+      panelOpen: false,
+      panelId,
+      panelAriaLabel: shell.panelAriaLabel,
+      panel: createElement(InfoPanelRegion, {
+        data: { linkSections: [], topPosts: [], blogRoll: [] },
+        strategies: new Map(),
+        aboutContent,
+      }),
+      children: createElement("div", null, body),
+    }),
+  );
+  html = injectRoot(html, shell.mount, shellHtml);
 
   const outDir = join(distDir, page.url);
   fs.mkdirSync(outDir, { recursive: true });

--- a/packages/blog/test/prerender-static.test.ts
+++ b/packages/blog/test/prerender-static.test.ts
@@ -16,6 +16,8 @@ vi.mock(import("node:fs"), async (importOriginal) => ({
   mkdirSync: vi.fn(),
 }));
 
+// The single injection path: the template ships an empty `<div id="root">`
+// PageShell mount, into which prerender injects renderToString(<BlogPageShell…>).
 const TEMPLATE = `<!DOCTYPE html>
 <html>
 <head>
@@ -23,25 +25,19 @@ const TEMPLATE = `<!DOCTYPE html>
   <title>My Blog</title>
 </head>
 <body>
-  <nav><app-nav id="nav"></app-nav></nav>
-  <section class="landing-hero">default hero marker</section>
-  <main id="app"></main>
-  <aside id="info-panel" class="sidebar"></aside>
+  <div id="root"></div>
 </body>
 </html>`;
 
-const TEMPLATE_WITH_FOOTER = `<!DOCTYPE html>
+// No `<div id="root">` mount — used for the missing-mount-marker case.
+const TEMPLATE_NO_MOUNT = `<!DOCTYPE html>
 <html>
 <head>
   <meta name="description" content="Default site description">
   <title>My Blog</title>
 </head>
 <body>
-  <nav><app-nav id="nav"></app-nav></nav>
-  <section class="landing-hero">default hero marker</section>
-  <main id="app"></main>
-  <aside id="info-panel" class="sidebar"></aside>
-  <footer></footer>
+  <div id="other"></div>
 </body>
 </html>`;
 
@@ -67,7 +63,18 @@ function makeStaticConfig(
       { href: "/", label: "Home" },
       { href: "/about", label: "About" },
     ],
-    panelHtml: '<section class="panel-section"><h3>Panel</h3></section>',
+    aboutContent: createElement(
+      "section",
+      { className: "panel-section profile-card" },
+      createElement("p", { className: "profile-name" }, "Nathan Buesgens"),
+    ),
+    shell: {
+      mount: "root",
+      wordmark: "commons.systems",
+      // hero is set but must be gated OFF for an off-home static page.
+      hero: createElement(Hero, { headline: "SHOULD NOT APPEAR", cards: [] }),
+      panelAriaLabel: "Context",
+    },
     ...overrides,
   };
 }
@@ -198,83 +205,39 @@ describe("prerenderStaticPage", () => {
     expect(html).toContain('"@type":"WebPage"');
   });
 
-  it("strips the landing-hero block by default", () => {
-    prerenderStaticPage(makeStaticConfig());
-    const html = getWrittenHtml("/dist/about/index.html");
-    expect(html).not.toContain('<section class="landing-hero">');
-    expect(html).not.toContain("default hero marker");
-  });
-
-  it("preserves the landing-hero block when stripHero is false", () => {
-    prerenderStaticPage(makeStaticConfig({ stripHero: false }));
-    const html = getWrittenHtml("/dist/about/index.html");
-    expect(html).toContain('<section class="landing-hero">');
-    expect(html).toContain("default hero marker");
-  });
-
-  it("injects the body ReactNode (wrapped in a <div>) into <main id=\"app\">", () => {
+  it("renders the body ReactNode (wrapped in a <div>) as the shell's children", () => {
     prerenderStaticPage(makeStaticConfig());
     const html = getWrittenHtml("/dist/about/index.html");
     // The body is server-rendered wrapped in a <div> so it byte-matches the
     // client's createElement("div", null, node) entry-hydration wrapper.
     expect(html).toContain(
-      '<main id="app"><div><article id="about-body">About body</article></div></main>',
+      '<div><article id="about-body">About body</article></div>',
     );
   });
 
-  it("injects panelHtml into the aside info-panel", () => {
+  it("renders the panel through InfoPanelRegion's aboutContent branch", () => {
     prerenderStaticPage(makeStaticConfig());
-    const html = getWrittenHtml("/dist/about/index.html");
-    expect(html).toContain(
-      '<aside id="info-panel" class="sidebar"><section class="panel-section"><h3>Panel</h3></section></aside>',
-    );
-  });
-
-  it("renders the panel through InfoPanelRegion's aboutContent branch when aboutContent is set", () => {
-    const aboutPanel = createElement(
-      "section",
-      { className: "panel-section profile-card" },
-      createElement("p", { className: "profile-name" }, "Nathan Buesgens"),
-    );
-    prerenderStaticPage(
-      makeStaticConfig({
-        aboutContent: aboutPanel,
-        // panelHtml is ignored when aboutContent is set — its content must not leak.
-        panelHtml: '<section class="panel-section"><h3>IGNORED PANEL</h3></section>',
-      }),
-    );
     const html = getWrittenHtml("/dist/about/index.html");
     // InfoPanelRegion's aboutContent branch wraps the node in a <div>, so the
     // prerendered #info-panel matches what the client hydrates on a deep /about entry.
+    expect(html).toContain('<aside id="info-panel"');
     expect(html).toContain(
-      '<aside id="info-panel" class="sidebar"><div><section class="panel-section profile-card"><p class="profile-name">Nathan Buesgens</p></section></div></aside>',
+      '<div><section class="panel-section profile-card"><p class="profile-name">Nathan Buesgens</p></section></div>',
     );
-    expect(html).not.toContain("IGNORED PANEL");
   });
 
-  it("renders the panel through InfoPanelRegion even without panelHtml when aboutContent is set", () => {
-    const aboutPanel = createElement("section", { className: "profile-card" }, "about");
-    prerenderStaticPage(
-      makeStaticConfig({ aboutContent: aboutPanel, panelHtml: undefined }),
-    );
-    const html = getWrittenHtml("/dist/about/index.html");
-    expect(html).toContain('<aside id="info-panel" class="sidebar"><div>');
-    expect(html).toContain("profile-card");
-  });
-
-  it("throws when neither aboutContent nor panelHtml is provided", () => {
+  it("throws when aboutContent is not provided", () => {
     expect(() =>
-      prerenderStaticPage(makeStaticConfig({ panelHtml: undefined })),
-    ).toThrow("requires either aboutContent or panelHtml");
+      prerenderStaticPage(makeStaticConfig({ aboutContent: undefined })),
+    ).toThrow("shell mode requires aboutContent for the panel");
   });
 
-  it("injects nav links into <app-nav>", () => {
+  it("renders the shell nav with the configured links", () => {
     prerenderStaticPage(makeStaticConfig({ showHomeLink: true }));
     const html = getWrittenHtml("/dist/about/index.html");
-    // The <app-nav> wrapper survives; inside it the ds Nav renders both links
-    // (the /about link is align:undefined here, so it stays in the start group)
-    // plus the home link, anonymously (no "Login").
-    expect(html).toContain('<app-nav id="nav">');
+    // The PageShell's ds Nav renders both links (the /about link is
+    // align:undefined here, so it stays in the start group) plus the home link,
+    // anonymously (no "Login").
     expect(html).toContain("cs-nav");
     expect(html).toContain('href="/"');
     expect(html).toContain("Home");
@@ -288,7 +251,6 @@ describe("prerenderStaticPage", () => {
     prerenderStaticPage(makeStaticConfig());
     const html = getWrittenHtml("/dist/about/index.html");
     // Nav still renders with cs-nav and the configured nav links.
-    expect(html).toContain('<app-nav id="nav">');
     expect(html).toContain("cs-nav");
     expect(html).toContain('href="/"');
     expect(html).toContain("Home");
@@ -351,7 +313,7 @@ describe("prerenderStaticPage", () => {
   it("throws when </head> marker is missing from template", () => {
     vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
       if (String(path).endsWith("index.html"))
-        return '<html><title>X</title><body><app-nav id="nav"></app-nav><section class="landing-hero">h</section><main id="app"></main><aside id="info-panel" class="sidebar"></aside></body></html>';
+        return '<html><title>X</title><body><div id="root"></div></body></html>';
       throw new Error(`Unexpected readFileSync: ${path}`);
     }) as typeof fs.readFileSync);
     expect(() => prerenderStaticPage(makeStaticConfig())).toThrow(
@@ -362,7 +324,7 @@ describe("prerenderStaticPage", () => {
   it("throws when <title> tag is missing from template", () => {
     vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
       if (String(path).endsWith("index.html"))
-        return '<html><head></head><body><app-nav id="nav"></app-nav><main id="app"></main><aside id="info-panel" class="sidebar"></aside></body></html>';
+        return '<html><head></head><body><div id="root"></div></body></html>';
       throw new Error(`Unexpected readFileSync: ${path}`);
     }) as typeof fs.readFileSync);
     expect(() => prerenderStaticPage(makeStaticConfig())).toThrow(
@@ -370,130 +332,45 @@ describe("prerenderStaticPage", () => {
     );
   });
 
-  it("injects footerHtml into <footer> when provided", () => {
-    vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
-      if (String(path).endsWith("index.html")) return TEMPLATE_WITH_FOOTER;
-      throw new Error(`Unexpected readFileSync: ${path}`);
-    }) as typeof fs.readFileSync);
-
-    prerenderStaticPage(makeStaticConfig({ footerHtml: "<p>FOOTER MARKER</p>" }));
-    const html = getWrittenHtml("/dist/about/index.html");
-    expect(html).toContain("<footer><p>FOOTER MARKER</p></footer>");
-    expect(html).not.toContain("<footer></footer>");
-  });
-
-  it("leaves <footer> untouched when footerHtml is not provided", () => {
-    vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
-      if (String(path).endsWith("index.html")) return TEMPLATE_WITH_FOOTER;
-      throw new Error(`Unexpected readFileSync: ${path}`);
-    }) as typeof fs.readFileSync);
-
+  // ── PageShell rendering (the single injection path) ────────────────────────
+  // The template ships an empty `<div id="root">` PageShell mount; prerender
+  // injects renderToString(<BlogPageShell…>) there, requires `aboutContent` for
+  // the panel, and gates the hero off (page.url !== "/"). The <head> SEO runs
+  // on top.
+  it("injects the ds PageShell at the mount with the about panel, no hero", () => {
     prerenderStaticPage(makeStaticConfig());
     const html = getWrittenHtml("/dist/about/index.html");
-    expect(html).toContain("<footer></footer>");
+    expect(html).toContain('<div id="root"><div class="page">');
+    expect(html).toContain('class="content-grid"');
+    expect(html).toContain("cs-nav");
+    expect(html).toContain('<aside id="info-panel"');
+    expect(html).toContain("profile-card");
+    expect(html).toContain("Nathan Buesgens");
+    // /about is off the home gate — no hero.
+    expect(html).not.toContain("hero-band-section");
+    expect(html).not.toContain("SHOULD NOT APPEAR");
+    expect(html).not.toContain('<div id="root"></div>');
   });
 
-  it("throws when footerHtml is set but <footer> is absent", () => {
-    // The default TEMPLATE has no <footer> element.
-    expect(() =>
-      prerenderStaticPage(makeStaticConfig({ footerHtml: "<p>FOOTER MARKER</p>" })),
-    ).toThrow("<footer> marker not found in template");
+  it("keeps the <head> SEO intact (canonical + title + og)", () => {
+    prerenderStaticPage(makeStaticConfig());
+    const html = getWrittenHtml("/dist/about/index.html");
+    expect(html).toContain('<link rel="canonical" href="https://example.com/about">');
+    expect(html).toContain("<title>My Blog - About</title>");
+    expect(html).toContain('<meta property="og:title" content="About">');
+    // The homepage default description is stripped; the page description remains.
+    expect(html).not.toContain("Default site description");
+    expect(html).toContain('content="About this site"');
   });
 
-  it("throws when stripHero is true (default) and the landing-hero marker is absent", () => {
+  it("throws when the #root mount marker is absent from the template", () => {
     vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
-      if (String(path).endsWith("index.html"))
-        return `<!DOCTYPE html><html><head><title>My Blog</title></head><body><app-nav id="nav"></app-nav><main id="app"></main><aside id="info-panel" class="sidebar"></aside></body></html>`;
+      if (String(path).endsWith("index.html")) return TEMPLATE_NO_MOUNT;
       throw new Error(`Unexpected readFileSync: ${path}`);
     }) as typeof fs.readFileSync);
     expect(() => prerenderStaticPage(makeStaticConfig())).toThrow(
-      '<section class="landing-hero"> marker not found in template',
+      '<div id="root"> mount marker not found in template',
     );
-  });
-
-  // ── Shell path (opt-in ds-chrome seam — landing /about) ────────────────────
-  // The template ships an empty `<div id="root">` PageShell mount; shell mode
-  // injects renderToString(<BlogPageShell…>) there, requires `aboutContent` for
-  // the panel, and gates the hero off (page.url !== "/"). The <head> SEO runs
-  // regardless. The legacy cases above are untouched (fellspiral guard).
-  describe("shell path", () => {
-    const TEMPLATE_WITH_ROOT = `<!DOCTYPE html>
-<html>
-<head>
-  <meta name="description" content="Default site description">
-  <title>My Blog</title>
-</head>
-<body>
-  <div id="root"></div>
-</body>
-</html>`;
-
-    beforeEach(() => {
-      vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
-        if (String(path).endsWith("index.html")) return TEMPLATE_WITH_ROOT;
-        throw new Error(`Unexpected readFileSync: ${path}`);
-      }) as typeof fs.readFileSync);
-    });
-
-    function shellStaticConfig(overrides: Partial<StaticPageConfig> = {}): StaticPageConfig {
-      return makeStaticConfig({
-        aboutContent: createElement(
-          "section",
-          { className: "profile-card" },
-          createElement("p", { className: "profile-name" }, "Nathan Buesgens"),
-        ),
-        shell: {
-          mount: "root",
-          wordmark: "commons.systems",
-          // hero is set but must be gated OFF for an off-home static page.
-          hero: createElement(Hero, { headline: "SHOULD NOT APPEAR", cards: [] }),
-          panelAriaLabel: "Context",
-        },
-        ...overrides,
-      });
-    }
-
-    it("injects the ds PageShell at the mount with the about panel, no hero", () => {
-      prerenderStaticPage(shellStaticConfig());
-      const html = getWrittenHtml("/dist/about/index.html");
-      expect(html).toContain('<div id="root"><div class="page">');
-      expect(html).toContain('class="content-grid"');
-      expect(html).toContain("cs-nav");
-      expect(html).toContain('<aside id="info-panel"');
-      expect(html).toContain("profile-card");
-      expect(html).toContain("Nathan Buesgens");
-      // /about is off the home gate — no hero.
-      expect(html).not.toContain("hero-band-section");
-      expect(html).not.toContain("SHOULD NOT APPEAR");
-      expect(html).not.toContain('<div id="root"></div>');
-    });
-
-    it("keeps the <head> SEO intact (canonical + title + og)", () => {
-      prerenderStaticPage(shellStaticConfig());
-      const html = getWrittenHtml("/dist/about/index.html");
-      expect(html).toContain('<link rel="canonical" href="https://example.com/about">');
-      expect(html).toContain("<title>My Blog - About</title>");
-      expect(html).toContain('<meta property="og:title" content="About">');
-      // The homepage default description is stripped; the page description remains.
-      expect(html).not.toContain("Default site description");
-      expect(html).toContain('content="About this site"');
-    });
-
-    it("throws when shell mode is used without aboutContent for the panel", () => {
-      expect(() =>
-        prerenderStaticPage(shellStaticConfig({ aboutContent: undefined })),
-      ).toThrow("shell mode requires aboutContent for the panel");
-    });
-
-    it("throws when the #root mount marker is absent from the template", () => {
-      vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
-        if (String(path).endsWith("index.html")) return TEMPLATE; // no #root div
-        throw new Error(`Unexpected readFileSync: ${path}`);
-      }) as typeof fs.readFileSync);
-      expect(() => prerenderStaticPage(shellStaticConfig())).toThrow(
-        '<div id="root"> mount marker not found in template',
-      );
-    });
   });
 });
 

--- a/packages/blog/test/prerender.test.ts
+++ b/packages/blog/test/prerender.test.ts
@@ -11,41 +11,26 @@ vi.mock(import("node:fs"), async (importOriginal) => ({
   mkdirSync: vi.fn(),
 }));
 
+// The single injection path: the template ships an empty `<div id="root">`
+// PageShell mount, into which prerender injects renderToString(<BlogPageShell…>).
 const TEMPLATE = `<!DOCTYPE html>
 <html>
 <head>
   <title>My Blog</title>
 </head>
 <body>
-  <nav><app-nav id="nav"></app-nav></nav>
-  <main id="app"></main>
-  <aside id="info-panel" class="sidebar"></aside>
+  <div id="root"></div>
 </body>
 </html>`;
 
-const TEMPLATE_WITH_HERO = `<!DOCTYPE html>
+// No `<div id="root">` mount — used for the missing-mount-marker case.
+const TEMPLATE_NO_MOUNT = `<!DOCTYPE html>
 <html>
 <head>
   <title>My Blog</title>
 </head>
 <body>
-  <nav><app-nav id="nav"></app-nav></nav>
-  <section class="landing-hero">default hero marker</section>
-  <main id="app"></main>
-  <aside id="info-panel" class="sidebar"></aside>
-</body>
-</html>`;
-
-const TEMPLATE_WITH_FOOTER = `<!DOCTYPE html>
-<html>
-<head>
-  <title>My Blog</title>
-</head>
-<body>
-  <nav><app-nav id="nav"></app-nav></nav>
-  <main id="app"></main>
-  <aside id="info-panel" class="sidebar"></aside>
-  <footer></footer>
+  <div id="other"></div>
 </body>
 </html>`;
 
@@ -89,6 +74,12 @@ function makeConfig(overrides: Partial<PrerenderConfig> = {}): PrerenderConfig {
       rssFeedUrl: "/feed.xml",
       opmlUrl: "/blogroll.opml",
     },
+    shell: {
+      mount: "root",
+      wordmark: "commons.systems",
+      hero: createElement(Hero, { headline: "Build with commons.systems", cards: [] }),
+      panelAriaLabel: "Context",
+    },
     ...overrides,
   };
 }
@@ -96,7 +87,7 @@ function makeConfig(overrides: Partial<PrerenderConfig> = {}): PrerenderConfig {
 function mockReadFileSync(postDir: string, markdownByFilename: Record<string, string>) {
   return (path: string | URL) => {
     const p = String(path);
-    if (p.endsWith("index.html")) return TEMPLATE_WITH_HERO;
+    if (p.endsWith("index.html")) return TEMPLATE;
     for (const [filename, content] of Object.entries(markdownByFilename)) {
       if (p === `${postDir}/${filename}`) return content;
     }
@@ -151,7 +142,7 @@ describe("prerenderPosts", () => {
   });
 
   it("replaces template meta description with post-specific description", async () => {
-    const templateWithDesc = TEMPLATE_WITH_HERO.replace(
+    const templateWithDesc = TEMPLATE.replace(
       "<title>",
       '<meta name="description" content="Site description" />\n  <title>',
     );
@@ -279,7 +270,7 @@ describe("prerenderPosts", () => {
   it("throws when </head> marker is missing from template", async () => {
     vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
       if (String(path).endsWith("index.html"))
-        return '<html><body><app-nav id="nav"></app-nav><main id="app"></main><aside id="info-panel" class="sidebar"></aside></body></html>';
+        return '<html><body><div id="root"></div></body></html>';
       return MARKDOWN_HELLO;
     }) as typeof fs.readFileSync);
     await expect(prerenderPosts(makeConfig())).rejects.toThrow("</head> marker not found");
@@ -288,10 +279,21 @@ describe("prerenderPosts", () => {
   it("throws when <title> tag is missing from template", async () => {
     vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
       if (String(path).endsWith("index.html"))
-        return '<html><head></head><body><app-nav id="nav"></app-nav><main id="app"></main><aside id="info-panel" class="sidebar"></aside></body></html>';
+        return '<html><head></head><body><div id="root"></div></body></html>';
       return MARKDOWN_HELLO;
     }) as typeof fs.readFileSync);
     await expect(prerenderPosts(makeConfig())).rejects.toThrow("<title> tag not found");
+  });
+
+  it("throws when the #root mount marker is absent from the template", async () => {
+    vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
+      if (String(path).endsWith("index.html")) return TEMPLATE_NO_MOUNT;
+      return MARKDOWN_HELLO;
+    }) as typeof fs.readFileSync);
+
+    await expect(prerenderPosts(makeConfig())).rejects.toThrow(
+      '<div id="root"> mount marker not found in template',
+    );
   });
 
   it("escapes HTML in title and description", async () => {
@@ -330,7 +332,7 @@ describe("prerenderPosts", () => {
     expect(html).toContain('id="post-hello-world"');
     expect(html).toContain('id="post-second-post"');
     expect(html).toContain('data-hydrated');
-    expect(html).toContain('<main id="app"><div id="posts">');
+    expect(html).toContain('<div id="posts">');
     expect(html).toContain("hello world");
   });
 
@@ -380,12 +382,11 @@ describe("prerenderPosts", () => {
       (c) => String(c[0]) === "/dist/index.html",
     );
     const html = rootCall![1] as string;
-    expect(html).toContain('<aside id="info-panel" class="sidebar">');
+    expect(html).toContain('<aside id="info-panel"');
     expect(html).toContain("Top Posts");
     expect(html).toContain("Blogroll");
     expect(html).toContain("Source");
     expect(html).toContain("test-blog");
-    expect(html).not.toContain('<aside id="info-panel" class="sidebar"></aside>');
   });
 
   it("extracts h1 from markdown as post title", async () => {
@@ -413,23 +414,21 @@ describe("prerenderPosts", () => {
     expect(html).toContain("Hello World");
   });
 
-  it("injects nav links into app-nav element", async () => {
+  it("renders the shell nav with the configured links", async () => {
     await prerenderPosts(makeConfig({ showHomeLink: true }));
 
     const rootCall = vi.mocked(fs.writeFileSync).mock.calls.find(
       (c) => String(c[0]) === "/dist/index.html",
     );
     const html = rootCall![1] as string;
-    // The <app-nav> wrapper survives as an inert tag; inside it the ds Nav
-    // renders the nav links (crawlers still see them) plus the home link.
-    expect(html).toContain('<app-nav id="nav">');
+    // The PageShell's ds Nav renders the nav links (crawlers still see them)
+    // plus the home link.
     expect(html).toContain("cs-nav");
     expect(html).toContain('href="/"');
     expect(html).toContain("Home");
     // Anonymous prerender: home link present, no auth "Login" control.
     expect(html).toContain('href="https://commons.systems/"');
     expect(html).not.toContain("Login");
-    expect(html).not.toContain('<app-nav id="nav"></app-nav>');
   });
 
   it("omits home link from nav when showHomeLink is false (default)", async () => {
@@ -440,7 +439,6 @@ describe("prerenderPosts", () => {
     );
     const html = rootCall![1] as string;
     // Nav still renders with cs-nav and the configured nav links.
-    expect(html).toContain('<app-nav id="nav">');
     expect(html).toContain("cs-nav");
     expect(html).toContain('href="/"');
     expect(html).toContain("Home");
@@ -456,7 +454,8 @@ describe("prerenderPosts", () => {
     );
     expect(rootCall).toBeDefined();
     const html = rootCall![1] as string;
-    expect(html).toContain('<main id="app"><div id="posts">');
+    expect(html).toContain('<div id="root"><div class="page">');
+    expect(html).toContain('<div id="posts">');
   });
 
   it("injects OG tags into root index.html when siteDefaults provided", async () => {
@@ -683,202 +682,60 @@ describe("prerenderPosts", () => {
     expect(html).not.toContain("SoftwareApplication");
   });
 
-  it("replaces <section class=\"landing-hero\"> with homeExtraHtml on root", async () => {
-    await prerenderPosts(makeConfig({ homeExtraHtml: "<div class=\"showcase-injected\">SHOWCASE</div>" }));
-    const rootCall = vi.mocked(fs.writeFileSync).mock.calls.find(
-      (c) => String(c[0]) === "/dist/index.html",
-    );
-    const html = rootCall![1] as string;
-    expect(html).toContain('<div class="showcase-injected">SHOWCASE</div>');
-    expect(html).not.toContain("default hero marker");
-    expect(html).not.toContain('<section class="landing-hero">');
-  });
-
-  it("strips <section class=\"landing-hero\"> from post pages when homeExtraHtml is set", async () => {
-    await prerenderPosts(makeConfig({ homeExtraHtml: "<div class=\"showcase-injected\">SHOWCASE</div>" }));
-    const perPostCall = vi.mocked(fs.writeFileSync).mock.calls.find(
-      (c) => String(c[0]).includes("post/hello-world"),
-    );
-    const html = perPostCall![1] as string;
-    expect(html).not.toContain('<section class="landing-hero">');
-    expect(html).not.toContain("default hero marker");
-    expect(html).not.toContain("SHOWCASE");
-  });
-
-  it("does not strip <section class=\"landing-hero\"> from post pages when homeExtraHtml is not set", async () => {
-    await prerenderPosts(makeConfig());
-    const perPostCall = vi.mocked(fs.writeFileSync).mock.calls.find(
-      (c) => String(c[0]).includes("post/hello-world"),
-    );
-    const html = perPostCall![1] as string;
-    expect(html).toContain('<section class="landing-hero">');
-  });
-
-  it("does not throw when homeExtraHtml is not set and template lacks <section class=\"landing-hero\">", async () => {
-    vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
-      if (String(path).endsWith("index.html")) return TEMPLATE;
-      return MARKDOWN_HELLO;
-    }) as typeof fs.readFileSync);
-
-    await expect(prerenderPosts(makeConfig())).resolves.toBeUndefined();
-  });
-
-  it("injects footerHtml into <footer> on root and post pages when provided", async () => {
-    vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
-      if (String(path).endsWith("index.html")) return TEMPLATE_WITH_FOOTER;
-      return MARKDOWN_HELLO;
-    }) as typeof fs.readFileSync);
-
-    await prerenderPosts(makeConfig({ footerHtml: "<p>FOOTER MARKER</p>" }));
-
-    const rootCall = vi.mocked(fs.writeFileSync).mock.calls.find(
-      (c) => String(c[0]) === "/dist/index.html",
-    );
-    const rootHtml = rootCall![1] as string; // type-safety-ok: vitest mock call arg; same pattern as existing tests
-    expect(rootHtml).toContain("<footer><p>FOOTER MARKER</p></footer>");
-    expect(rootHtml).not.toContain("<footer></footer>");
-
-    const perPostCall = vi.mocked(fs.writeFileSync).mock.calls.find(
-      (c) => String(c[0]).includes("post/hello-world"),
-    );
-    const perPostHtml = perPostCall![1] as string; // type-safety-ok: vitest mock call arg; same pattern as existing tests
-    expect(perPostHtml).toContain("<footer><p>FOOTER MARKER</p></footer>");
-    expect(perPostHtml).not.toContain("<footer></footer>");
-  });
-
-  it("leaves <footer> untouched when footerHtml is not provided", async () => {
-    vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
-      if (String(path).endsWith("index.html")) return TEMPLATE_WITH_FOOTER;
-      return MARKDOWN_HELLO;
-    }) as typeof fs.readFileSync);
-
+  // ── PageShell rendering (the single injection path) ────────────────────────
+  // The template ships an empty `<div id="root">` PageShell mount; prerender
+  // injects a renderToString(<BlogPageShell…>) there. The <head> SEO injectors
+  // run on top.
+  it("injects the ds PageShell at the mount on the home (/) page with the hero", async () => {
     await prerenderPosts(makeConfig());
 
-    const rootCall = vi.mocked(fs.writeFileSync).mock.calls.find(
-      (c) => String(c[0]) === "/dist/index.html",
+    const html = getRootHtml();
+    // The PageShell chrome was injected into the #root mount.
+    expect(html).toContain('<div id="root"><div class="page">');
+    expect(html).toContain('class="content-grid"');
+    expect(html).toContain("cs-nav");
+    expect(html).toContain('<aside id="info-panel"');
+    // Hero shows on home.
+    expect(html).toContain("hero-band-section");
+    expect(html).toContain("Build with commons.systems");
+    // The empty mount placeholder is gone.
+    expect(html).not.toContain('<div id="root"></div>');
+  });
+
+  it("omits the hero from per-post pages (off the home gate)", async () => {
+    await prerenderPosts(makeConfig());
+
+    const perPostCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+      (c) => String(c[0]).includes("post/hello-world"),
     );
-    const rootHtml = rootCall![1] as string; // type-safety-ok: vitest mock call arg; same pattern as existing tests
-    expect(rootHtml).toContain("<footer></footer>");
+    const html = perPostCall![1] as string; // type-safety-ok: find() result asserted present by test; writeFileSync arg is always string
+    // Shell chrome still injected, but no hero on a post page.
+    expect(html).toContain('<div id="root"><div class="page">');
+    expect(html).toContain('class="content-grid"');
+    expect(html).not.toContain("hero-band-section");
   });
 
-  it("throws when footerHtml is set but <footer> is absent", async () => {
-    // The default TEMPLATE_WITH_HERO has no <footer> element.
-    await expect(
-      prerenderPosts(makeConfig({ footerHtml: "<p>FOOTER MARKER</p>" })),
-    ).rejects.toThrow("<footer> marker not found in template");
-  });
+  it("keeps the <head> SEO intact (canonical + title) on home and post pages", async () => {
+    await prerenderPosts(
+      makeConfig({
+        siteDefaults: { title: "My Site", description: "Site description", image: "/og.png" },
+        organization: { name: "Example Org", url: "https://example.com", logo: "https://example.com/logo.svg", sameAs: [] },
+        author: { name: "Alice" },
+      }),
+    );
 
-  it("throws when homeExtraHtml is set but <section class=\"landing-hero\"> is absent", async () => {
-    vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
-      if (String(path).endsWith("index.html")) return TEMPLATE;
-      return MARKDOWN_HELLO;
-    }) as typeof fs.readFileSync);
+    const rootHtml = getRootHtml();
+    expect(rootHtml).toContain('<link rel="canonical" href="https://example.com/">');
+    expect(rootHtml).toContain('<meta property="og:title" content="My Site">');
+    expect(rootHtml).toContain('"@type":"Organization"');
 
-    await expect(
-      prerenderPosts(makeConfig({ homeExtraHtml: '<div class="showcase">SHOWCASE</div>' })),
-    ).rejects.toThrow('<section class="landing-hero"> marker not found in template');
-  });
-
-  // ── Shell path (opt-in ds-chrome seam — landing) ───────────────────────────
-  // The template ships an empty `<div id="root">` PageShell mount; shell mode
-  // injects a renderToString(<BlogPageShell…>) there instead of the legacy
-  // injectMain/injectNav/injectInfoPanel injectors. The <head> SEO injectors run
-  // regardless. The legacy cases above are untouched (fellspiral guard).
-  describe("shell path", () => {
-    const TEMPLATE_WITH_ROOT = `<!DOCTYPE html>
-<html>
-<head>
-  <title>My Blog</title>
-</head>
-<body>
-  <div id="root"></div>
-</body>
-</html>`;
-
-    function mockRootTemplate() {
-      vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
-        if (String(path).endsWith("index.html")) return TEMPLATE_WITH_ROOT;
-        return MARKDOWN_HELLO;
-      }) as typeof fs.readFileSync);
-    }
-
-    function shellOverride(): Partial<PrerenderConfig> {
-      return {
-        shell: {
-          mount: "root",
-          wordmark: "commons.systems",
-          hero: createElement(Hero, { headline: "Build with commons.systems", cards: [] }),
-          panelAriaLabel: "Context",
-        },
-      };
-    }
-
-    it("injects the ds PageShell at the mount on the home (/) page with the hero", async () => {
-      mockRootTemplate();
-      await prerenderPosts(makeConfig(shellOverride()));
-
-      const html = getRootHtml();
-      // The PageShell chrome was injected into the #root mount.
-      expect(html).toContain('<div id="root"><div class="page">');
-      expect(html).toContain('class="content-grid"');
-      expect(html).toContain("cs-nav");
-      expect(html).toContain('<aside id="info-panel"');
-      // Hero shows on home.
-      expect(html).toContain("hero-band-section");
-      expect(html).toContain("Build with commons.systems");
-      // The empty mount placeholder is gone.
-      expect(html).not.toContain('<div id="root"></div>');
-    });
-
-    it("omits the hero from per-post pages (off the home gate)", async () => {
-      mockRootTemplate();
-      await prerenderPosts(makeConfig(shellOverride()));
-
-      const perPostCall = vi.mocked(fs.writeFileSync).mock.calls.find(
-        (c) => String(c[0]).includes("post/hello-world"),
-      );
-      const html = perPostCall![1] as string; // type-safety-ok: find() result asserted present by test; writeFileSync arg is always string
-      // Shell chrome still injected, but no hero on a post page.
-      expect(html).toContain('<div id="root"><div class="page">');
-      expect(html).toContain('class="content-grid"');
-      expect(html).not.toContain("hero-band-section");
-    });
-
-    it("keeps the <head> SEO intact (canonical + title) on home and post pages", async () => {
-      mockRootTemplate();
-      await prerenderPosts(
-        makeConfig({
-          ...shellOverride(),
-          siteDefaults: { title: "My Site", description: "Site description", image: "/og.png" },
-          organization: { name: "Example Org", url: "https://example.com", logo: "https://example.com/logo.svg", sameAs: [] },
-          author: { name: "Alice" },
-        }),
-      );
-
-      const rootHtml = getRootHtml();
-      expect(rootHtml).toContain('<link rel="canonical" href="https://example.com/">');
-      expect(rootHtml).toContain('<meta property="og:title" content="My Site">');
-      expect(rootHtml).toContain('"@type":"Organization"');
-
-      const perPostCall = vi.mocked(fs.writeFileSync).mock.calls.find(
-        (c) => String(c[0]).includes("post/hello-world"),
-      );
-      const perPostHtml = perPostCall![1] as string; // type-safety-ok: find() result asserted present by test; writeFileSync arg is always string
-      expect(perPostHtml).toContain('<link rel="canonical" href="https://example.com/post/hello-world">');
-      expect(perPostHtml).toContain("<title>My Blog - Hello World</title>");
-      expect(perPostHtml).toContain('"@type":"BlogPosting"');
-    });
-
-    it("throws when the #root mount marker is absent from the template", async () => {
-      vi.mocked(fs.readFileSync).mockImplementation(((path: string) => {
-        if (String(path).endsWith("index.html")) return TEMPLATE; // no #root div
-        return MARKDOWN_HELLO;
-      }) as typeof fs.readFileSync);
-
-      await expect(prerenderPosts(makeConfig(shellOverride()))).rejects.toThrow(
-        '<div id="root"> mount marker not found in template',
-      );
-    });
+    const perPostCall = vi.mocked(fs.writeFileSync).mock.calls.find(
+      (c) => String(c[0]).includes("post/hello-world"),
+    );
+    const perPostHtml = perPostCall![1] as string; // type-safety-ok: find() result asserted present by test; writeFileSync arg is always string
+    expect(perPostHtml).toContain('<link rel="canonical" href="https://example.com/post/hello-world">');
+    expect(perPostHtml).toContain("<title>My Blog - Hello World</title>");
+    expect(perPostHtml).toContain('"@type":"BlogPosting"');
   });
 
   function getRootHtml(): string {
@@ -888,3 +745,4 @@ describe("prerenderPosts", () => {
     return rootCall![1] as string; // type-safety-ok: find() result asserted present by test; writeFileSync arg is always string
   }
 });
+


### PR DESCRIPTION
## Context

`packages/blog/src/prerender.ts` carried two hydration-injection paths (see
its prior header doc, `prerender.ts:41-44` and `:81-84`):

- The legacy path: regex/string `String.replace` injectors at marked
  template sites — `injectMain`, `injectInfoPanel`, `injectNav`,
  `injectFooter`, `injectHomeExtra`, `stripHomeExtra`. This is the class that
  produced the `tactic-blog-prerender-injection` defect (regex injection into
  HTML).
- The PageShell single-root path: `injectRoot` replaces one empty
  `<div id="${mount}"></div>` placeholder with the SSR-rendered `BlogPageShell`,
  which already carries nav, panel, hero, and footer.

`landing`'s blog already used the PageShell path; `fellspiral` remained on the
legacy path. This PR migrates fellspiral onto PageShell and deletes the legacy
injectors, removing the regex-injection bug class entirely.

## Unit 1 — Migrate fellspiral's blog prerender onto BlogPageShell

- `fellspiral/index.html` — collapsed `<body>` to the single `<div id="root">`
  mount + script tag, matching landing's template shape.
- `fellspiral/src/main.ts` — added the `shell` config to `createBlogApp`
  (`mount: "root"`, `wordmark: "fellspiral"`, `panelAriaLabel: "Info"`; no
  tagline/hero — fellspiral has neither), added the ds token/context-panel CSS
  imports, dropped the now-dead `@commons-systems/components/footer` import.
- `fellspiral/scripts/prerender.ts` — added the byte-identical `shell` config
  to `prerenderPosts`, dropped `footerHtml` (the shell's ds `<Footer/>` renders
  the same markup `@commons-systems/components/footer` re-exports).
- `fellspiral/package.json` — added `@commons-systems/ds`, `react`,
  `react-dom` (+ devDeps), matching landing's versions.
- New `fellspiral/test/prerender.test.ts` asserting the single-mount template
  and no legacy per-region markers survive, and that the client/server `shell`
  configs stay textually identical (the hydration byte-match contract).

## Unit 2 — Delete the legacy injectors and their template markers

- `packages/blog/src/prerender.ts` — deleted `injectMain`, `injectInfoPanel`,
  `injectNav`, `injectFooter`, `injectHomeExtra`, `stripHomeExtra`, their
  `if (shell) {...} else {...}` legacy branches, and the config fields that
  only fed them (`homeExtraHtml`, `footerHtml`, `panelHtml`, `stripHero`).
  `shell` is now required (not optional) on `PrerenderConfig` and
  `StaticPageConfig`. `injectRoot` and the `<head>` SEO injectors are
  untouched.
- `packages/blog/src/create-blog-app.ts` — one stale doc-comment fix (no code
  change): fellspiral is no longer the shell-absent default.
- `packages/blog/test/prerender.test.ts` and `prerender-static.test.ts` —
  updated to the single-path defaults; tests exercising legacy-only behavior
  (`homeExtraHtml`, `footerHtml`, `panelHtml`, `stripHero`) were deleted
  outright since that behavior no longer exists (per this repo's
  test-integrity rule); tests still asserting real behavior were rewritten
  against shell markup instead of legacy markup.

## Verification

```verify
npx vitest run --project packages/blog --root .
```

```verify
npx vitest run --project fellspiral --root .
```

Both pass (packages/blog: 29 files / 448 tests; fellspiral: 8 files passed / 2
skipped, 55 tests passed / 5 skipped). Note: the node plan's verify block used
`--project blog`, which errors ("No projects matched") — the vitest workspace
project id for that package is `packages/blog` (the workspace dir), not the
bare package name; a plan-text typo, not a code defect.

`npx tsc -p packages/blog/tsconfig.json --noEmit` and `npm run lint` (both
touched packages) are clean. `npx knip` shows no newly-dead exports.

Manual (preview deploy, not run in this session): load a fellspiral blog post
and the blog index, confirm no hydration mismatch warning in the console and
that nav, info panel, and footer all render correctly from the prerendered
HTML before JS runs (disable JS to check the prerendered shell).

Graph node: `tactic-prerender-single-injection-path`
