### PR TITLE
align-tactics: carry target_node rationale/body/phase into tactic-mode plan prompt

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/align-tactics-target-context-probe.mjs
+++ b/.claude/skills/dispatch-propagate/scripts/align-tactics-target-context-probe.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+// align-tactics-target-context-probe.mjs
+//
+// CI-vector probe for synthesizeTargetPlanTactic and tacticModeFraming in
+// .claude/workflows/align-tactics.js. run-unit-tests.sh has no mapping for
+// .claude/workflows/*, so a PR touching only align-tactics.js triggers no
+// vitest suite. Its test-*.sh glob over this directory is NOT a fallback
+// either: that glob only runs when RUN_PR_SCRIPTS is set, which auto-detect
+// sets solely for changed paths under
+// .claude/skills/dispatch-propagate/scripts/ (run-unit-tests.sh:88). The
+// actual CI vector is the hook-tests job in .github/workflows/unit-tests.yml,
+// which runs test-align-tactics-target-context.sh (this probe's driver)
+// unconditionally on every PR. Keep that step wired — deleting it removes all
+// coverage here.
+//
+// align-tactics.js is a Workflow-tool script (top-level await + injected
+// globals), so it CANNOT be imported/executed by node. Instead this probe
+// SLICES the pure functions' text out from between sentinel comments and
+// evals just those slices, then runs a handful of assertions against them —
+// mirroring align-tactics-tempref-probe.mjs's scaffold.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Resolve align-tactics.js relative to this helper's own location. This helper
+// sits at .claude/skills/dispatch-propagate/scripts/, so align-tactics.js is
+// three dirs up at .claude/workflows/align-tactics.js.
+const alignTacticsPath = fileURLToPath(
+  new URL('../../../workflows/align-tactics.js', import.meta.url)
+);
+
+const source = readFileSync(alignTacticsPath, 'utf8');
+
+// FAIL LOUDLY: each sentinel must appear exactly once.
+function countOccurrences(haystack, needle) {
+  let count = 0;
+  let idx = haystack.indexOf(needle);
+  while (idx !== -1) {
+    count += 1;
+    idx = haystack.indexOf(needle, idx + needle.length);
+  }
+  return count;
+}
+
+// sliceFn — locate a START/END sentinel pair exactly once each, slice the text
+// strictly between them, trim it, and eval it into a standalone function via
+// `new Function('return ' + slice)()`.
+//
+// .trim() is load-bearing: a raw slice begins with a newline, and
+// `'return ' + '\nfunction...'` triggers automatic semicolon insertion after
+// `return`, so the constructed function would return undefined. Trimming makes
+// the slice start with `function`, yielding a same-line function expression.
+function sliceFn(src, start, end, label) {
+  const startCount = countOccurrences(src, start);
+  const endCount = countOccurrences(src, end);
+  if (startCount !== 1) {
+    process.stderr.write(
+      `align-tactics-target-context-probe: START sentinel for ${label} not found exactly once (count=${startCount}) in ${alignTacticsPath}\n`
+    );
+    process.exit(1);
+  }
+  if (endCount !== 1) {
+    process.stderr.write(
+      `align-tactics-target-context-probe: END sentinel for ${label} not found exactly once (count=${endCount}) in ${alignTacticsPath}\n`
+    );
+    process.exit(1);
+  }
+  const startIdx = src.indexOf(start) + start.length;
+  const endIdx = src.indexOf(end);
+  const fnSource = src.slice(startIdx, endIdx).trim();
+  if (!fnSource) {
+    process.stderr.write(
+      `align-tactics-target-context-probe: empty function body between sentinels for ${label}\n`
+    );
+    process.exit(1);
+  }
+  return new Function('return ' + fnSource)();
+}
+
+const SPECS = {
+  synthesizeTargetPlanTactic: {
+    start: "// >>> synthesizeTargetPlanTactic: sliced + eval'd by test-align-tactics-target-context.sh >>>",
+    end: '// <<< synthesizeTargetPlanTactic <<<',
+  },
+  tacticModeFraming: {
+    start: "// >>> tacticModeFraming: sliced + eval'd by test-align-tactics-target-context.sh >>>",
+    end: '// <<< tacticModeFraming <<<',
+  },
+};
+
+const synthesizeTargetPlanTactic = sliceFn(
+  source,
+  SPECS.synthesizeTargetPlanTactic.start,
+  SPECS.synthesizeTargetPlanTactic.end,
+  'synthesizeTargetPlanTactic'
+);
+const tacticModeFraming = sliceFn(
+  source,
+  SPECS.tacticModeFraming.start,
+  SPECS.tacticModeFraming.end,
+  'tacticModeFraming'
+);
+
+// Minimal assertion helpers (this probe prints its own PASS/FAIL lines; the
+// driver in test-align-tactics-target-context.sh asserts on the final "ALL
+// PASS" token).
+let failures = 0;
+function ok(name, cond) {
+  if (cond) {
+    process.stdout.write(`  ok: ${name}\n`);
+  } else {
+    failures += 1;
+    process.stdout.write(`  FAIL: ${name}\n`);
+  }
+}
+function doesNotThrow(name, fn) {
+  try {
+    const result = fn();
+    ok(name, true);
+    return result;
+  } catch (e) {
+    ok(name, false);
+    process.stderr.write(`  ${name}: unexpected throw: ${String((e && e.message) || e)}\n`);
+    return undefined;
+  }
+}
+
+// --- synthesizeTargetPlanTactic ---------------------------------------------
+
+// Vector 1: full node — rationale/body/phase must all ride through unchanged.
+// This is the exact regression the tactic exists to prevent.
+{
+  const targetNode = {
+    id: 'tactic-x',
+    statement: 's',
+    rationale: 'r',
+    body: 'B',
+    phase: 'qa',
+  };
+  const out = synthesizeTargetPlanTactic(targetNode);
+  ok('vector1: rationale rides through', out.rationale === 'r');
+  ok('vector1: body rides through', out.body === 'B');
+  ok('vector1: phase rides through', out.phase === 'qa');
+  ok('vector1: temp_ref === id', out.temp_ref === 'tactic-x');
+  ok('vector1: existing_id === id', out.existing_id === 'tactic-x');
+  ok('vector1: draft_source_id === id', out.draft_source_id === 'tactic-x');
+  ok('vector1: claude_eligible === true', out.claude_eligible === true);
+
+  // Vector 4: serialization guard — an undefined field silently vanishes from
+  // JSON.stringify, so assert these three fields actually survive it (this is
+  // exactly what buildPlanPrompt embeds via asJson).
+  const serialized = JSON.stringify(out);
+  ok('vector4: serialized JSON contains "rationale"', serialized.includes('"rationale"'));
+  ok('vector4: serialized JSON contains "body"', serialized.includes('"body"'));
+  ok('vector4: serialized JSON contains "phase"', serialized.includes('"phase"'));
+}
+
+// Vector 2: draft node — no rationale/body/phase supplied. rationale/body
+// default to '', phase must be explicitly null (not undefined).
+{
+  const targetNode = { id: 'tactic-y', statement: 's' };
+  const out = synthesizeTargetPlanTactic(targetNode);
+  ok('vector2: rationale defaults to empty string', out.rationale === '');
+  ok('vector2: body defaults to empty string', out.body === '');
+  ok('vector2: phase is explicitly null', Object.is(out.phase, null));
+}
+
+// Vector 3: undefined targetNode does not throw and yields safe defaults.
+{
+  const out = doesNotThrow('vector3: synthesizeTargetPlanTactic(undefined) does not throw', () =>
+    synthesizeTargetPlanTactic(undefined)
+  );
+  if (out) {
+    ok('vector3: temp_ref defaults to "target"', out.temp_ref === 'target');
+    ok('vector3: phase is explicitly null', Object.is(out.phase, null));
+  } else {
+    ok('vector3: temp_ref defaults to "target"', false);
+    ok('vector3: phase is explicitly null', false);
+  }
+}
+
+// --- tacticModeFraming -------------------------------------------------------
+
+// Vector 5: strategy mode returns [] — a decomposed tactic is new work with no
+// prior body to reconcile.
+{
+  const out = tacticModeFraming('strategy', { phase: 'qa' });
+  ok('vector5: strategy mode returns an empty array', Array.isArray(out) && out.length === 0);
+}
+
+// Vector 6: tactic mode, phase null — FINALIZE branch, no RE-PLAN text.
+{
+  const out = tacticModeFraming('tactic', { phase: null });
+  const text = out.join('\n');
+  ok('vector6: phase null includes FINALIZE', text.includes('FINALIZE'));
+  ok('vector6: phase null excludes RE-PLAN', !text.includes('RE-PLAN'));
+  // Vector 10 (part 1): both tactic-mode branches carry the wholesale-replace warning.
+  ok(
+    'vector10a: FINALIZE branch includes REPLACES THE NODE BODY WHOLESALE',
+    text.includes('REPLACES THE NODE BODY WHOLESALE')
+  );
+}
+
+// Vector 7: tactic mode, phase 'draft' — equivalent to absent, still FINALIZE.
+{
+  const out = tacticModeFraming('tactic', { phase: 'draft' });
+  const text = out.join('\n');
+  ok('vector7: phase draft includes FINALIZE', text.includes('FINALIZE'));
+}
+
+// Vector 8: tactic mode, phase 'implement' — RE-PLAN branch, carries the
+// literal quoted phase value, and excludes FINALIZE.
+{
+  const out = tacticModeFraming('tactic', { phase: 'implement' });
+  const text = out.join('\n');
+  ok('vector8: phase implement includes RE-PLAN', text.includes('RE-PLAN'));
+  ok('vector8: phase implement includes literal "implement"', text.includes('"implement"'));
+  ok('vector8: phase implement excludes FINALIZE', !text.includes('FINALIZE'));
+  // Vector 10 (part 2): both tactic-mode branches carry the wholesale-replace warning.
+  ok(
+    'vector10b: RE-PLAN branch includes REPLACES THE NODE BODY WHOLESALE',
+    text.includes('REPLACES THE NODE BODY WHOLESALE')
+  );
+}
+
+// Vector 9: tactic mode, phase 'qa' — RE-PLAN branch.
+{
+  const out = tacticModeFraming('tactic', { phase: 'qa' });
+  const text = out.join('\n');
+  ok('vector9: phase qa includes RE-PLAN', text.includes('RE-PLAN'));
+}
+
+// Vector 11: undefined tactic in tactic mode does not throw and yields the
+// FINALIZE branch (phase treated as absent).
+{
+  const out = doesNotThrow('vector11: tacticModeFraming("tactic", undefined) does not throw', () =>
+    tacticModeFraming('tactic', undefined)
+  );
+  if (out) {
+    const text = out.join('\n');
+    ok('vector11: undefined tactic yields FINALIZE branch', text.includes('FINALIZE'));
+  } else {
+    ok('vector11: undefined tactic yields FINALIZE branch', false);
+  }
+}
+
+if (failures > 0) {
+  process.stdout.write(`align-tactics-target-context-probe: ${failures} FAILURE(S)\n`);
+  process.exit(1);
+}
+process.stdout.write('align-tactics-target-context-probe: ALL PASS\n');

--- a/.claude/skills/dispatch-propagate/scripts/test-align-tactics-target-context.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-align-tactics-target-context.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Tests for align-tactics' synthesizeTargetPlanTactic and tacticModeFraming
+# (sliced out of .claude/workflows/align-tactics.js by
+# align-tactics-target-context-probe.mjs). CI vector: run-unit-tests.sh has no
+# mapping for .claude/workflows/*, so a PR touching only align-tactics.js
+# triggers no vitest suite. Its test-*.sh glob over this directory is NOT a
+# fallback either — that glob only runs when RUN_PR_SCRIPTS is set, which
+# auto-detect sets solely for changed paths under
+# .claude/skills/dispatch-propagate/scripts/ (run-unit-tests.sh:88). So this
+# script is wired unconditionally into the hook-tests job of
+# .github/workflows/unit-tests.yml; that step is the only thing that runs this
+# coverage on every PR. Keep it wired.
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=dispatch-test-fixture.sh
+source "$FIXTURE_DIR/dispatch-test-fixture.sh"
+
+echo "Test: align-tactics tactic-mode target-node context"
+
+out_tc=$(node "$SCRIPT_DIR/align-tactics-target-context-probe.mjs")
+
+assert_eq "align-tactics target-context: all probe vectors pass" \
+  "align-tactics-target-context-probe: ALL PASS" \
+  "$(printf '%s' "$out_tc" | tail -n1)"
+
+report_results

--- a/.claude/workflows/align-tactics.js
+++ b/.claude/workflows/align-tactics.js
@@ -33,6 +33,13 @@
  *       rounds:{count,last_completed,last_aligned} },
  *     target_node: {              // tactic mode ONLY: the single tactic being (re)planned
  *       id, statement, rationale, body, phase },
+ *       // ALL FIVE fields ride into the plan prompt (synthesizeTargetPlanTactic
+ *       // + tacticModeFraming below). `body` must be the node's FULL current
+ *       // body text below the frontmatter fence: the plan agent reconciles
+ *       // against it and its returned body_markdown REPLACES it wholesale
+ *       // (references/write-path.md), so a truncated body silently loses
+ *       // content. `phase` is the finalize-vs-re-plan discriminator
+ *       // (null/absent/"draft" => finalize; any in-flight phase => re-plan).
  *     draft_tactics:[ { id, statement, body } ],  // strategy mode: retained /align-strategy drafts
  *     existing_children:[ { id, phase, on_signal_path } ], // non-draft children already on the signal path
  *     reuse_hunts:[ { focus, scope } ],           // up to 3 reuse-hunt foci (default 1)
@@ -449,6 +456,114 @@ const untrusted = (text) => ['<untrusted>', String(text == null ? '' : text), '<
 // Compact JSON for embedding a data structure inside a prompt.
 const asJson = (obj) => JSON.stringify(obj, null, 2);
 
+// --- tactic-mode target-node context -----------------------------------------
+
+// synthesizeTargetPlanTactic — build the one-entry `planTactics` record for
+// mode: "tactic" from args.target_node.
+//
+// The defect this fixes: this record used to carry only id/statement, and it is
+// the object buildPlanPrompt serializes verbatim (`untrusted(asJson(tactic))`),
+// so the plan agent never saw the node's own rationale, its accumulated body
+// evidence, or its phase. All three now ride through. PURE (no fs/git) so the
+// probe can eval it in isolation.
+//
+// >>> synthesizeTargetPlanTactic: sliced + eval'd by test-align-tactics-target-context.sh >>>
+function synthesizeTargetPlanTactic(targetNode) {
+  const t = targetNode || {};
+  return {
+    temp_ref: t.id || 'target',
+    slug_hint: t.id || 'target',
+    statement: t.statement || '',
+    // The node's own accumulated evidence — the primary input to a finalize or
+    // a re-plan, not decoration.
+    rationale: t.rationale || '',
+    body: t.body || '',
+    // null (not undefined) so the discriminator is explicit in the serialized
+    // JSON the agent reads.
+    phase: t.phase == null ? null : t.phase,
+    claude_eligible: true,
+    draft_source_id: t.id || null,
+    existing_id: t.id || null,
+  };
+}
+// <<< synthesizeTargetPlanTactic <<<
+
+// tacticModeFraming — the finalize-vs-re-plan prose block for buildPlanPrompt.
+//
+// Returns [] in strategy mode (a decomposed tactic is new work with no prior
+// body to reconcile). In tactic mode it branches on the target node's phase.
+// The doctrine text is spliced from
+// .claude/skills/align-tactics/references/tactic-target.md:40-56 (draft/raw ->
+// finalize) and :58-73 + :160-172 (soft-frozen -> re-plan, clarification 32's
+// whole-node reconciliation bar) — author-approved wording, not re-derived.
+//
+// Phase values are the schema enum (packages/intentionsutil/src/schema.ts:36-43):
+// draft | align-tactics | implement | qa | review | main-qa | done. A null,
+// empty, or "draft" phase means never-decomposed; anything else is in-flight.
+// ("fix" is NOT a phase — the CI-fix interrupt lives in execution.fix.)
+//
+// >>> tacticModeFraming: sliced + eval'd by test-align-tactics-target-context.sh >>>
+function tacticModeFraming(mode, tactic) {
+  if (mode !== 'tactic') return [];
+  const t = tactic || {};
+  const phase = t.phase == null ? '' : String(t.phase);
+  const isFinalize = phase === '' || phase === 'draft';
+  const head = isFinalize
+    ? [
+        'TACTIC-MODE DISPOSITION — FINALIZE. This node has never been decomposed',
+        '(its phase is absent/draft), so this run authors its FIRST full',
+        'clean-session plan body.',
+      ]
+    : [
+        `TACTIC-MODE DISPOSITION — RE-PLAN. This node is soft-frozen at phase`,
+        `"${phase}": work is already in flight against the body below. This run`,
+        'RECONCILES that node, it does not author a plan from zero.',
+      ];
+  const shared = [
+    '',
+    'The `rationale` and `body` fields on the tactic below are the node\'s OWN',
+    'accumulated evidence — the recorded diagnosis, root cause, path:line',
+    'anchors, caveats, and instructions its author put there. Read them as the',
+    'PRIMARY input. The gather-phase reuse evidence and the strategy substance',
+    'are context around them, never a replacement for them.',
+    '',
+    'YOUR RETURNED body_markdown REPLACES THE NODE BODY WHOLESALE. Anything in',
+    '`body` that is still true and still needed — root-cause analysis, path:line',
+    'anchors, explicit caveats, instructions addressed to sibling or child nodes',
+    '— must be carried forward into what you author, or it is permanently lost.',
+    'Anything in it that your plan contradicts must be rewritten, not left',
+    'standing beside it.',
+  ];
+  const tail = isFinalize
+    ? [
+        '',
+        'WHOLE-NODE RECONCILE (clarification 32): rewrite any stale draft',
+        'narrative so nothing in the body contradicts the finalized plan. Do NOT',
+        'sweep the serving strategy\'s other draft tactics and do NOT propose a',
+        'rounds bump — neither is this run\'s job.',
+      ]
+    : [
+        '',
+        'WHOLE-NODE RECONCILIATION BAR (clarification 32): reconcile the node\'s',
+        'WHOLE body — the ## Context prose, EVERY unit, ## Reuse, and',
+        '## Verification — against the full current strategy substance shown',
+        'above, in this one pass. A one-bullet delta that leaves a sibling unit',
+        'or a verification step contradicting the amendment is an INCOMPLETE',
+        'amendment. Preserve verbatim every unit the current strategy substance',
+        'does not invalidate (units already implemented against this body are',
+        'cited by landed work); revise only what it actually invalidates, and',
+        'say explicitly in ## Context what changed and why. Do NOT relabel or',
+        'renumber the phase — the caller preserves the in-flight phase on',
+        'landing.',
+      ];
+  return head.concat(shared, tail, [
+    '',
+    'Whichever disposition applies, the body_markdown you return must satisfy',
+    'the PLAN BODY SCHEMA above in full.',
+  ]);
+}
+// <<< tacticModeFraming <<<
+
 // --- prompt builders ---------------------------------------------------------
 
 // gather: reuse-hunt Explore-style agent (mechanical search, reuse-first).
@@ -702,7 +817,7 @@ function buildDecomposePrompt(strategy, drafts, gather, drift) {
 }
 
 // plan: the per-tactic plan-body schema + quality bar (SKILL.md Step 3), inline.
-function buildPlanPrompt(strategy, tactic, gather) {
+function buildPlanPrompt(strategy, tactic, gather, mode) {
   return [
     'You are the plan-authoring agent for a single claude-eligible tactic. Produce',
     'a FULL clean-session plan and return it as body_markdown. The quality bar:',
@@ -749,12 +864,28 @@ function buildPlanPrompt(strategy, tactic, gather) {
     '',
     `Serving strategy id: ${strategy.id || '?'}`,
     'Strategy intent:',
-    untrusted(
-      [
-        `statement: ${strategy.statement || ''}`,
-        `success_signal: ${strategy.success_signal || ''}`,
-      ].join('\n')
-    ),
+    mode === 'tactic'
+      ? untrusted(
+          asJson({
+            id: strategy.id,
+            statement: strategy.statement,
+            rationale: strategy.rationale,
+            success_signal: strategy.success_signal,
+            reading: strategy.reading,
+            gap: strategy.gap,
+            conditions: strategy.conditions || [],
+            clarifications: strategy.clarifications || [],
+            rounds: strategy.rounds || null,
+          })
+        )
+      : untrusted(
+          [
+            `statement: ${strategy.statement || ''}`,
+            `success_signal: ${strategy.success_signal || ''}`,
+          ].join('\n')
+        ),
+    '',
+    ...tacticModeFraming(mode, tactic),
     '',
     'Tactic to plan:',
     untrusted(asJson(tactic)),
@@ -792,7 +923,7 @@ let subagentsLaunched = 0;
 // A short summary of the decomposition target, reused by the reuse-hunt prompts.
 const targetSummary =
   mode === 'tactic'
-    ? `Finalize/re-plan the single tactic "${(_a.target_node && _a.target_node.id) || '?'}": ${(_a.target_node && _a.target_node.statement) || ''}`
+    ? `Finalize/re-plan the single tactic "${(_a.target_node && _a.target_node.id) || '?'}" (phase: ${(_a.target_node && _a.target_node.phase) || 'draft/raw — finalize'}): ${(_a.target_node && _a.target_node.statement) || ''}`
     : `Decompose strategy "${strategy.id || '?'}" into its minimum signal-validating tactic subtree this round.`;
 
 // --- 1. GATHER (parallel: reuse hunts + corpus scan + clause coverage) --------
@@ -954,17 +1085,7 @@ let planTactics = [];
 if (!driftProceed) {
   planTactics = []; // parked — nothing to plan this run
 } else if (mode === 'tactic') {
-  const t = _a.target_node || {};
-  planTactics = [
-    {
-      temp_ref: t.id || 'target',
-      slug_hint: t.id || 'target',
-      statement: t.statement || '',
-      claude_eligible: true,
-      draft_source_id: t.id || null,
-      existing_id: t.id || null,
-    },
-  ];
+  planTactics = [synthesizeTargetPlanTactic(_a.target_node)];
 } else {
   planTactics = (decompose.tactics || []).filter((t) => t.claude_eligible === true);
 }
@@ -975,7 +1096,7 @@ if (planTactics.length) {
   subagentsLaunched += planTactics.length;
   const planResults = await parallel(
     planTactics.map((t) => () =>
-      agent(buildPlanPrompt(strategy, t, gather), {
+      agent(buildPlanPrompt(strategy, t, gather, mode), {
         model: 'opus',
         agentType: 'general-purpose',
         schema: PLAN_SCHEMA,

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -264,6 +264,8 @@ jobs:
         run: .github/scripts/test-check-test-integrity.sh
       - name: Run graph fast-path guard script tests
         run: .github/scripts/test-check-graph-fast-path.sh
+      - name: Run align-tactics tactic-mode target-node context tests
+        run: .claude/skills/dispatch-propagate/scripts/test-align-tactics-target-context.sh
 
   test-integrity:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

`.claude/workflows/align-tactics.js`'s tactic-mode plan phase dropped
`target_node.rationale`, `target_node.body`, and `target_node.phase` entirely —
`buildPlanPrompt` only ever saw the bare `statement` string, so a fresh
finalize/re-plan round's plan-authoring agent never received the node's own
accumulated evidence, and `target_node.phase` (the documented finalize-vs-re-plan
discriminator) was never read anywhere in the script.

**Unit 1** — added two pure helpers, `synthesizeTargetPlanTactic` and
`tacticModeFraming`, and wired them in:

- `synthesizeTargetPlanTactic` now carries `rationale`, `body`, and `phase`
  (explicit `null` when absent) into the one-entry `planTactics` record for
  tactic mode, instead of only `id`/`statement`.
- `buildPlanPrompt` gained a `mode` parameter. In tactic mode it now serializes
  the full strategy record (not just `statement`/`success_signal`) and splices
  in `tacticModeFraming`'s FINALIZE-vs-RE-PLAN disposition prose — spliced from
  the already-authored doctrine in
  `.claude/skills/align-tactics/references/tactic-target.md`.
- `targetSummary`'s tactic-mode arm now surfaces `phase` for the reuse-hunt
  prompts.
- No SKILL or reference-doc changes — the docs already described this behavior
  correctly; only the Workflow's consumption of `target_node` was broken.

**Unit 2** — added a sentinel-slice CI probe
(`align-tactics-target-context-probe.mjs` + driver
`test-align-tactics-target-context.sh`, mirroring the existing
`align-tactics-tempref-probe.mjs` pattern) covering both new helpers, wired
unconditionally into the `hook-tests` job of `.github/workflows/unit-tests.yml`
(this file has no vitest mapping and is not covered by `run-unit-tests.sh`).

## Verification

```verify
node --check .claude/workflows/align-tactics.js
```

```verify
node .claude/skills/dispatch-propagate/scripts/align-tactics-target-context-probe.mjs
```

```verify
.claude/skills/dispatch-propagate/scripts/test-align-tactics-target-context.sh
```

```verify
.claude/skills/dispatch-propagate/scripts/test-align-tactics-tempref.sh
```

```verify
.claude/skills/dispatch-propagate/scripts/lint-prose-rules.sh
```

All five pass locally.

## Out of scope

- The assemble-phase tactic-mode branch (only emits `id`/`statement`/`body_markdown` on output — nothing consumes a widened output there).
- `PLAN_SCHEMA` (constrains only the agent's output, not this input object).
- The `driftProceed` plan gate / `buildDriftPrompt` (PR #2982's scope).
- All files under `.claude/skills/align-tactics/` (doctrine already correct).

Manual/production-observation checks (not machine-verifiable) are noted in the
node's own `## Verification` section — the real signal is the next live
`/align-tactics <tactic-id>` finalize and re-plan round.
