### PR TITLE
conflict-lane: sidecar marker + tick sweep turns a silently frozen exit-11 conflict lane into a tracked hold

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-graph-execute
@@ -233,6 +233,7 @@ for spec in "$@"; do
       # reset the Producer 1 strike counter (below) so it means "consecutive
       # failures", not a lifetime total.
       rm -f "$PROJECT_ROOT/.claude/worktrees/$id.conflict-strikes"
+      rm -f "$PROJECT_ROOT/.claude/worktrees/$id.conflict-lane"
       if "$SCRIPT_DIR/dispatch-spawn-job" --no-verify --name "$id" \
           --cwd "$WT" --model "$ORCH_MODEL" "${EFFORT_ARGS[@]}" \
           "$SKILL $id" 1>&2; then
@@ -286,6 +287,14 @@ for spec in "$@"; do
       # successful kicks accumulate into a hold whose stated reason ("could not
       # be launched for N consecutive ticks") is false.
       STRIKE_FILE="$PROJECT_ROOT/.claude/worktrees/$id.conflict-strikes"
+      # LANE_FILE: a sidecar marker, same convention as STRIKE_FILE and
+      # provision-node-worktree's own `.scope-fingerprint` — a plain file
+      # outside every checkout, so it never dirties a tree and is never a
+      # graph write. Written on a successful Lane 3 kick below so a later
+      # sweep (not part of this unit) can detect a stuck lane. Fail-open on
+      # loss: losing it just means no hold is ever raised for that episode —
+      # never a spurious one.
+      LANE_FILE="$PROJECT_ROOT/.claude/worktrees/$id.conflict-lane"
       # REAP CONTRACT: `--name "$id"` alone makes this session a graph-native
       # NODE WORKER — dispatch-stop.sh's discriminator 2 matches it (name ==
       # node id, `intentions/<id>.md` present) and hands it to
@@ -322,6 +331,11 @@ for spec in "$@"; do
           --cwd "$PROJECT_ROOT" --model "$ORCH_MODEL" \
           "/dispatch-conflict $id" 1>&2; then
         rm -f "$STRIKE_FILE"
+        # Best-effort bookkeeping only — never changes this branch's
+        # disposition (echo/continue/exit code). One fixed line so a reader
+        # can `sed -n 's/^spawned=//p' | head -n1`. Overwrite, not append: a
+        # later kick for the same node starts a new episode.
+        printf 'spawned=%s\n' "$(date -u +%s)" > "$LANE_FILE" || echo "dispatch-graph-execute: WARNING: could not write $LANE_FILE; a stuck conflict lane for $id will not be escalated" >&2
         # Hold the claim through the boot window; reservation_sweep rule (a)
         # releases it once the worker registers.
         hand_off_reservation "$id"
@@ -378,6 +392,7 @@ for spec in "$@"; do
         if "$HOLD_NODE" "$id" --kind provision-conflict \
             --reason-file "$REASON_FILE" --recommendation-file "$RECOMMENDATION_FILE"; then
           rm -f "$STRIKE_FILE"
+          rm -f "$LANE_FILE"
           echo "held $id"
         else
           echo "failed $id hold-failed"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-tick
@@ -142,6 +142,19 @@
 #      Behavior item 0.5 above) on the same two cadences as the frozen-session
 #      sweep it is paired with. Never gates the tick — a load failure logs
 #      loudly and the tick continues.
+#   5. Run the stuck conflict-lane hold sweep (conflict_lane_hold_sweep,
+#      lib-conflict-lane-hold.sh) on the same two cadences as the stand-down
+#      re-check sweep (item 3), immediately after it on both: on the paused
+#      branch (so a /dispatch-conflict Lane 3 session stuck at a
+#      `.conflict-lane` marker still surfaces to a tracked hold while dispatch
+#      is paused — that `exit 0` is the only autonomous path that never reaches
+#      dispatch-select-tick's own sweeps; no per-tick snapshot exists yet on
+#      this branch, so its registry reads fall back to live per-call queries,
+#      bounded by the marker count, which is normally zero), and on the normal
+#      path, after the per-tick daemon snapshot is captured and before Step 1
+#      target selection (so it reuses the snapshot and any node it holds is
+#      already excluded from this tick's own selection). Never gates the tick —
+#      a load failure logs loudly and the tick continues.
 #
 # The legacy gh-issue lane (explicit/pr/issue decisions →
 # dispatch-materialize-spawn → dispatch-launch-worker, and the recoverable-death
@@ -357,6 +370,25 @@ if [[ -z "$MANUAL" && -e "$DISPATCH_PAUSE_FLAG" ]]; then
     echo "dispatch-tick: lib-standdown-recheck.sh failed to load; stand-down re-check NOT run this tick" >&2
   fi
 
+  # A /dispatch-conflict Lane 3 session that died without declaring a terminal
+  # disposition (provision-conflict, .conflict-lane sidecar marker) must still
+  # surface even while dispatch is paused — the same "only autonomous path that
+  # never reaches select-tick's own sweeps" reason the sweeps above are here. On
+  # this branch no per-tick daemon snapshot exists yet (that capture happens
+  # further below, on the normal path only), so this sweep's registry reads fall
+  # back to live per-call `claude agents` queries — bounded by the marker count,
+  # which is normally zero. Same conditional-source + verify + loud-failure idiom
+  # as standdown_recheck_sweep above.
+  if ! declare -f conflict_lane_hold_sweep >/dev/null 2>&1; then
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/lib-conflict-lane-hold.sh"
+  fi
+  if declare -f conflict_lane_hold_sweep >/dev/null 2>&1; then
+    conflict_lane_hold_sweep 1>&2
+  else
+    echo "dispatch-tick: lib-conflict-lane-hold.sh failed to load; stuck conflict lanes NOT swept this tick" >&2
+  fi
+
   # A node frozen at a permission/classifier denial (tactic-denied-command-parks-node)
   # must still surface to office_hours even while dispatch is paused — this is the
   # same "only autonomous path that never reaches select-tick's own sweeps" reason
@@ -562,6 +594,24 @@ if declare -f standdown_recheck_sweep >/dev/null 2>&1; then
   standdown_recheck_sweep 1>&2
 else
   echo "dispatch-tick: lib-standdown-recheck.sh failed to load; stand-down re-check NOT run this tick" >&2
+fi
+
+# --- Stuck conflict-lane hold sweep -------------------------------------------
+# Placement matters: runs AFTER the stand-down re-check sweep above and BEFORE
+# Step 1 target selection below, for the same two reasons as the stand-down
+# sweep's own placement — it reuses this tick's daemon snapshot(s) captured
+# above instead of an extra round-trip, and any node this sweep holds lands on
+# `main` before selection runs, so this tick's own selection already excludes
+# it. Same conditional-source + verify + loud-failure idiom as the paused-branch
+# call above.
+if ! declare -f conflict_lane_hold_sweep >/dev/null 2>&1; then
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/lib-conflict-lane-hold.sh"
+fi
+if declare -f conflict_lane_hold_sweep >/dev/null 2>&1; then
+  conflict_lane_hold_sweep 1>&2
+else
+  echo "dispatch-tick: lib-conflict-lane-hold.sh failed to load; stuck conflict lanes NOT swept this tick" >&2
 fi
 
 # --- Frozen-session sweep (denied-command park, tactic-denied-command-parks-node) ---

--- a/.claude/skills/dispatch-propagate/scripts/lib-conflict-lane-hold.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-conflict-lane-hold.sh
@@ -1,0 +1,449 @@
+#!/usr/bin/env bash
+# lib-conflict-lane-hold.sh — the stuck-conflict-lane detection sweep: turns a
+# /dispatch-conflict Lane 3 session that died without declaring a terminal
+# disposition into a tracked, human-visible hold.
+#
+# The failure this closes: a node's branch does not merge clean against
+# origin/main (provision exit 11), so dispatch-graph-execute kicks a Lane 3
+# `/dispatch-conflict <id>` session to resolve it and drops a
+# `.claude/worktrees/<id>.conflict-lane` sidecar marker recording the episode.
+# Lane 3 is spawned as a graph-native NODE WORKER (`--name <id>`), so
+# dispatch-stop.sh hands it to `dispatch-self-close --node <id>`, which reaps the
+# job ONLY on a `$CLAUDE_JOB_DIR/node-terminal` marker naming that node. When the
+# session dies WITHOUT writing that marker — a crash, an API error, an exhausted
+# context — nothing ever reaps it: the job stays HELD in the daemon's registry
+# forever, `worktree_has_live_session` reports the worktree permanently occupied
+# (no timeout, by design), and the node is silently unselectable forever with
+# NOTHING recorded in the graph. The conflict is unresolved and no autonomous
+# path will ever retry it.
+#
+# This sweep is the detection half. It periodically re-checks each
+# `.conflict-lane` marker against the `--all` session registry and, when the
+# lane's session is DEFINITELY terminal-but-unreaped and has been idle past a
+# grace, raises a tracked HOLD via `hold-node --kind provision-conflict`. The
+# hold is a small born-parked hold tactic plus a `blocked_by` edge from the
+# source — the source's own `office_hours` is NEVER written here (doctrine:
+# a mechanical retry state is not "no autonomous path exists").
+#
+# It never reaps a session itself. `claude rm` is the human's act — it deletes
+# the session AND may strand work — so the hold's recommendation names it and
+# this sweep never runs it.
+#
+# Usage: source this file, then call:
+#   conflict_lane_hold_sweep
+#
+# conflict_lane_hold_sweep
+#   No arguments. Containment/observability only — it is NEVER a gate, so it
+#   ALWAYS returns 0, on every path including an unresolvable main worktree, an
+#   unqueryable daemon, an unreadable transcript, and a failed `hold-node`.
+#   Every disposition is one greppable stderr line per node per pass, and the
+#   sweep ends with EXACTLY ONE summary line.
+#     return 0 — ALWAYS.
+#
+#   Step 1 — resolve the sidecar dir: `<resolve_main_worktree>/.claude/worktrees`
+#   (the SAME resolver dispatch-graph-execute uses, so producer and sweep agree
+#   on the root byte-for-byte), or DISPATCH_CONFLICT_LANE_ROOT verbatim when set.
+#
+#   Step 2 — enumerate `*.conflict-lane` files there (dotfiles and `.tmp*`
+#   skipped, exactly as reservation_sweep does). ZERO candidates emits the
+#   summary and returns WITHOUT ANY DAEMON QUERY: the common case must cost
+#   nothing, since this runs on every tick.
+#
+#   Step 3 — per candidate, this rule ladder IN THIS EXACT ORDER; each branch
+#   logs one line and moves to the next candidate:
+#     a. marker basename (minus the suffix) fails the node-id regex →
+#        `unsafe-id`, keep the file, next. It would otherwise become a path
+#        component and a `hold-node` argument.
+#     b. `claude_sessions_with_name_all <id>` returns non-zero → UNKNOWN →
+#        `daemon unqueryable; observing <id>`, next. UNKNOWN NEVER escalates and
+#        NEVER garbage-collects.
+#     c. zero registry rows → the lane's session was reaped (resolved normally,
+#        or already `claude rm`'d). GC the marker, but ONLY once the marker's own
+#        age has passed the grace: a younger marker with no row yet is the
+#        spawn/registration lag window, and dropping it there would lose the
+#        episode.
+#     d. any row reporting `live` or `unknown` → `observing`, next. The lane is
+#        (or may be) still working.
+#     e. all rows `stopped` → candidate; the NEWEST such sid (registry order,
+#        last wins) is the reported holder.
+#     f. transcript idle time under the grace → `observing`, next. An
+#        UNMEASURABLE idle (no transcript, unreadable mtime) is UNKNOWN → keep:
+#        never escalate without positive evidence of staleness.
+#     g. the hold cap for this pass is spent → `deferring`, keep, next.
+#     h. otherwise HOLD via `hold-node <id> --kind provision-conflict`. On exit 0
+#        the marker is removed (one hold per episode); on ANY non-zero exit the
+#        marker is KEPT and the next pass retries. A failed hold is never fatal.
+#     i. every candidate that reached (h) — held OR hold-failed — appends one
+#        best-effort JSONL decision record.
+#
+#   The hold reuses the EXISTING `provision-conflict` kind (the same kind
+#   dispatch-graph-execute's exit-11 strike-cap backstop raises); no new hold
+#   kind is introduced, and the hold id remains a valid /dispatch-conflict Lane 3
+#   entry point for the human draining it.
+#
+# Environment overrides (all optional; each integer-valued one is
+# integer-guarded, falling back to its default on a malformed value):
+#   DISPATCH_CONFLICT_LANE_ROOT          Sidecar directory. When set it is used
+#                                        VERBATIM (no main-worktree resolution).
+#                                        Default: <main-worktree>/.claude/worktrees.
+#   DISPATCH_CONFLICT_LANE_NOW_EPOCH     Pinned clock (epoch seconds) for the
+#                                        marker-age and idle math.
+#                                        Default: `date -u +%s`.
+#   DISPATCH_CONFLICT_LANE_GRACE_S       Idle/age grace, seconds. Default: 1800.
+#   DISPATCH_CONFLICT_LANE_HOLD_MAX      Maximum holds per invocation. Default: 3.
+#                                        `hold-node` pushes to main through
+#                                        graph-commit's landing lock, so an
+#                                        unbounded batch would serialize N pushes
+#                                        inside one tick; the excess is deferred.
+#   DISPATCH_CONFLICT_LANE_PROJECTS_ROOT Transcript store root (mirrors
+#                                        DISPATCH_RECLAIM_PROJECTS_ROOT).
+#                                        Default: $HOME/.claude/projects.
+#   DISPATCH_CONFLICT_LANE_HOLD_NODE     hold-node path. Default:
+#                                        <main-worktree>/packages/intentionsutil/
+#                                        scripts/hold-node. It MUST be the copy
+#                                        under the main worktree: hold-node
+#                                        derives its own REPO_ROOT from its
+#                                        script path.
+# Respected via the libraries this file sources, NOT redefined here:
+#   DISPATCH_GRAPH_MAIN_WORKTREE      lib-graph-worktree.sh — main-worktree override.
+#   CLAUDE_AGENTS_CMD                 lib-claude-agents.sh — replaces the
+#                                     `claude` invocation (testable, no daemon).
+#   DISPATCH_DECISION_LOG_DIR / _FILE lib-decision-log.sh — the JSONL sink.
+#
+# Sandbox: the liveness queries reach the local Claude daemon over a Unix
+# socket, so callers must run this with `dangerouslyDisableSandbox: true` — see
+# `.claude/rules/sandbox.md`. A sandboxed call yields `[]`, a definite "no
+# sessions", which would GC markers rather than escalate them.
+#
+# Safe to source multiple times. Does NOT use set -e (must return, not exit).
+#
+# Side effect: sourcing this file once sets `-u` and `-o pipefail` in the caller
+# shell (via its own load-guard, and transitively via the siblings below).
+
+# Source siblings via BASH_SOURCE dirname, matching lib-standdown-recheck.sh.
+# lib-graph-worktree.sh is plain function definitions; lib-claude-agents.sh is
+# load-guarded. lib-decision-log.sh is sourced non-fatally — its log is a
+# best-effort observability sink, exactly as dispatch-select-tick sources it.
+_lclh_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib-claude-agents.sh
+source "$_lclh_dir/lib-claude-agents.sh"
+# shellcheck source=lib-graph-worktree.sh
+source "$_lclh_dir/lib-graph-worktree.sh"
+# shellcheck source=/dev/null
+source "$_lclh_dir/lib-decision-log.sh" 2>/dev/null || true
+
+if [[ -z "${_LIB_CONFLICT_LANE_HOLD_LOADED:-}" ]]; then
+  _LIB_CONFLICT_LANE_HOLD_LOADED=1
+
+  set -uo pipefail
+
+  # _conflict_lane_idle_s <sid> <now> <projects-root> — print the session's
+  # transcript idle time in seconds. The transcript lives at
+  # <projects-root>/<project>/<sid>.jsonl — keyed on the globally-unique session
+  # id, so the project-dir slug (a mangling of the session's cwd) never has to be
+  # reconstructed. Takes the NEWEST mtime across matches. No match, or an
+  # unreadable mtime, is UNKNOWN: return 1 with no output, which the caller
+  # treats as "keep, do not escalate". Shape copied from
+  # lib-standdown-recheck.sh's _standdown_session_idle_s.
+  _conflict_lane_idle_s() {
+    local sid="${1:-}" now="${2:-}" projects_root="${3:-}"
+    [[ -n "$sid" && -n "$projects_root" ]] || return 1
+    # The sid feeds a `find -name` glob; validate its shape at this edge (input
+    # validation at a system boundary).
+    [[ "$sid" =~ ^[0-9a-fA-F-]+$ ]] || return 1
+    local matches transcript best="" cur
+    matches=$(find "$projects_root" -mindepth 2 -maxdepth 2 -name "${sid}.jsonl" 2>/dev/null)
+    [[ -n "$matches" ]] || return 1
+    while IFS= read -r transcript; do
+      [[ -n "$transcript" ]] || continue
+      cur=$(stat -c %Y "$transcript" 2>/dev/null) || continue
+      [[ "$cur" =~ ^[0-9]+$ ]] || continue
+      if [[ -z "$best" ]] || (( cur > best )); then
+        best="$cur"
+      fi
+    done <<<"$matches"
+    [[ -n "$best" ]] || return 1
+    printf '%s\n' $(( now - best ))
+    return 0
+  }
+
+  # _conflict_lane_log_decision <node> <session> <state> <idle> <disposition> —
+  # append one best-effort JSONL decision record. Mirrors
+  # lib-standdown-recheck.sh's _standdown_log_decision and dispatch-select-tick's
+  # _dlog_select_emit: build with `jq -c -n`, hand to `decision_log_append`
+  # behind a `command -v` guard, never fail the caller.
+  _conflict_lane_log_decision() {
+    local node="$1" session="$2" state="$3" idle="$4" disposition="$5"
+    local json
+    json=$(jq -c -n \
+      --arg ts          "$(date -u +%FT%TZ)" \
+      --arg site        "conflict-lane-hold" \
+      --arg node        "$node" \
+      --arg session     "$session" \
+      --arg state       "$state" \
+      --arg idle        "$idle" \
+      --arg disposition "$disposition" \
+      '
+      {
+        ts:           $ts,
+        site:         $site,
+        node:         $node,
+        session:      $session,
+        state:        $state,
+        idle_seconds: (try ($idle | tonumber) catch null),
+        disposition:  $disposition
+      }' 2>/dev/null) || return 0
+    command -v decision_log_append >/dev/null 2>&1 && decision_log_append "$json" || true
+    return 0
+  }
+
+  # conflict_lane_hold_sweep — see the header comment for the full rule ladder
+  # and the fail-safe posture. ALWAYS returns 0.
+  conflict_lane_hold_sweep() {
+    local markers=0 held_count=0 observing=0 cleared=0 deferred=0
+
+    # --- tunables, computed ONCE ---------------------------------------------
+    local now
+    if [[ "${DISPATCH_CONFLICT_LANE_NOW_EPOCH:-}" =~ ^[0-9]+$ ]]; then
+      now="$DISPATCH_CONFLICT_LANE_NOW_EPOCH"
+    else
+      now=$(date -u +%s)
+    fi
+    local grace="${DISPATCH_CONFLICT_LANE_GRACE_S:-1800}"
+    [[ "$grace" =~ ^[0-9]+$ ]] || grace=1800
+    local hold_max="${DISPATCH_CONFLICT_LANE_HOLD_MAX:-3}"
+    [[ "$hold_max" =~ ^[0-9]+$ ]] || hold_max=3
+    local projects_root="${DISPATCH_CONFLICT_LANE_PROJECTS_ROOT:-$HOME/.claude/projects}"
+
+    # --- Step 1: the sidecar dir ---------------------------------------------
+    # resolve_main_worktree is the resolver dispatch-graph-execute's PROJECT_ROOT
+    # comes from, so the producer's marker path and this consumer's scan path are
+    # the same bytes. Its `git worktree list` stderr is suppressed: an
+    # unresolvable root is reported by this file's own line, not git's.
+    local main_wt=""
+    main_wt=$(resolve_main_worktree 2>/dev/null) || main_wt=""
+
+    local dir=""
+    if [[ -n "${DISPATCH_CONFLICT_LANE_ROOT:-}" ]]; then
+      dir="$DISPATCH_CONFLICT_LANE_ROOT"
+    elif [[ -n "$main_wt" ]]; then
+      dir="$main_wt/.claude/worktrees"
+    else
+      printf 'lib-conflict-lane-hold: main worktree unresolvable and DISPATCH_CONFLICT_LANE_ROOT unset; escalating nothing\n' >&2
+      printf 'lib-conflict-lane-hold: swept %s marker(s): %s held, %s observing, %s cleared, %s deferred\n' \
+        "$markers" "$held_count" "$observing" "$cleared" "$deferred" >&2
+      return 0
+    fi
+
+    local hold_node="${DISPATCH_CONFLICT_LANE_HOLD_NODE:-$main_wt/packages/intentionsutil/scripts/hold-node}"
+
+    # --- Step 2: enumerate candidates ----------------------------------------
+    # Collected BEFORE any daemon query so the zero-marker case — the common one,
+    # on every tick — costs nothing.
+    local candidates=() f bn
+    if [[ -d "$dir" ]]; then
+      local had_nullglob=0
+      shopt -q nullglob && had_nullglob=1
+      shopt -s nullglob
+      for f in "$dir"/*.conflict-lane; do
+        # Regular files directly in the dir only. The default glob already
+        # excludes dot-prefixed in-flight tempfiles; the explicit `.tmp` test
+        # covers any non-dot variant (reservation_sweep's convention).
+        [[ -f "$f" ]] || continue
+        bn=$(basename "$f")
+        case "$bn" in .*|*.tmp*) continue ;; esac
+        candidates+=("$f")
+      done
+      (( had_nullglob )) || shopt -u nullglob
+    fi
+
+    if (( ${#candidates[@]} == 0 )); then
+      printf 'lib-conflict-lane-hold: swept %s marker(s): %s held, %s observing, %s cleared, %s deferred\n' \
+        "$markers" "$held_count" "$observing" "$cleared" "$deferred" >&2
+      return 0
+    fi
+
+    # --- Step 3: the rule ladder, per candidate -------------------------------
+    local id rows line rest sid state
+    for f in "${candidates[@]}"; do
+      markers=$(( markers + 1 ))
+      bn=$(basename "$f")
+      id="${bn%.conflict-lane}"
+
+      # (a) The id becomes a `hold-node` argument and a path component below, so
+      # validate its shape at this edge with the SAME node-id regex
+      # dispatch-graph-execute applies before provisioning. The marker is KEPT: a
+      # human should see it.
+      if [[ ! "$id" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]]; then
+        printf 'lib-conflict-lane-hold: unsafe-id %s (marker name is not a valid node id); keeping marker, taking no action\n' "$id" >&2
+        continue
+      fi
+
+      # (b) The REGISTERED (`--all`) view for this name. A stopped-but-not-`claude
+      # rm`'d session is invisible to the default active-only listing, and that is
+      # precisely the session this sweep exists to find. Non-zero is UNKNOWN.
+      if ! rows=$(claude_sessions_with_name_all "$id"); then
+        observing=$(( observing + 1 ))
+        printf 'lib-conflict-lane-hold: daemon unqueryable; observing %s (taking no action this pass)\n' "$id" >&2
+        continue
+      fi
+
+      # Split the TSV BY HAND. `IFS=$'\t' read -r sid state ...` cannot be used:
+      # TAB is IFS whitespace, so bash collapses a RUN of tabs into one delimiter
+      # and an empty middle column (the daemon reports `state: null` for some
+      # rows, which `@tsv` renders empty) would shift every field left.
+      local sids=() row_states=()
+      if [[ -n "$rows" ]]; then
+        while IFS= read -r line; do
+          [[ -n "$line" ]] || continue
+          sid="${line%%$'\t'*}"
+          rest="${line#*$'\t'}"
+          state="${rest%%$'\t'*}"
+          [[ -n "$sid" ]] || continue
+          sids+=("$sid")
+          row_states+=("$state")
+        done <<<"$rows"
+      fi
+
+      # (c) No registry row at all: the lane's session was reaped — it resolved
+      # normally, or a human already `claude rm`'d it. GC the marker, but only
+      # once its own age has passed the grace: between the spawn and the daemon
+      # registering the job there is a window with a marker and no row, and
+      # dropping the marker there would lose the episode.
+      if (( ${#sids[@]} == 0 )); then
+        local spawned age_s=""
+        spawned=$(sed -n 's/^spawned=//p' "$f" 2>/dev/null | head -n1)
+        if [[ "$spawned" =~ ^[0-9]+$ ]]; then
+          age_s=$(( now - spawned ))
+        fi
+        if [[ -n "$age_s" ]] && (( age_s >= grace )); then
+          rm -f "$f" 2>/dev/null || true
+          cleared=$(( cleared + 1 ))
+          printf 'lib-conflict-lane-hold: cleared %s (no registry row; marker age %ss >= grace %ss — the lane session was reaped)\n' \
+            "$id" "$age_s" "$grace" >&2
+        else
+          observing=$(( observing + 1 ))
+          printf 'lib-conflict-lane-hold: observing %s (awaiting registration; no registry row yet, marker age %ss < grace %ss)\n' \
+            "$id" "${age_s:-unmeasurable}" "$grace" >&2
+        fi
+        continue
+      fi
+
+      # (d)/(e) Resolve every row's granular liveness. ANY row reporting `live`
+      # or `unknown` means the lane may still be working — observe. Only when
+      # EVERY row is definitely `stopped` is the episode a candidate, and the
+      # NEWEST such sid (registry order, last wins) is the reported holder.
+      local i newest_stopped="" newest_state="" nonterminal_sid="" nonterminal_state=""
+      for (( i = 0; i < ${#sids[@]}; i++ )); do
+        sid="${sids[$i]}"
+        claude_session_id_is_live "$sid" >/dev/null 2>&1 || true
+        state="$CLAUDE_SESSION_ID_LIVE_STATE"
+        case "$state" in
+          stopped)
+            newest_stopped="$sid"
+            newest_state="${row_states[$i]:-$state}"
+            ;;
+          absent)
+            # A row the name query returned that the id query cannot find: a
+            # race against a concurrent `claude rm`. Not a stopped holder, and
+            # not evidence of life either — it simply contributes nothing.
+            :
+            ;;
+          *)
+            # live | unknown — fail safe.
+            nonterminal_sid="$sid"
+            nonterminal_state="$state"
+            ;;
+        esac
+      done
+
+      if [[ -n "$nonterminal_sid" ]]; then
+        observing=$(( observing + 1 ))
+        printf 'lib-conflict-lane-hold: observing %s (session %s state=%s)\n' \
+          "$id" "$nonterminal_sid" "$nonterminal_state" >&2
+        continue
+      fi
+
+      if [[ -z "$newest_stopped" ]]; then
+        # Every row resolved `absent` — no holder to name, nothing to escalate.
+        observing=$(( observing + 1 ))
+        printf 'lib-conflict-lane-hold: observing %s (registry rows resolved absent; no stopped holder to report)\n' "$id" >&2
+        continue
+      fi
+
+      sid="$newest_stopped"
+      state="${newest_state:-stopped}"
+
+      # (f) Idle grace. An UNMEASURABLE idle is UNKNOWN → keep. This sweep never
+      # escalates without POSITIVE evidence of staleness.
+      local idle
+      if ! idle=$(_conflict_lane_idle_s "$sid" "$now" "$projects_root"); then
+        observing=$(( observing + 1 ))
+        printf 'lib-conflict-lane-hold: keeping %s (transcript unreadable — idle time unmeasurable for session %s)\n' \
+          "$id" "$sid" >&2
+        continue
+      fi
+      if (( idle < grace )); then
+        observing=$(( observing + 1 ))
+        printf 'lib-conflict-lane-hold: observing %s (session %s idle_seconds=%s < grace_seconds=%s)\n' \
+          "$id" "$sid" "$idle" "$grace" >&2
+        continue
+      fi
+
+      # (g) Cap. Excess candidates wait for the next pass rather than serializing
+      # N graph-commit landing-lock pushes inside this one.
+      if (( held_count >= hold_max )); then
+        deferred=$(( deferred + 1 ))
+        printf 'lib-conflict-lane-hold: deferring %s (hold cap %s reached this sweep)\n' "$id" "$hold_max" >&2
+        continue
+      fi
+
+      # (h) The hold. Reason and recommendation are FILES (hold-node's
+      # interface), written into a per-candidate tempdir that is removed
+      # immediately after the call.
+      local tmpd
+      if ! tmpd=$(mktemp -d 2>/dev/null); then
+        printf 'lib-conflict-lane-hold: hold failed for %s (mktemp -d failed); keeping marker, will retry next tick\n' "$id" >&2
+        continue
+      fi
+
+      local reason recommendation
+      printf -v reason \
+        "This tactic's branch did not merge clean (provision exit 11) and the /dispatch-conflict Lane 3 session dispatched to resolve it has stopped without declaring a terminal disposition: 'claude agents --json --all' reports session %s for '%s' in state %s, its transcript has had no activity for %ss, and no node-terminal marker was written — so dispatch-self-close held the job instead of reaping it. A registered session keeps claiming its node by design, so '%s' is skipped by every selection tick until that job is removed by hand: the conflict is unresolved and nothing autonomous will retry it." \
+        "$sid" "$id" "$state" "$idle" "$id"
+      printf -v recommendation \
+        "First release the node: 'claude rm %s'. A stopped-but-not-removed session keeps blocking its node by design and nothing autonomous reaps it. If the session's transcript holds work worth keeping, attach it first ('claude attach %s'). Then resolve the conflict: run '/dispatch-conflict %s' by hand (Lane 3 reproduces and resolves the merge on the node's own branch; it merges origin/%s before reproducing the origin/main merge, which covers both causes of exit 11), or resolve it directly in .claude/worktrees/%s and push the branch. Then resolve THIS HOLD TACTIC to 'phase: done' and prune it — clearing 'office_hours' alone does not unblock the source. 'resolve-hold %s --kind provision-conflict' does the resolve and the source's blocked_by clear in one landed write." \
+        "$sid" "$sid" "$id" "$id" "$id" "$id"
+
+      printf '%s\n' "$reason" > "$tmpd/reason.txt"
+      printf '%s\n' "$recommendation" > "$tmpd/recommendation.txt"
+
+      local rc=0
+      "$hold_node" "$id" --kind provision-conflict \
+        --reason-file "$tmpd/reason.txt" \
+        --recommendation-file "$tmpd/recommendation.txt" >/dev/null || rc=$?
+      rm -rf "$tmpd" 2>/dev/null || true
+
+      if (( rc == 0 )); then
+        # One hold per episode: the marker is the episode record, and the hold
+        # now carries it.
+        rm -f "$f" 2>/dev/null || true
+        held_count=$(( held_count + 1 ))
+        printf 'lib-conflict-lane-hold: held %s (stuck conflict lane, idle %ss, session %s)\n' "$id" "$idle" "$sid" >&2
+        # (i)
+        _conflict_lane_log_decision "$id" "$sid" "$state" "$idle" "held"
+      else
+        # A hold failure is never fatal to the sweep or the tick: log it, KEEP
+        # the marker so the next pass retries, and move on.
+        printf 'lib-conflict-lane-hold: hold failed for %s (hold-node exit %s); will retry next tick\n' "$id" "$rc" >&2
+        # (i)
+        _conflict_lane_log_decision "$id" "$sid" "$state" "$idle" "hold-failed"
+      fi
+    done
+
+    printf 'lib-conflict-lane-hold: swept %s marker(s): %s held, %s observing, %s cleared, %s deferred\n' \
+      "$markers" "$held_count" "$observing" "$cleared" "$deferred" >&2
+    return 0
+  }
+
+fi

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-graph-execute.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-graph-execute.sh
@@ -37,6 +37,23 @@ assert_not_contains() {  # $1 = label, $2 = needle, $3 = haystack
   fi
 }
 
+# assert_lane_file_fresh <label> <file> — the .conflict-lane sidecar contains
+# exactly one line matching ^spawned=[0-9]+$.
+assert_lane_file_fresh() {  # $1 = label, $2 = file
+  local label="$1" file="$2"
+  TOTAL=$((TOTAL + 1))
+  if [[ -f "$file" ]] && [[ "$(wc -l < "$file" | tr -d ' ')" == "1" ]] \
+      && grep -Eq '^spawned=[0-9]+$' "$file"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $label"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $label"
+    echo "    expected a single line matching ^spawned=[0-9]+\$"
+    echo "    actual: $([[ -f "$file" ]] && cat "$file" || echo '(file missing)')"
+  fi
+}
+
 # --- harness ----------------------------------------------------------------
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
@@ -236,16 +253,25 @@ assert_contains "conflict-lane handoff preserves the selection session=" "sessio
   "$(cat "$RES_DIR/tactic-c")"
 assert_contains "conflict-lane handoff preserves the selection issue=" "issue=tactic-c" \
   "$(cat "$RES_DIR/tactic-c")"
+# A successful kick writes the .conflict-lane sidecar marker: one fixed
+# `spawned=<epoch>` line so a later sweep can detect a stuck lane.
+assert_lane_file_fresh "conflict-lane writes the .conflict-lane sidecar marker" \
+  "$MAIN_WT/.claude/worktrees/tactic-c.conflict-lane"
 
 # A successful kick must also CLEAR a strike file left by earlier failed kicks:
 # the backstop's counter means "consecutive failures to launch the lane", which
 # is what its hold reason asserts.
 printf '%s\n' "3" > "$MAIN_WT/.claude/worktrees/tactic-c.conflict-strikes"
 printf 'session=headless:c\nissue=tactic-c\ntimestamp=2026-01-01T00:00:00Z\n' > "$RES_DIR/tactic-c"
+# Seed a stale .conflict-lane marker from a prior episode — a second kick must
+# OVERWRITE it, not append to it.
+printf 'spawned=1111111111\nstale-garbage-from-a-prior-episode\n' > "$MAIN_WT/.claude/worktrees/tactic-c.conflict-lane"
 PROV_RC=11 run_exec "tactic-c:tactic:qa"
 assert_eq "conflict-lane stdout after prior strikes" "conflict-lane tactic-c" "$OUT"
 assert_eq "a successful kick resets the strike counter" "gone" \
   "$([ -e "$MAIN_WT/.claude/worktrees/tactic-c.conflict-strikes" ] && echo present || echo gone)"
+assert_lane_file_fresh "a second kick overwrites (not appends to) the .conflict-lane marker" \
+  "$MAIN_WT/.claude/worktrees/tactic-c.conflict-lane"
 
 # ============================================================================
 # Case 5b: the strike-then-hold ladder survives as the BACKSTOP for the case
@@ -269,7 +295,12 @@ for n in 1 2 3 4; do
   assert_eq "accumulate strike $n leaves the reservation marker" "present" \
     "$([ -e "$RES_DIR/tactic-acc" ] && echo present || echo gone)"
 done
-# 5th run: strikes reach the cap -> escalate to hold-node.
+# 5th run: strikes reach the cap -> escalate to hold-node. Pre-seed a
+# .conflict-lane marker from an earlier successful (but never-resolved) lane
+# kick — the backstop hold success must clear it too, since the launch-failure
+# ladder already raised the hold for this node and the marker would only
+# produce a second escalation for the same state.
+printf 'spawned=1111111111\n' > "$MAIN_WT/.claude/worktrees/tactic-acc.conflict-lane"
 PROV_RC=11 SPAWN_RC=1 run_exec "tactic-acc:tactic:qa"
 assert_eq "cap-th run stdout" "held tactic-acc" "$OUT"
 assert_eq "cap-th run exit 0" "0" "$RC"
@@ -281,15 +312,22 @@ assert_contains "cap-th run calls hold-node with --kind provision-conflict" \
 assert_eq "cap-th run makes no park-node write" "" "$(cat "$PARK_LOG")"
 assert_eq "cap-th run clears the strike sidecar" "gone" \
   "$([ -e "$MAIN_WT/.claude/worktrees/tactic-acc.conflict-strikes" ] && echo present || echo gone)"
+assert_eq "cap-th run's backstop hold success clears the .conflict-lane marker" "gone" \
+  "$([ -e "$MAIN_WT/.claude/worktrees/tactic-acc.conflict-lane" ] && echo present || echo gone)"
 
 # ============================================================================
 # Case 5c: exit 0 (successful provision) clears the strike sidecar file
 # ============================================================================
 echo "Case 5c: exit 0 clears any accumulated strike sidecar"
 printf '%s\n' "3" > "$MAIN_WT/.claude/worktrees/tactic-clr.conflict-strikes"
+# A successful provision means any prior merge-conflict retry state
+# self-resolved — pre-seed a .conflict-lane marker from an earlier episode too.
+printf 'spawned=1111111111\n' > "$MAIN_WT/.claude/worktrees/tactic-clr.conflict-lane"
 run_exec "tactic-clr:tactic:implement"
 assert_eq "exit-0 clears sidecar" "gone" \
   "$([ -e "$MAIN_WT/.claude/worktrees/tactic-clr.conflict-strikes" ] && echo present || echo gone)"
+assert_eq "exit-0 clears the .conflict-lane marker" "gone" \
+  "$([ -e "$MAIN_WT/.claude/worktrees/tactic-clr.conflict-lane" ] && echo present || echo gone)"
 
 # ============================================================================
 # Case 6: provision exit 12 -> skipped, reservation cleared, no spawn
@@ -333,6 +371,10 @@ assert_contains "prov-error parks the node" "tactic-e" "$(cat "$PARK_LOG")"
 # office_hours is never written by this producer.
 # ============================================================================
 echo "Case 8b: provision exit 14 -> held via a worktree-residue hold, first occurrence"
+# Exit 14 must not acquire .conflict-lane marker semantics it does not own —
+# pre-seed one and assert it is untouched (still present, unchanged content)
+# after the run.
+printf 'spawned=1111111111\n' > "$MAIN_WT/.claude/worktrees/tactic-res.conflict-lane"
 PROV_RC=14 run_exec "tactic-res:tactic:qa"
 HOLD=$(cat "$HOLD_LOG")
 assert_eq "residue stdout" "held tactic-res worktree-residue" "$OUT"
@@ -341,6 +383,8 @@ assert_eq "residue spawns nothing" "" "$(cat "$SPAWN_LOG")"
 assert_eq "residue makes no park-node write" "" "$(cat "$PARK_LOG")"
 assert_contains "residue calls hold-node with --kind worktree-residue" \
   "tactic-res --kind worktree-residue" "$HOLD"
+assert_eq "exit 14 leaves the .conflict-lane marker untouched" "spawned=1111111111" \
+  "$(cat "$MAIN_WT/.claude/worktrees/tactic-res.conflict-lane")"
 
 # ============================================================================
 # Case 8c: exit 14 where hold-node itself fails -> failed, exit 1

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-tick.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-tick.sh
@@ -61,6 +61,19 @@ tick_setup() {
   # lib-frozen-session-park.sh also sources lib-decision-log.sh non-fatally at
   # load time (best-effort decision-log sink); the stand-down block above
   # already copies it, so a single copy serves both sweeps.
+  # lib-conflict-lane-hold.sh (Unit 3 wiring) and its own sourced sibling
+  # lib-graph-worktree.sh, so the tick's paused-branch and normal-path
+  # conflict_lane_hold_sweep calls genuinely run instead of source-failing.
+  # lib-claude-agents.sh and lib-decision-log.sh are already copied above.
+  cp "$SCRIPT_DIR/lib-conflict-lane-hold.sh" "$TMPDIR_TEST/lib-conflict-lane-hold.sh"
+  cp "$SCRIPT_DIR/lib-graph-worktree.sh" "$TMPDIR_TEST/lib-graph-worktree.sh"
+  # Point the sweep at an empty scratch marker dir, used VERBATIM (no
+  # main-worktree resolution needed) so the sweep finds zero `.conflict-lane`
+  # candidates and simply logs its one-line "swept 0 marker(s)" summary —
+  # sufficient to assert invocation, and it costs no daemon query per the
+  # library's own zero-candidate fast path.
+  export DISPATCH_CONFLICT_LANE_ROOT="$TMPDIR_TEST/conflict-lanes"
+  mkdir -p "$DISPATCH_CONFLICT_LANE_ROOT"
   chmod +x "$TMPDIR_TEST/dispatch-tick"
   # Pin the canonical main worktree so the advisory diagnose-main / jit-reminder
   # spawns get a deterministic --cwd independent of the host repo layout and the
@@ -196,7 +209,8 @@ tick_teardown() {
     DISPATCH_STANDDOWN_DIR DISPATCH_STANDDOWN_REPO_ROOT \
     DISPATCH_FROZEN_SESSION_PROJECTS_ROOT DISPATCH_FROZEN_SESSION_REPO_ROOT \
     DISPATCH_FROZEN_SESSION_PARK_NODE \
-    DISPATCH_FROZEN_SESSION_NOW_EPOCH TICK_PARK_NODE_RC
+    DISPATCH_FROZEN_SESSION_NOW_EPOCH TICK_PARK_NODE_RC \
+    DISPATCH_CONFLICT_LANE_ROOT
   export DISPATCH_DECISION_LOG_DIR="$DISPATCH_TEST_DECISION_LOG_DIR"
 }
 
@@ -871,6 +885,67 @@ err=$("$TMPDIR_TEST/dispatch-tick" 2>&1 1>/dev/null) && rc=0 || rc=$?
 assert_eq "standdown-load-fail-normal: tick still exits 0" "0" "$rc"
 assert_eq "standdown-load-fail-normal: loud diagnostic on stderr" "1" \
   "$(printf '%s' "$err" | grep -qF 'lib-standdown-recheck.sh failed to load; stand-down re-check NOT run this tick' && echo 1 || echo 0)"
+tick_teardown
+
+# --- Unit 3 (tick wiring): conflict_lane_hold_sweep wiring --------------------
+# Both call sites run the REAL conflict_lane_hold_sweep (lib-conflict-lane-hold.sh,
+# copied into TMPDIR_TEST by tick_setup) against an empty scratch marker dir
+# (DISPATCH_CONFLICT_LANE_ROOT), so the sweep finds zero `.conflict-lane`
+# candidates and emits its one-line "swept 0 marker(s)" summary to stderr —
+# sufficient to assert invocation, same posture as the standdown_recheck_sweep
+# tests above. The normal-path placement (immediately after
+# standdown_recheck_sweep, before Step 1's dispatch-select-tick) was verified by
+# code inspection when the call was inserted, not by an ordering assertion here:
+# unlike the frozen-session sweep, this sweep's zero-candidate fast path writes
+# nothing to order.log, so there is no observable ordering signal to assert
+# against — only invocation (exactly once) is asserted, mirroring the sibling
+# standdown_recheck_sweep tests' documented limitation.
+
+echo "Test: dispatch-tick paused branch invokes conflict_lane_hold_sweep"
+tick_setup
+: > "$TMPDIR_TEST/paused"
+export TICK_DECISION="empty"
+err=$("$TMPDIR_TEST/dispatch-tick" 2>&1 1>/dev/null) && rc=0 || rc=$?
+assert_eq "paused-conflict-lane: exit 0" "0" "$rc"
+assert_eq "paused-conflict-lane: conflict_lane_hold_sweep ran exactly once (swept-summary line on stderr)" "1" \
+  "$(printf '%s' "$err" | grep -cF 'lib-conflict-lane-hold: swept 0 marker(s)')"
+tick_teardown
+
+echo "Test: dispatch-tick normal path invokes conflict_lane_hold_sweep exactly once, before dispatch-select-tick"
+tick_setup
+export TICK_DECISION="empty"
+err=$("$TMPDIR_TEST/dispatch-tick" 2>&1 1>/dev/null) && rc=0 || rc=$?
+assert_eq "normal-conflict-lane: exit 0" "0" "$rc"
+assert_eq "normal-conflict-lane: conflict_lane_hold_sweep ran exactly once (swept-summary line on stderr)" "1" \
+  "$(printf '%s' "$err" | grep -cF 'lib-conflict-lane-hold: swept 0 marker(s)')"
+tick_teardown
+
+# --- lib-conflict-lane-hold.sh fails to load → loud diagnostic, tick still ----
+# completes. Replace the copied lib with an unsourceable file (invalid bash
+# syntax) so `declare -f conflict_lane_hold_sweep` comes back false on both call
+# sites. Both must log the loud diagnostic and the tick must still complete
+# (exit 0) rather than abort.
+echo "Test: dispatch-tick lib-conflict-lane-hold.sh load failure → loud diagnostic, tick still completes (paused)"
+tick_setup
+printf 'this is not valid bash ((( \n' > "$TMPDIR_TEST/lib-conflict-lane-hold.sh"
+: > "$TMPDIR_TEST/paused"
+export TICK_DECISION="empty"
+err=$("$TMPDIR_TEST/dispatch-tick" 2>&1 1>/dev/null) && rc=0 || rc=$?
+assert_eq "conflict-lane-load-fail-paused: tick still exits 0" "0" "$rc"
+assert_eq "conflict-lane-load-fail-paused: loud diagnostic on stderr" "1" \
+  "$(printf '%s' "$err" | grep -qF 'dispatch-tick: lib-conflict-lane-hold.sh failed to load; stuck conflict lanes NOT swept this tick' && echo 1 || echo 0)"
+assert_eq "conflict-lane-load-fail-paused: no swept-summary line (sweep never ran)" "0" \
+  "$(printf '%s' "$err" | grep -cF 'lib-conflict-lane-hold: swept')"
+tick_teardown
+
+echo "Test: dispatch-tick lib-conflict-lane-hold.sh load failure → loud diagnostic, tick still completes (normal path)"
+tick_setup
+printf 'this is not valid bash ((( \n' > "$TMPDIR_TEST/lib-conflict-lane-hold.sh"
+export TICK_DECISION="empty"
+err=$("$TMPDIR_TEST/dispatch-tick" 2>&1 1>/dev/null) && rc=0 || rc=$?
+assert_eq "conflict-lane-load-fail-normal: tick still exits 0" "0" "$rc"
+assert_eq "conflict-lane-load-fail-normal: loud diagnostic on stderr" "1" \
+  "$(printf '%s' "$err" | grep -qF 'dispatch-tick: lib-conflict-lane-hold.sh failed to load; stuck conflict lanes NOT swept this tick' && echo 1 || echo 0)"
 tick_teardown
 
 # --- tactic-denied-command-parks-node: normal-path frozen-session sweep --------

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-conflict-lane-hold.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-conflict-lane-hold.sh
@@ -1,0 +1,435 @@
+#!/usr/bin/env bash
+# Tests for lib-conflict-lane-hold.sh — the sweep that turns a /dispatch-conflict
+# Lane 3 session which died without declaring a terminal disposition into a
+# tracked, human-visible hold.
+#
+# Everything the sweep touches is faked: `claude agents --json --all` via
+# CLAUDE_AGENTS_CMD (a small script printing a controlled registry array, which
+# also TOUCHES a sentinel file so a test can assert the daemon was never
+# queried), the sidecar dir via DISPATCH_CONFLICT_LANE_ROOT, the transcript store
+# via DISPATCH_CONFLICT_LANE_PROJECTS_ROOT (files whose mtime `touch -d` sets),
+# `hold-node` via DISPATCH_CONFLICT_LANE_HOLD_NODE (an argv logger with a
+# test-controlled exit code that also copies out the reason/recommendation files
+# before the sweep deletes their tempdir), and the clock via
+# DISPATCH_CONFLICT_LANE_NOW_EPOCH.
+#
+# conflict_lane_hold_sweep always returns 0, but every call is still wrapped in
+# an `if` to capture the code — the test shell runs under `set -e` — and EVERY
+# case asserts that 0.
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=dispatch-test-fixture.sh
+source "$FIXTURE_DIR/dispatch-test-fixture.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib-claude-agents.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib-conflict-lane-hold.sh"
+
+echo "=== lib-conflict-lane-hold.sh ==="
+
+# A fixed clock for every test. Transcript mtimes and marker stamps are
+# expressed relative to it. The default grace is 1800s.
+CL_NOW=1700000000
+
+CL_DIR=""
+CL_ROOT=""
+CL_PROJ=""
+CL_FAKE=""
+CL_HOLD=""
+CL_HOLDLOG=""
+CL_QUERIED=""
+CL_ENTRIES=()
+CL_RC=0
+CL_ERR=""
+
+cl_setup() {
+  CL_DIR=$(mktemp -d)
+  CL_ROOT="$CL_DIR/worktrees"
+  CL_PROJ="$CL_DIR/projects"
+  CL_FAKE="$CL_DIR/fake-claude"
+  CL_HOLD="$CL_DIR/fake-hold-node"
+  CL_HOLDLOG="$CL_DIR/hold-node.log"
+  CL_QUERIED="$CL_DIR/daemon-queried"
+  CL_ENTRIES=()
+  mkdir -p "$CL_ROOT" "$CL_PROJ/proj-a" "$CL_DIR/decisions"
+  : > "$CL_HOLDLOG"
+
+  # The sweep queries the daemon directly with --all; make sure no tick snapshot
+  # is in scope regardless.
+  unset DISPATCH_AGENTS_SNAPSHOT || true
+
+  DISPATCH_CONFLICT_LANE_NOW_EPOCH="$CL_NOW"
+  DISPATCH_CONFLICT_LANE_ROOT="$CL_ROOT"
+  DISPATCH_CONFLICT_LANE_PROJECTS_ROOT="$CL_PROJ"
+  DISPATCH_CONFLICT_LANE_HOLD_NODE="$CL_HOLD"
+  unset DISPATCH_CONFLICT_LANE_GRACE_S || true
+  unset DISPATCH_CONFLICT_LANE_HOLD_MAX || true
+
+  # lib-decision-log.sh resolves DECISION_LOG_FILE ONCE, at source time, inside
+  # its load guard — so a per-test DISPATCH_DECISION_LOG_DIR set after sourcing
+  # would not be read. Set the env var for documentation/parity and re-point the
+  # already-resolved variable at the same scratch path.
+  DISPATCH_DECISION_LOG_DIR="$CL_DIR/decisions"
+  DECISION_LOG_FILE="$DISPATCH_DECISION_LOG_DIR/routing-decisions.jsonl"
+
+  cl_write_hold_node 0
+}
+
+cl_teardown() {
+  rm -rf "$CL_DIR"
+  CL_DIR=""
+  unset CLAUDE_AGENTS_CMD || true
+  unset DISPATCH_CONFLICT_LANE_NOW_EPOCH DISPATCH_CONFLICT_LANE_ROOT \
+        DISPATCH_CONFLICT_LANE_PROJECTS_ROOT DISPATCH_CONFLICT_LANE_HOLD_NODE \
+        DISPATCH_CONFLICT_LANE_GRACE_S DISPATCH_CONFLICT_LANE_HOLD_MAX \
+        DISPATCH_DECISION_LOG_DIR || true
+}
+
+# cl_write_hold_node <exit-code> — install the fake hold-node: it logs its argc
+# and full argv, copies the reason/recommendation files out (the sweep rm -rf's
+# their tempdir immediately after the call), then exits <exit-code>.
+cl_write_hold_node() {
+  cat > "$CL_HOLD" <<HOLD
+#!/usr/bin/env bash
+{
+  printf 'ARGC=%s\n' "\$#"
+  printf 'ARGV=%s\n' "\$*"
+} >> "$CL_HOLDLOG"
+while [[ \$# -gt 0 ]]; do
+  case "\$1" in
+    --reason-file) cat "\$2" >> "$CL_DIR/reason.txt"; shift 2 ;;
+    --recommendation-file) cat "\$2" >> "$CL_DIR/rec.txt"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf 'held tactic-hold-x (NONE)\n'
+exit $1
+HOLD
+  chmod +x "$CL_HOLD"
+}
+
+# cl_add_session <sid> <name> [state] — append one registry entry. [state]
+# defaults to "working" (which claude_session_id_is_live classifies as `live`);
+# pass "done" for the terminal-but-not-removed shape this sweep hunts.
+cl_add_session() {
+  local sid="$1" name="$2" state="${3-working}"
+  CL_ENTRIES+=("{\"sessionId\":\"$sid\",\"name\":\"$name\",\"state\":\"$state\",\"cwd\":\"/tmp/$name\"}")
+}
+
+# cl_install_claude [exit-code] — install the fake `claude`. It TOUCHES the
+# daemon-queried sentinel on every invocation, so a test can assert the sweep
+# made no daemon call at all.
+cl_install_claude() {
+  local exit_code="${1:-0}" payload
+  payload=$( IFS=,; printf '[%s]' "${CL_ENTRIES[*]}" )
+  printf '%s' "$payload" > "$CL_DIR/payload.json"
+  cat > "$CL_FAKE" <<FAKE
+#!/usr/bin/env bash
+touch "$CL_QUERIED"
+cat "$CL_DIR/payload.json"
+exit $exit_code
+FAKE
+  chmod +x "$CL_FAKE"
+  CLAUDE_AGENTS_CMD="$CL_FAKE"
+}
+
+# cl_write_marker <id> <spawned-epoch> — write the sidecar marker
+# dispatch-graph-execute writes on a successful Lane 3 kick.
+cl_write_marker() {
+  printf 'spawned=%s\n' "$2" > "$CL_ROOT/$1.conflict-lane"
+}
+
+cl_marker_exists() {
+  [[ -f "$CL_ROOT/$1.conflict-lane" ]] && printf 'yes' || printf 'no'
+}
+
+# cl_write_transcript <sid> <mtime-epoch>
+cl_write_transcript() {
+  printf '{}\n' > "$CL_PROJ/proj-a/$1.jsonl"
+  touch -d "@$2" "$CL_PROJ/proj-a/$1.jsonl"
+}
+
+cl_run() {
+  if conflict_lane_hold_sweep 2>"$CL_DIR/err"; then CL_RC=0; else CL_RC=$?; fi
+  CL_ERR=$(cat "$CL_DIR/err")
+}
+
+cl_contains() {
+  case "$CL_ERR" in *"$1"*) printf 'yes' ;; *) printf 'no' ;; esac
+}
+
+cl_hold_calls() {
+  local c
+  c=$(grep -c '^ARGC=' "$CL_HOLDLOG" 2>/dev/null) || c=0
+  [[ -n "$c" ]] || c=0
+  printf '%s' "$c"
+}
+
+cl_err_count() {
+  local c
+  c=$(grep -c -- "$1" <<<"$CL_ERR") || c=0
+  [[ -n "$c" ]] || c=0
+  printf '%s' "$c"
+}
+
+cl_file_contains() {
+  local file="$1" needle="$2"
+  [[ -f "$file" ]] || { printf 'no'; return 0; }
+  if grep -qF -- "$needle" "$file"; then printf 'yes'; else printf 'no'; fi
+}
+
+# --- Test 1: zero markers costs nothing — no daemon query at all -------------
+# This runs on every tick, so the common case must not touch the daemon. The
+# fake `claude` here EXITS 1 and touches the sentinel: if the sweep queried it,
+# the sentinel would exist and an "unqueryable" line would be logged.
+
+echo "Test: with no markers the sweep never queries the daemon"
+cl_setup
+cl_install_claude 1
+cl_run
+assert_eq "no-markers: sweep returns 0" "0" "$CL_RC"
+assert_eq "no-markers: the daemon was never queried" "no" \
+  "$([[ -e "$CL_QUERIED" ]] && printf 'yes' || printf 'no')"
+assert_eq "no-markers: no unqueryable line" "no" "$(cl_contains 'daemon unqueryable')"
+assert_eq "no-markers: hold-node not invoked" "0" "$(cl_hold_calls)"
+assert_eq "no-markers: summary reports zero markers" "yes" \
+  "$(cl_contains 'swept 0 marker(s): 0 held, 0 observing, 0 cleared, 0 deferred')"
+cl_teardown
+
+# --- Test 2: a live lane session is observed ---------------------------------
+
+echo "Test: a marker whose lane session is still live is observed, never held"
+cl_setup
+cl_write_marker "tactic-lane-live" $(( CL_NOW - 7200 ))
+cl_add_session "0aa1-1111" "tactic-lane-live" working
+cl_install_claude 0
+cl_write_transcript "0aa1-1111" $(( CL_NOW - 7200 ))
+cl_run
+assert_eq "lane-live: sweep returns 0" "0" "$CL_RC"
+assert_eq "lane-live: hold-node not invoked" "0" "$(cl_hold_calls)"
+assert_eq "lane-live: the marker is kept" "yes" "$(cl_marker_exists tactic-lane-live)"
+assert_eq "lane-live: stderr reports observing" "yes" \
+  "$(cl_contains 'observing tactic-lane-live (session 0aa1-1111 state=live)')"
+cl_teardown
+
+# --- Test 3: a stopped lane session idle past the grace is held --------------
+
+echo "Test: a stopped-but-unreaped lane session idle past the grace raises one hold"
+cl_setup
+cl_write_marker "tactic-lane-stuck" $(( CL_NOW - 7200 ))
+cl_add_session "0aa1-1111" "tactic-lane-stuck" done
+cl_install_claude 0
+cl_write_transcript "0aa1-1111" $(( CL_NOW - 3600 ))
+cl_run
+assert_eq "lane-stuck: sweep returns 0" "0" "$CL_RC"
+assert_eq "lane-stuck: hold-node invoked exactly once" "1" "$(cl_hold_calls)"
+assert_eq "lane-stuck: argv names the node and the provision-conflict kind" "yes" \
+  "$(cl_file_contains "$CL_HOLDLOG" 'ARGV=tactic-lane-stuck --kind provision-conflict')"
+assert_eq "lane-stuck: reason names the stopped session" "yes" \
+  "$(cl_file_contains "$CL_DIR/reason.txt" '0aa1-1111')"
+assert_eq "lane-stuck: reason names provision exit 11" "yes" \
+  "$(cl_file_contains "$CL_DIR/reason.txt" 'provision exit 11')"
+assert_eq "lane-stuck: recommendation carries the literal claude rm" "yes" \
+  "$(cl_file_contains "$CL_DIR/rec.txt" 'claude rm 0aa1-1111')"
+assert_eq "lane-stuck: recommendation carries the literal resolve-hold" "yes" \
+  "$(cl_file_contains "$CL_DIR/rec.txt" 'resolve-hold tactic-lane-stuck --kind provision-conflict')"
+assert_eq "lane-stuck: the marker is removed after the hold lands" "no" \
+  "$(cl_marker_exists tactic-lane-stuck)"
+assert_eq "lane-stuck: stderr reports the hold" "yes" \
+  "$(cl_contains 'held tactic-lane-stuck (stuck conflict lane, idle 3600s, session 0aa1-1111)')"
+cl_teardown
+
+# --- Test 4: a stopped session still inside the grace is observed ------------
+
+echo "Test: a stopped lane session idle UNDER the grace is observed, not held"
+cl_setup
+cl_write_marker "tactic-lane-fresh" $(( CL_NOW - 7200 ))
+cl_add_session "0aa1-1111" "tactic-lane-fresh" done
+cl_install_claude 0
+cl_write_transcript "0aa1-1111" $(( CL_NOW - 60 ))
+cl_run
+assert_eq "lane-fresh: sweep returns 0" "0" "$CL_RC"
+assert_eq "lane-fresh: hold-node not invoked" "0" "$(cl_hold_calls)"
+assert_eq "lane-fresh: the marker is kept" "yes" "$(cl_marker_exists tactic-lane-fresh)"
+assert_eq "lane-fresh: stderr reports the idle comparison" "yes" \
+  "$(cl_contains 'observing tactic-lane-fresh (session 0aa1-1111 idle_seconds=60 < grace_seconds=1800)')"
+cl_teardown
+
+# --- Test 5: an unmeasurable idle never escalates ----------------------------
+
+echo "Test: a stopped lane session with no transcript is kept, never held"
+cl_setup
+cl_write_marker "tactic-lane-notrans" $(( CL_NOW - 7200 ))
+cl_add_session "0aa1-1111" "tactic-lane-notrans" done
+cl_install_claude 0
+cl_run
+assert_eq "lane-notrans: sweep returns 0" "0" "$CL_RC"
+assert_eq "lane-notrans: hold-node not invoked" "0" "$(cl_hold_calls)"
+assert_eq "lane-notrans: the marker is kept" "yes" "$(cl_marker_exists tactic-lane-notrans)"
+assert_eq "lane-notrans: stderr reports the unmeasurable idle" "yes" \
+  "$(cl_contains 'idle time unmeasurable')"
+cl_teardown
+
+# --- Test 6: no registry row and an aged marker → GC -------------------------
+
+echo "Test: a marker with no registry row whose age passed the grace is cleared"
+cl_setup
+cl_write_marker "tactic-lane-reaped" $(( CL_NOW - 7200 ))
+cl_add_session "0cc3-3333" "tactic-some-other-node" working
+cl_install_claude 0
+cl_run
+assert_eq "lane-reaped: sweep returns 0" "0" "$CL_RC"
+assert_eq "lane-reaped: hold-node not invoked" "0" "$(cl_hold_calls)"
+assert_eq "lane-reaped: the marker is removed" "no" "$(cl_marker_exists tactic-lane-reaped)"
+assert_eq "lane-reaped: stderr reports the clear" "yes" \
+  "$(cl_contains 'cleared tactic-lane-reaped (no registry row')"
+cl_teardown
+
+# --- Test 7: no registry row but a young marker → the registration window ----
+
+echo "Test: a marker with no registry row still inside the grace is kept"
+cl_setup
+cl_write_marker "tactic-lane-booting" $(( CL_NOW - 60 ))
+cl_add_session "0cc3-3333" "tactic-some-other-node" working
+cl_install_claude 0
+cl_run
+assert_eq "lane-booting: sweep returns 0" "0" "$CL_RC"
+assert_eq "lane-booting: hold-node not invoked" "0" "$(cl_hold_calls)"
+assert_eq "lane-booting: the marker is kept" "yes" "$(cl_marker_exists tactic-lane-booting)"
+assert_eq "lane-booting: stderr reports the registration window" "yes" \
+  "$(cl_contains 'observing tactic-lane-booting (awaiting registration')"
+cl_teardown
+
+# --- Test 8: an unqueryable daemon neither holds nor GCs ---------------------
+
+echo "Test: an unqueryable daemon holds nothing and clears nothing"
+cl_setup
+cl_write_marker "tactic-lane-unknown" $(( CL_NOW - 7200 ))
+cl_install_claude 1
+cl_run
+assert_eq "lane-unknown: sweep returns 0" "0" "$CL_RC"
+assert_eq "lane-unknown: hold-node not invoked" "0" "$(cl_hold_calls)"
+assert_eq "lane-unknown: the marker is kept" "yes" "$(cl_marker_exists tactic-lane-unknown)"
+assert_eq "lane-unknown: stderr reports the unqueryable daemon" "yes" \
+  "$(cl_contains 'daemon unqueryable; observing tactic-lane-unknown')"
+cl_teardown
+
+# --- Test 9: two stopped rows for one name still raise ONE hold --------------
+
+echo "Test: two stopped rows under one node name raise exactly one hold"
+cl_setup
+cl_write_marker "tactic-lane-twice" $(( CL_NOW - 7200 ))
+cl_add_session "0aa1-1111" "tactic-lane-twice" done
+cl_add_session "0bb2-2222" "tactic-lane-twice" done
+cl_install_claude 0
+cl_write_transcript "0aa1-1111" $(( CL_NOW - 3600 ))
+cl_write_transcript "0bb2-2222" $(( CL_NOW - 3600 ))
+cl_run
+assert_eq "lane-twice: sweep returns 0" "0" "$CL_RC"
+assert_eq "lane-twice: hold-node invoked exactly once" "1" "$(cl_hold_calls)"
+assert_eq "lane-twice: the newest row is the reported holder" "yes" \
+  "$(cl_contains 'session 0bb2-2222')"
+cl_teardown
+
+# --- Test 10: the per-sweep hold cap defers the excess -----------------------
+
+echo "Test: the hold cap bounds holds per sweep and defers the rest"
+cl_setup
+DISPATCH_CONFLICT_LANE_HOLD_MAX=2
+i=1
+for n in one two three four; do
+  cl_write_marker "tactic-cap-$n" $(( CL_NOW - 7200 ))
+  cl_add_session "0cab-000$i" "tactic-cap-$n" done
+  cl_write_transcript "0cab-000$i" $(( CL_NOW - 3600 ))
+  i=$(( i + 1 ))
+done
+cl_install_claude 0
+cl_run
+assert_eq "cap: sweep returns 0" "0" "$CL_RC"
+assert_eq "cap: exactly two hold-node invocations" "2" "$(cl_hold_calls)"
+assert_eq "cap: two deferring lines" "2" "$(cl_err_count 'lib-conflict-lane-hold: deferring ')"
+cl_remaining=0
+for n in one two three four; do
+  [[ -f "$CL_ROOT/tactic-cap-$n.conflict-lane" ]] && cl_remaining=$(( cl_remaining + 1 ))
+done
+assert_eq "cap: the two deferred markers are still on disk" "2" "$cl_remaining"
+assert_eq "cap: summary counts the deferrals" "yes" \
+  "$(cl_contains 'swept 4 marker(s): 2 held, 0 observing, 0 cleared, 2 deferred')"
+cl_teardown
+
+# --- Test 11: a hold-node failure is non-fatal and keeps the marker ----------
+
+echo "Test: a hold-node failure is logged, the marker kept, and the sweep returns 0"
+cl_setup
+cl_write_hold_node 1
+cl_write_marker "tactic-lane-holdfail" $(( CL_NOW - 7200 ))
+cl_add_session "0aa1-1111" "tactic-lane-holdfail" done
+cl_install_claude 0
+cl_write_transcript "0aa1-1111" $(( CL_NOW - 3600 ))
+cl_run
+assert_eq "hold-fail: sweep returns 0" "0" "$CL_RC"
+assert_eq "hold-fail: hold-node was attempted" "1" "$(cl_hold_calls)"
+assert_eq "hold-fail: the marker is kept for the next pass" "yes" \
+  "$(cl_marker_exists tactic-lane-holdfail)"
+assert_eq "hold-fail: stderr reports the failure" "yes" \
+  "$(cl_contains 'hold failed for tactic-lane-holdfail (hold-node exit 1); will retry next tick')"
+assert_eq "hold-fail: summary counts zero holds" "yes" \
+  "$(cl_contains 'swept 1 marker(s): 0 held, 0 observing, 0 cleared, 0 deferred')"
+cl_teardown
+
+# --- Test 12: an unsafe marker name is never used to build a path ------------
+
+echo "Test: a marker whose name fails the node-id regex is kept and skipped"
+cl_setup
+printf 'spawned=%s\n' $(( CL_NOW - 7200 )) > "$CL_ROOT/tactic-Bad_Id.conflict-lane"
+cl_install_claude 0
+cl_run
+assert_eq "unsafe-id: sweep returns 0" "0" "$CL_RC"
+assert_eq "unsafe-id: the daemon was never queried for it" "no" \
+  "$([[ -e "$CL_QUERIED" ]] && printf 'yes' || printf 'no')"
+assert_eq "unsafe-id: hold-node not invoked" "0" "$(cl_hold_calls)"
+assert_eq "unsafe-id: the marker is kept" "yes" \
+  "$([[ -f "$CL_ROOT/tactic-Bad_Id.conflict-lane" ]] && printf 'yes' || printf 'no')"
+assert_eq "unsafe-id: stderr reports the unsafe id" "yes" "$(cl_contains 'unsafe-id tactic-Bad_Id')"
+cl_teardown
+
+# --- Test 13: the decision log records the held candidate --------------------
+
+echo "Test: a held candidate appends one conflict-lane-hold decision record"
+cl_setup
+cl_write_marker "tactic-lane-logged" $(( CL_NOW - 7200 ))
+cl_add_session "0aa1-1111" "tactic-lane-logged" done
+cl_install_claude 0
+cl_write_transcript "0aa1-1111" $(( CL_NOW - 3600 ))
+cl_run
+assert_eq "decision-log: sweep returns 0" "0" "$CL_RC"
+assert_eq "decision-log: the log file exists" "yes" \
+  "$([[ -f "$DECISION_LOG_FILE" ]] && printf 'yes' || printf 'no')"
+assert_eq "decision-log: exactly one conflict-lane-hold record" "1" \
+  "$(jq -r 'select(.site == "conflict-lane-hold") | .site' "$DECISION_LOG_FILE" | wc -l | tr -d ' ')"
+assert_eq "decision-log: the record says held" "held" \
+  "$(jq -r 'select(.site == "conflict-lane-hold") | .disposition' "$DECISION_LOG_FILE")"
+assert_eq "decision-log: the record names the node" "tactic-lane-logged" \
+  "$(jq -r 'select(.site == "conflict-lane-hold") | .node' "$DECISION_LOG_FILE")"
+assert_eq "decision-log: the record carries a numeric idle_seconds" "3600" \
+  "$(jq -r 'select(.site == "conflict-lane-hold") | .idle_seconds' "$DECISION_LOG_FILE")"
+cl_teardown
+
+# --- Test 14: a hold-failed candidate is also recorded -----------------------
+
+echo "Test: a hold-failed candidate appends a hold-failed decision record"
+cl_setup
+cl_write_hold_node 1
+cl_write_marker "tactic-lane-logfail" $(( CL_NOW - 7200 ))
+cl_add_session "0aa1-1111" "tactic-lane-logfail" done
+cl_install_claude 0
+cl_write_transcript "0aa1-1111" $(( CL_NOW - 3600 ))
+cl_run
+assert_eq "decision-log-fail: sweep returns 0" "0" "$CL_RC"
+assert_eq "decision-log-fail: the record says hold-failed" "hold-failed" \
+  "$(jq -r 'select(.site == "conflict-lane-hold") | .disposition' "$DECISION_LOG_FILE")"
+cl_teardown
+
+report_results

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -228,6 +228,8 @@ jobs:
         run: .claude/skills/dispatch-propagate/scripts/test-mark-node-terminal.sh
       - name: Run dispatch-graph-execute tests
         run: .claude/skills/dispatch-propagate/scripts/test-dispatch-graph-execute.sh
+      - name: Run conflict-lane hold sweep tests
+        run: .claude/skills/dispatch-propagate/scripts/test-lib-conflict-lane-hold.sh
       - name: Run provision-node-worktree tests
         run: .claude/skills/dispatch-propagate/scripts/test-provision-node-worktree.sh
       - name: Run dispatch-derive-node-target tests


### PR DESCRIPTION
## What

Bounds the exit-11 conflict-lane kicks: a `/dispatch-conflict` Lane 3 session
that stops without declaring a terminal disposition today freezes its node
forever — the conflict unresolved, one live-session slot permanently
consumed, and nothing recorded in the graph. This lands a sidecar-marker
producer plus an external tick sweep that turns that silent freeze into a
tracked, human-actionable hold.

Settled from landed code, not observation (see the node body's Context
section): `worktree_has_live_session` reads the REGISTERED
(`claude agents --json --all`) view with no timeout, so a Lane-3 session that
dies without writing its `node-terminal` marker HOLDS the job and
`graph-select-target` skips the node forever. There is exactly **one** kick
per freeze episode, never accumulation — so the fix is detection +
escalation, not a per-tick retry counter.

**Unit 1** — `dispatch-graph-execute`'s exit-11 case now drops a
`.claude/worktrees/<id>.conflict-lane` sidecar marker (`spawned=<epoch>`) on
a successful Lane-3 kick, and clears it at the two points that mean "this
episode is over": a clean exit-0 provision (guards against later phase
workers, which reuse `--name "$id"`, being misattributed to the conflict
lane) and a successful launch-failure backstop hold. Same fail-open sidecar
convention as the existing `.conflict-strikes` file — outside every
checkout, never a graph write, losing it just means no hold is raised for
that episode.

**Unit 2** — new `lib-conflict-lane-hold.sh`, a sourceable library exporting
`conflict_lane_hold_sweep` (no args, always returns 0), modeled structurally
on `lib-standdown-recheck.sh`. Per `.conflict-lane` candidate: skip an unsafe
node-id shape; on a daemon-UNKNOWN result, only observe (never escalate or
GC); on zero registry rows past the marker's grace window, GC the marker
(session already reaped); on any `live`/`unknown` row, observe; once every
row is `stopped`, check the newest session's transcript idle time against a
grace window (default 1800s, deliberately larger than the stand-down sweep's
900s — a conflict lane runs long subagents and a mid-turn yield also HOLDs);
past grace, escalate via the existing `hold-node --kind provision-conflict`
primitive (reused, not a new kind) with a reason and recommendation that
names `claude rm <sid>` and `resolve-hold <id> --kind provision-conflict`
verbatim as the human's own required acts. Caps holds per sweep call
(default 3) since `hold-node` serializes through `graph-commit`'s landing
lock. Never calls `claude rm` itself and never touches the source node's
`office_hours` — the hold node carries the park.

**Unit 3** — wires `conflict_lane_hold_sweep` into `dispatch-tick` on both
cadences (the normal path, after the per-tick daemon snapshot and before
target selection so a hold it lands is visible to this tick's own
selection; and the paused branch, since the pause sentinel gates worker
spawning, never bookkeeping, and that exit path is the only autonomous path
that otherwise never reaches the sweeps) using the identical
conditional-source + verify + loud-failure idiom the existing stand-down
sweep call sites use. Adds the new test suite to CI
(`.github/workflows/unit-tests.yml`).

## Disambiguation from siblings touching the same territory

- `tactic-node-worker-fresh-skill-body` — a different exit-11 fix (checkout
  currency). Not this.
- `tactic-denied-command-parks-node` (PR #2994, not merged) — detects a
  session frozen **live** at a permission prompt. Disjoint condition
  (terminal, held un-reaped, not live-blocked). No dependency on its files.
- `tactic-graph-router-conflict-routing` (phase implement) — will replace
  case 11 with an `execution.conflict` interrupt. This sweep depends on case
  11 for exactly one line (the marker write); when the interrupt lands it
  keeps writing the same marker and the sweep is untouched.
- `tactic-review-stall-conflict-lane` — explicitly not superseded per the
  author's prior `/align-strategy` ratification; this remains the backstop
  for a lane that runs and does not resolve.

## Verification

```verify
.claude/skills/dispatch-propagate/scripts/test-dispatch-graph-execute.sh
```

```verify
.claude/skills/dispatch-propagate/scripts/test-lib-conflict-lane-hold.sh
```

```verify
.claude/skills/dispatch-propagate/scripts/test-dispatch-tick.sh
```

```verify
.claude/skills/dispatch-propagate/scripts/test-lib-standdown-recheck.sh
```

```verify
.claude/skills/dispatch-propagate/scripts/test-lib-claude-agents.sh
```

```verify
bash -n .claude/skills/dispatch-propagate/scripts/dispatch-graph-execute && bash -n .claude/skills/dispatch-propagate/scripts/lib-conflict-lane-hold.sh && bash -n .claude/skills/dispatch-propagate/scripts/dispatch-tick
```

```verify
.claude/skills/dispatch-propagate/scripts/lint-prose-rules.sh
```

All pass locally: 124 (dispatch-graph-execute) + 66 (lib-conflict-lane-hold) +
131 (dispatch-tick) + 84 (lib-standdown-recheck) + 183 (lib-claude-agents)
bash-suite assertions, clean syntax check, clean lint.

## Out of scope (see plan)

Any change to `CONFLICT_STRIKE_CAP` or the launch-failure strike ladder;
cases 10/12/13/14 of `dispatch-graph-execute`; a new hold kind (reuses
`provision-conflict`); auto-reaping a session (`claude rm` stays a human
act); wiring `test-lib-standdown-recheck.sh` / `test-lib-claude-agents.sh`
into CI (pre-existing gap, another node's).
