### PR TITLE
graph-select-target: conflict outranks failing CI in the normal fix interrupt

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/graph-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/graph-select-target
@@ -23,7 +23,15 @@
 # The ONE exception is the CI-fix interrupt (tactic-fix-interrupt-orthogonal-state):
 # selection is the sole CI-routing authority. On a fix-interruptible ladder phase
 # (implement/qa/review) whose PR CI has CONCLUDED-RED and which carries no active
-# interrupt, the gate ENTERS the interrupt — `apply-fix-state --set-fix` +
+# interrupt, the gate ENTERS the interrupt — UNLESS the PR is also CONFLICTING,
+# which is EXCLUDED from the exception (tactic-conflict-outranks-ci-precedence):
+# `interruptRoute` (packages/intentionsutil/src/transitions.ts) ranks a merge
+# conflict above red CI, so such a node makes NO write here at all — it is emitted
+# at its ladder phase and reaches the conflict lane via provision-node-worktree's
+# exit 11. The red verdict describes stale pre-merge code, and the fix lane cannot
+# run until the conflict clears, so spending a graph write plus one of a limited
+# fix-attempt budget on it is pure waste. For the non-conflicting red case the gate
+# still enters the interrupt — `apply-fix-state --set-fix` +
 # `graph-commit` (a state-only commit on main, mirroring what transition-node
 # used to do at the transition seam) — and emits the candidate as `fix` the same
 # tick. On CONCLUDED-GREEN of an active interrupt it RESOLVES it — `apply-fix-state
@@ -509,30 +517,104 @@ _hold_node_fix_cap() {
 }
 
 # _read_pr_ci <pr> — one gh_pr_view_rest + one CI verdict, into globals
-# _CI_MERGED / _CI_HEAD / _CI_VERDICT. rc 1 when the PR is unreadable.
+# _CI_MERGED / _CI_HEAD / _CI_VERDICT / _CI_MERGEABLE. rc 1 when the PR is
+# unreadable. _CI_MERGEABLE is read off the SAME already-fetched PR view (no
+# extra gh round-trip): gh_pr_view_rest projects REST's boolean `.mergeable`
+# into the porcelain enum MERGEABLE/CONFLICTING/UNKNOWN (lib.sh, the
+# `mergeable:` branch of its jq projection).
 _read_pr_ci() {
   local pr="$1" pv
-  _CI_MERGED=""; _CI_HEAD=""; _CI_VERDICT=""
+  _CI_MERGED=""; _CI_HEAD=""; _CI_VERDICT=""; _CI_MERGEABLE=""
   pv=$(gh_pr_view_rest "$pr" 2>/dev/null) || return 1
   _CI_MERGED=$(jq -r '.mergedAt // empty' <<<"$pv" 2>/dev/null)
+  _CI_MERGEABLE=$(jq -r '.mergeable // empty' <<<"$pv" 2>/dev/null)
   _CI_HEAD=$(jq -r '.headRefOid // empty' <<<"$pv" 2>/dev/null)
   [[ -n "$_CI_HEAD" ]] || return 1
   _CI_VERDICT=$(dispatch_ci_verdict_rest "$_CI_HEAD" 2>/dev/null || echo pending)
   return 0
 }
 
-# _gate_maybe_interrupt <id> <pr> — for a fix-interruptible ladder phase carrying
-# NO active interrupt: enter `fix` iff the PR's CI has CONCLUDED-RED. On entry it
-# writes execution.fix and lands it on main.
-#   rc 0 — interrupt entered (caller emits `fix` this tick).
-#   rc 1 — no interrupt (caller falls through to the phase's normal gate).
-#   rc 3 — interrupt was due but the write/commit failed (reason printed; skip).
+# _gate_maybe_interrupt <id> <pr> <phase> — for a fix-interruptible ladder phase
+# carrying NO active interrupt: decide whether an interrupt is due, and which lane
+# it belongs to, by delegating to `interruptRoute`
+# (packages/intentionsutil/src/transitions.ts — the single home of the
+# CONFLICTING-outranks-failing-CI precedence rule). Only the `fix` route writes:
+# it writes execution.fix and lands it on main.
+#   rc 0 — fix interrupt entered (caller emits `fix` this tick).
+#   rc 1 — no interrupt is due for this caller (caller falls through to the
+#          phase's normal gate and the node is emitted at its ladder phase).
+#          This covers BOTH the `null` route and the `conflict` route: a
+#          CONFLICTING PR is DECLINED here — no execution.fix write, no
+#          graph-commit, no fix attempt consumed — and reaches the conflict lane
+#          through provision-node-worktree's exit 11 instead.
+#   rc 3 — an interrupt was due but could not be acted on (write/commit failed,
+#          an unreadable `.mergeable`, or a failed interruptRoute eval); a short
+#          reason token is printed on stdout and the caller skips the node.
+#
+# STDOUT DISCIPLINE: on rc 1 this function must print NOTHING to stdout. The
+# caller's arm falls through to its own `echo "$phase"`, and sensor_gate's whole
+# stdout is captured as the emitted phase — so the conflict-decline diagnostic
+# (and any future rc-1 note) goes to STDERR only. rc 1/rc 3 stdout tokens are
+# recorded as skip reasons; rc 3 is the only rc-1-adjacent path that may print.
 _gate_maybe_interrupt() {
-  local id="$1" pr="$2"
+  local id="$1" pr="$2" phase="$3"
   [[ "$pr" == "null" || -z "$pr" ]] && return 1
   _read_pr_ci "$pr" || return 1               # unreadable PR → do not interrupt
   [[ -n "$_CI_MERGED" ]] && return 1          # merged-awaiting-reconcile → not an interrupt
-  [[ "$_CI_VERDICT" == "failing" ]] || return 1
+
+  # Cost guard, NOT the routing rule: interruptRoute returns null unless CI is
+  # failing or the PR is CONFLICTING, so skip the node subprocess when neither
+  # holds (the overwhelmingly common case). This condition MUST stay a
+  # superset of interruptRoute's non-null conditions; the transitions.test.ts
+  # case named for "the shell pre-filter's superset invariant" pins that.
+  if [[ "$_CI_VERDICT" != "failing" && "$_CI_MERGEABLE" != "CONFLICTING" ]]; then
+    return 1
+  fi
+
+  # Validate at the shell/TypeScript edge before crossing it — interruptRoute
+  # takes closed unions, so an unexpected value would silently route to `null`
+  # (mirrors reconcile-graph-review-stall's posture on the same fields).
+  case "$_CI_MERGEABLE" in
+    MERGEABLE|CONFLICTING|UNKNOWN) ;;
+    *)
+      echo "graph-select-target: unexpected .mergeable '$_CI_MERGEABLE' from gh_pr_view_rest #$pr for $id (projection changed?)" >&2
+      echo "mergeable-unreadable"; return 3 ;;
+  esac
+  # dispatch_ci_verdict_rest emits passing|failing|pending; CiVerdict's third
+  # member is "unknown". Normalize, exactly as reconcile-graph-review-stall does.
+  local verdict
+  case "$_CI_VERDICT" in
+    passing|failing) verdict="$_CI_VERDICT" ;;
+    *) verdict="unknown" ;;
+  esac
+
+  local route
+  route=$( (cd "$REPO_ROOT" && node --import tsx/esm -e '
+    const { interruptRoute } = await import("./packages/intentionsutil/src/transitions.js");
+    process.stdout.write(String(interruptRoute(process.argv[1], process.argv[2], process.argv[3])));
+  ' "$phase" "$verdict" "$_CI_MERGEABLE") ) || {
+    echo "graph-select-target: interruptRoute eval failed for $id (pr #$pr)" >&2
+    echo "route-eval-failed"; return 3
+  }
+
+  case "$route" in
+    conflict)
+      # Conflict outranks failing CI (transitions.ts, interruptRoute). DECLINE the
+      # interrupt: no execution.fix write, no graph-commit, no attempt burned. The
+      # candidate falls through to its phase's normal gate and is emitted at its
+      # ladder phase; provision-node-worktree exit 11 -> dispatch-graph-execute
+      # case 11 routes it to /dispatch-conflict Lane 3, which is the only lane
+      # that actually resolves the conflict.
+      #
+      # STDERR ONLY. An rc-1 return falls through to the caller's own
+      # `echo "$phase"`, and sensor_gate's stdout is captured whole as the emitted
+      # phase — anything printed to stdout here corrupts the selection line.
+      echo "graph-select-target: $id PR #$pr is CONFLICTING; conflict outranks failing CI — declining the fix interrupt (provisioning routes it to the conflict lane)" >&2
+      return 1 ;;
+    fix) ;;                 # fall through to the interrupt write below
+    *) return 1 ;;          # "null" or anything else: no interrupt is due
+  esac
+
   # CONCLUDED-RED at an interruptible phase, fix null (guaranteed: the router
   # would have emitted phase `fix` otherwise). Enter the interrupt this tick.
   if _apply_fix "$id" --set-fix >/dev/null 2>&1 \
@@ -611,7 +693,7 @@ sensor_gate() {
     implement)
       # Interruptible: a red PR at implement enters fix this tick; else ready
       # (implement has no CI gate of its own).
-      _gate_maybe_interrupt "$id" "$pr"
+      _gate_maybe_interrupt "$id" "$pr" "$phase"
       case $? in
         0) echo "fix"; return 0 ;;
         3) return 1 ;;
@@ -620,7 +702,7 @@ sensor_gate() {
     qa|review)
       # Interruptible: a red PR enters fix this tick; otherwise the existing
       # CI-verdict-present gate.
-      _gate_maybe_interrupt "$id" "$pr"
+      _gate_maybe_interrupt "$id" "$pr" "$phase"
       case $? in
         0) echo "fix"; return 0 ;;
         3) return 1 ;;

--- a/.claude/skills/dispatch-propagate/scripts/graph-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/graph-select-target
@@ -629,6 +629,21 @@ _gate_maybe_interrupt() {
 # carries an active interrupt (router emitted phase `fix`). Resolve on green,
 # guard/retry otherwise. Prints the phase to emit (rc 0), a skip reason
 # (rc 1), or an env error (rc 2).
+#
+# DELIBERATELY CONFLICT-BLIND: this function reads CI only (`_read_pr_ci`'s
+# `_CI_VERDICT`) and never consults `_CI_MERGEABLE`. A node that entered `fix`
+# BEFORE the conflict appeared keeps retrying and guarding here, and can burn
+# fix attempts against a CI verdict that describes stale pre-merge code. That
+# is authorized scope residue of the tactic that made `_gate_maybe_interrupt`
+# (above, around lines 537-559) conflict-aware at ENTRY — not an oversight:
+# the node is not stranded, because `provision-node-worktree` exit 11 (routed
+# by `dispatch-graph-execute` case 11 to `/dispatch-conflict` Lane 3) still
+# catches it, and that lane is the only one that actually resolves the
+# conflict. Closing this asymmetry belongs to a later, separate unification of
+# this arm into the ordered `interruptRoute` cascade
+# (packages/intentionsutil/src/transitions.ts), and, separately, to
+# `tactic-graph-router-conflict-routing`'s `execution.conflict` state — neither
+# of which this PR introduces.
 _gate_fix_active() {
   local id="$1" pr="$2" pushed_sha="$3" fix_since="$4" out phase
   if [[ "$pr" == "null" || -z "$pr" ]]; then echo "no-pr"; return 1; fi

--- a/.claude/skills/dispatch-propagate/scripts/test-graph-select-target.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-graph-select-target.sh
@@ -646,6 +646,272 @@ fi
 unset gsc13_rc
 gsc_standalone_teardown
 
+# ============================================================================
+# Test: graph-select-target — the fix interrupt routes through interruptRoute
+# (tactic-conflict-outranks-ci-precedence Unit 2)
+# ============================================================================
+# _gate_maybe_interrupt no longer decides on `ci == failing` alone: it reads the
+# PR's `.mergeable` off the SAME gh_pr_view_rest call and delegates the decision
+# to interruptRoute (packages/intentionsutil/src/transitions.ts), where
+# CONFLICTING outranks failing CI. A PR that is BOTH conflicted and red must
+# therefore make NO graph write and burn NO fix attempt — it is emitted at its
+# ladder phase and reaches the conflict lane through provision-node-worktree's
+# exit 11 (out of scope here; unchanged).
+#
+# The cascade's own ordering is unit-tested in TypeScript
+# (packages/intentionsutil/test/transitions.test.ts). This fixture pins the
+# SHELL seam only: that the selector hands the cascade the right sensors, honors
+# whatever route comes back, and never writes on the decline path. `node` is
+# therefore a stub that logs its argv and replays a route from a file.
+#
+# Hermetic: fake `npx` (select-targets.ts AND apply-fix-state.ts), fake `gh`
+# (the two REST shapes gh_pr_view_rest and dispatch_ci_verdict_rest fetch),
+# fake `claude`, fake `node`, and a no-op graph-commit stub. No network.
+#
+# NOTE on the `mergeable-unreadable` rc-3 branch in _gate_maybe_interrupt: it is
+# unreachable by construction against the current lib.sh projection.
+# gh_pr_view_rest's `mergeable:` jq branch (lib.sh:1137-1141) is a total
+# if/elif/else over REST's boolean — true -> MERGEABLE, false -> CONFLICTING,
+# EVERYTHING else (including null and an absent key) -> UNKNOWN — so no PR REST
+# response can yield a fourth value. The branch is kept as an edge guard against
+# a future projection change (mirroring reconcile-graph-review-stall's identical
+# guard) and is deliberately not covered here rather than covered by stubbing
+# gh_pr_view_rest itself, which would test the stub, not the script.
+gsc_interrupt_setup() {
+  GSCI_ROOT=$(mktemp -d)
+  GSCI_BARE=$(mktemp -d)
+  GSCI_SCRIPTS="$GSCI_ROOT/.claude/skills/dispatch-propagate/scripts"
+  mkdir -p "$GSCI_SCRIPTS" "$GSCI_ROOT/bin" "$GSCI_ROOT/packages/intentionsutil/scripts"
+  # Physical copies (not symlinks): graph-select-target derives REPO_ROOT from
+  # its own on-disk location, and dispatch-ci-ready resolves lib.sh as a sibling.
+  cp "$SCRIPT_DIR"/graph-select-target "$SCRIPT_DIR"/dispatch-ci-ready \
+     "$SCRIPT_DIR"/lib.sh "$SCRIPT_DIR"/lib-*.sh "$GSCI_SCRIPTS/"
+  chmod +x "$GSCI_SCRIPTS/graph-select-target" "$GSCI_SCRIPTS/dispatch-ci-ready"
+  # graph-commit stub: _graph_commit_fix runs it from NATIVE_ROOT on the `fix`
+  # route, so the control case exercises the clean emission path rather than
+  # `fix-write-failed`.
+  cat > "$GSCI_ROOT/packages/intentionsutil/scripts/graph-commit" <<'GSCIGC'
+#!/usr/bin/env bash
+exit 0
+GSCIGC
+  chmod +x "$GSCI_ROOT/packages/intentionsutil/scripts/graph-commit"
+  # Fake npx: serves BOTH tsx entry points the selector shells out to —
+  # select-targets.ts (the candidate list, from a per-case file) and
+  # apply-fix-state.ts (the interrupt write, whose invocation is logged; the
+  # log's presence/absence is the load-bearing assertion below).
+  cat > "$GSCI_ROOT/bin/npx" <<'GSCINPX'
+#!/usr/bin/env bash
+_root="$(cd "$(dirname "$0")/.." && pwd)"
+for _a in "$@"; do
+  case "$_a" in
+    *apply-fix-state*)
+      printf '%s\n' "$*" >> "$_root/apply-fix-calls.log"
+      echo '{}'
+      exit 0 ;;
+  esac
+done
+cat "$_root/candidates.json"
+exit 0
+GSCINPX
+  chmod +x "$GSCI_ROOT/bin/npx"
+  # Fake gh: the two REST calls the sensor path makes, each served from a
+  # per-case file. `gh api repos/{owner}/{repo}/pulls/2999` returns the RAW REST
+  # PR shape (gh_pr_view_rest applies its own jq projection over it — same
+  # byte-compat shape test-lib-gh-rest.sh pins); the check-runs path feeds
+  # dispatch_ci_verdict_rest. Anything else fails, keeping the case offline.
+  cat > "$GSCI_ROOT/bin/gh" <<'GSCIGH'
+#!/usr/bin/env bash
+_root="$(cd "$(dirname "$0")/.." && pwd)"
+for _a in "$@"; do
+  case "$_a" in
+    */pulls/2999) cat "$_root/pr-2999.json"; exit 0 ;;
+    */commits/deadbee/check-runs) cat "$_root/check-runs.json"; exit 0 ;;
+  esac
+done
+exit 1
+GSCIGH
+  chmod +x "$GSCI_ROOT/bin/gh"
+  # Fake node: records the TRAILING three positional args — phase, ci verdict,
+  # mergeable, i.e. exactly the sensors handed to interruptRoute — then replays
+  # the route from route.txt (no trailing newline, like the real one-liner's
+  # process.stdout.write). `node-fail` makes the eval fail instead.
+  cat > "$GSCI_ROOT/bin/node" <<'GSCINODE'
+#!/usr/bin/env bash
+_root="$(cd "$(dirname "$0")/.." && pwd)"
+printf '%s %s %s\n' "${@: -3}" >> "$_root/node-calls.log"
+if [[ -e "$_root/node-fail" ]]; then
+  echo "fake node: forced failure" >&2
+  exit 1
+fi
+printf '%s' "$(cat "$_root/route.txt")"
+exit 0
+GSCINODE
+  chmod +x "$GSCI_ROOT/bin/node"
+  # Fake `claude agents --json`: empty registry (no live session claims the id).
+  cat > "$GSCI_ROOT/bin/claude" <<'GSCICLAUDE'
+#!/usr/bin/env bash
+_root="$(cd "$(dirname "$0")/.." && pwd)"
+cat "$_root/claude-payload.json"
+exit 0
+GSCICLAUDE
+  chmod +x "$GSCI_ROOT/bin/claude"
+  printf '%s' '[]' > "$GSCI_ROOT/claude-payload.json"
+  # Per-case defaults: one implement-phase candidate WITH a pr, a CONFLICTING
+  # red PR, and the `conflict` route. Cases rewrite whichever of these they vary
+  # (rewriting fixture files per case is this file's existing convention).
+  gsci_candidate implement
+  gsci_pr false
+  gsci_checks '{"check_runs":[{"status":"completed","conclusion":"failure"}]}'
+  printf 'conflict' > "$GSCI_ROOT/route.txt"
+  # A git repo whose origin/main carries an intentions/ tree, main checked out
+  # at the fixture root so NATIVE_ROOT resolves there.
+  git init -q -b main "$GSCI_ROOT"
+  git -C "$GSCI_ROOT" config user.email t@t
+  git -C "$GSCI_ROOT" config user.name t
+  mkdir -p "$GSCI_ROOT/intentions"
+  echo '# placeholder' > "$GSCI_ROOT/intentions/placeholder.md"
+  git -C "$GSCI_ROOT" add -A
+  git -C "$GSCI_ROOT" commit -q -m seed
+  git init -q --bare -b main "$GSCI_BARE"
+  git -C "$GSCI_ROOT" remote add origin "$GSCI_BARE"
+  git -C "$GSCI_ROOT" push -q origin main
+  git -C "$GSCI_ROOT" fetch -q origin
+  GSCI_GST="$GSCI_SCRIPTS/graph-select-target"
+}
+
+# gsci_candidate <phase> — rewrite the select-targets.ts candidate list.
+gsci_candidate() {
+  printf '%s\n' "{\"candidates\":[{\"id\":\"tactic-fixture\",\"kind\":\"tactic\",\"phase\":\"$1\",\"pr\":\"2999\",\"pace_exempt\":false}],\"events\":[]}" \
+    > "$GSCI_ROOT/candidates.json"
+}
+
+# gsci_pr <mergeable-json> — rewrite the RAW REST PR object. `false` =>
+# CONFLICTING, `true` => MERGEABLE, `null` => UNKNOWN (lib.sh's projection).
+gsci_pr() {
+  local m="$1" state="dirty"
+  [[ "$m" == "true" ]] && state="clean"
+  printf '%s\n' "{\"number\":2999,\"state\":\"open\",\"merged_at\":null,\"merge_commit_sha\":null,\"mergeable\":$m,\"mergeable_state\":\"$state\",\"title\":\"t\",\"body\":\"\",\"head\":{\"sha\":\"deadbee\",\"ref\":\"tactic-fixture\"},\"labels\":[]}" \
+    > "$GSCI_ROOT/pr-2999.json"
+}
+
+# gsci_checks <json> — rewrite the single check-runs page.
+gsci_checks() { printf '%s\n' "$1" > "$GSCI_ROOT/check-runs.json"; }
+
+gsc_interrupt_teardown() {
+  rm -rf "$GSCI_ROOT" "$GSCI_BARE"
+  GSCI_ROOT="" ; GSCI_BARE="" ; GSCI_SCRIPTS="" ; GSCI_GST=""
+}
+
+# gsci_run — invoke the selector with the fixture's env, stderr to gsci.err.
+# Env needed only for this one invocation is passed as a command PREFIX (this
+# file's convention), with every ledger/log dir pointed inside the fixture.
+gsci_run() {
+  PATH="$GSCI_ROOT/bin:$SAVED_PATH" \
+    CLAUDE_AGENTS_CMD="$GSCI_ROOT/bin/claude" \
+    DISPATCH_RESERVATION_DIR="$GSCI_ROOT/reservations" \
+    DISPATCH_SELECTION_LOG_DIR="$GSCI_ROOT/seldir" \
+    DISPATCH_PR_LIST_FILE="$GSCI_ROOT/pr-list.json" \
+    "$GSCI_GST" "$@" 2>"$GSCI_ROOT/gsci.err"
+}
+
+# --- Case 1: CONFLICTING + red declines the interrupt (the defect) -----------
+echo "Test: graph-select-target — a CONFLICTING red PR declines the fix interrupt and is emitted at its ladder phase"
+gsc_interrupt_setup
+gsci1_out=$(gsci_run)
+assert_eq "graph-select-target interrupt: CONFLICTING + red emits the ladder phase, not fix" \
+  "node tactic-fixture tactic implement" "$gsci1_out"
+# The load-bearing half: no apply-fix-state call at all, so no execution.fix
+# write and no fix attempt consumed against a verdict the conflict invalidates.
+assert_eq "graph-select-target interrupt: CONFLICTING + red makes NO apply-fix-state --set-fix call" \
+  "0" "$([ -f "$GSCI_ROOT/apply-fix-calls.log" ] && echo 1 || echo 0)"
+assert_eq "graph-select-target interrupt: the decline is reported on stderr" \
+  "1" "$(grep -q "declining the fix interrupt" "$GSCI_ROOT/gsci.err" && echo 1 || echo 0)"
+# Case 3 (first half): the sensors handed to the cascade.
+assert_eq "graph-select-target interrupt: the cascade receives phase/ci/mergeable" \
+  "implement failing CONFLICTING" "$(tail -n 1 "$GSCI_ROOT/node-calls.log")"
+gsc_interrupt_teardown
+
+# --- Case 2: control — red but MERGEABLE still enters the fix interrupt ------
+# Without this, Case 1 would pass vacuously if the gate broke entirely.
+echo "Test: graph-select-target — a red but MERGEABLE PR still enters the fix interrupt (Case 1 control)"
+gsc_interrupt_setup
+gsci_pr true
+printf 'fix' > "$GSCI_ROOT/route.txt"
+gsci2_out=$(gsci_run)
+assert_eq "graph-select-target interrupt: red + MERGEABLE emits fix" \
+  "node tactic-fixture tactic fix" "$gsci2_out"
+assert_eq "graph-select-target interrupt: red + MERGEABLE calls apply-fix-state" \
+  "1" "$([ -f "$GSCI_ROOT/apply-fix-calls.log" ] && echo 1 || echo 0)"
+assert_eq "graph-select-target interrupt: the apply-fix-state call carries --set-fix" \
+  "1" "$(grep -q -- "--set-fix" "$GSCI_ROOT/apply-fix-calls.log" && echo 1 || echo 0)"
+assert_eq "graph-select-target interrupt: red + MERGEABLE hands the cascade MERGEABLE" \
+  "implement failing MERGEABLE" "$(tail -n 1 "$GSCI_ROOT/node-calls.log")"
+gsc_interrupt_teardown
+
+# --- Case 3 (second half): pending CI normalizes to `unknown` ----------------
+# dispatch_ci_verdict_rest emits passing|failing|pending; CiVerdict's third
+# member is `unknown`. This also pins that a CONFLICTING-but-not-red candidate
+# still REACHES the cascade — the cost guard is a superset of interruptRoute's
+# non-null conditions, so it must not filter this one out.
+echo "Test: graph-select-target — pending CI on a CONFLICTING PR reaches the cascade as 'unknown'"
+gsc_interrupt_setup
+gsci_checks '{"check_runs":[{"status":"in_progress","conclusion":null}]}'
+gsci3_out=$(gsci_run)
+assert_eq "graph-select-target interrupt: pending CI is normalized to unknown at the cascade edge" \
+  "implement unknown CONFLICTING" "$(tail -n 1 "$GSCI_ROOT/node-calls.log")"
+assert_eq "graph-select-target interrupt: pending + CONFLICTING still emits the ladder phase" \
+  "node tactic-fixture tactic implement" "$gsci3_out"
+assert_eq "graph-select-target interrupt: pending + CONFLICTING makes no apply-fix-state call" \
+  "0" "$([ -f "$GSCI_ROOT/apply-fix-calls.log" ] && echo 1 || echo 0)"
+gsc_interrupt_teardown
+
+# --- Case 4: the cost guard holds (green + MERGEABLE spawns no subprocess) ---
+# interruptRoute is null unless CI is failing or the PR is CONFLICTING, so the
+# common case must never pay for the node subprocess at all.
+echo "Test: graph-select-target — a green MERGEABLE PR never spawns the interruptRoute subprocess"
+gsc_interrupt_setup
+gsci_pr true
+gsci_checks '{"check_runs":[{"status":"completed","conclusion":"success"}]}'
+gsci4_out=$(gsci_run)
+assert_eq "graph-select-target interrupt: green + MERGEABLE emits the ladder phase" \
+  "node tactic-fixture tactic implement" "$gsci4_out"
+assert_eq "graph-select-target interrupt: green + MERGEABLE spawns no node subprocess" \
+  "0" "$([ -f "$GSCI_ROOT/node-calls.log" ] && echo 1 || echo 0)"
+gsc_interrupt_teardown
+
+# --- Case 5: declining at `qa` routes onward instead of stranding the node ---
+# The qa arm's normal gate runs after the declined interrupt: the merged check
+# passes (mergedAt null), then dispatch-ci-ready short-circuits READY for a
+# CONFLICTING draft even with CI unresolved (dispatch-ci-ready:72-76), so the
+# node is emitted at `qa` and provisioning takes it to the conflict lane.
+echo "Test: graph-select-target — declining the interrupt at qa still emits qa (no stranding)"
+gsc_interrupt_setup
+gsci_candidate qa
+printf '%s\n' '[{"number":2999,"headRefName":"tactic-fixture","isDraft":true,"headRefOid":"deadbee","labels":[],"mergeable":"CONFLICTING"}]' \
+  > "$GSCI_ROOT/pr-list.json"
+gsci5_out=$(gsci_run)
+assert_eq "graph-select-target interrupt: a declined qa candidate is emitted at qa" \
+  "node tactic-fixture tactic qa" "$gsci5_out"
+assert_eq "graph-select-target interrupt: a declined qa candidate makes no apply-fix-state call" \
+  "0" "$([ -f "$GSCI_ROOT/apply-fix-calls.log" ] && echo 1 || echo 0)"
+assert_eq "graph-select-target interrupt: the qa cascade call carries the qa phase" \
+  "qa failing CONFLICTING" "$(tail -n 1 "$GSCI_ROOT/node-calls.log")"
+gsc_interrupt_teardown
+
+# --- Case 6: an interruptRoute eval failure fails SAFE -----------------------
+# rc 3 (`route-eval-failed`) skips the candidate rather than guessing a lane:
+# no write, no emission. With one candidate the run prints `empty`.
+echo "Test: graph-select-target — an interruptRoute eval failure skips the candidate without writing"
+gsc_interrupt_setup
+touch "$GSCI_ROOT/node-fail"
+gsci6_out=$(gsci_run)
+assert_eq "graph-select-target interrupt: a failed cascade eval degrades to empty" "empty" "$gsci6_out"
+assert_eq "graph-select-target interrupt: a failed cascade eval makes no apply-fix-state call" \
+  "0" "$([ -f "$GSCI_ROOT/apply-fix-calls.log" ] && echo 1 || echo 0)"
+assert_eq "graph-select-target interrupt: a failed cascade eval is reported on stderr" \
+  "1" "$(grep -q "interruptRoute eval failed" "$GSCI_ROOT/gsci.err" && echo 1 || echo 0)"
+gsc_interrupt_teardown
+
 # <<< END MOVED <<<
 
 report_results

--- a/packages/intentionsutil/src/index.ts
+++ b/packages/intentionsutil/src/index.ts
@@ -29,6 +29,7 @@ export {
   LADDER,
   forwardPhase,
   fixInterrupt,
+  interruptRoute,
   decideTransition,
   addMarker,
   incrementAttempt,
@@ -43,7 +44,7 @@ export {
   isStrategyStale,
   isFingerprintStale,
 } from "./transitions.js";
-export type { CiVerdict, TransitionDecision, ScopeStamp } from "./transitions.js";
+export type { CiVerdict, TransitionDecision, ScopeStamp, InterruptRoute } from "./transitions.js";
 export { IntentionSchemaError } from "./errors.js";
 export { lintTacticBodies, loadPlanBodyBaseline } from "./planlint.js";
 export type { PlanBodyMarker, PlanBodyBaselineEntry } from "./planlint.js";

--- a/packages/intentionsutil/src/transitions.ts
+++ b/packages/intentionsutil/src/transitions.ts
@@ -294,17 +294,27 @@ export function reviewStallRoute(ci: CiVerdict, mergeable: Mergeable): ReviewSta
  *  - the review-stall sweep (`reviewStallRoute`, which delegates here at the
  *    fixed phase `"review"`); and
  *  - the normal selection gate (`graph-select-target`'s
- *    `_gate_maybe_interrupt`), wired to call this function in a later,
- *    separate follow-up unit.
+ *    `_gate_maybe_interrupt`), which calls this function through a
+ *    `node --import tsx/esm -e` bridge before writing any fix-attempt state.
  *
- * That normal path is CURRENTLY merge-blind: it only checks `ci === "failing"`
- * before writing a fix-attempt state, so a PR that is BOTH `CONFLICTING` and
- * red gets a fix-attempt state written and burns one of a limited attempt
- * budget (`FIX_ATTEMPT_CAP`) against a CI verdict that actually describes
- * stale pre-merge code — and the fix lane cannot even run until the conflict
- * clears, since fixing requires merging origin/main first. Routing that case
- * to `"conflict"` instead avoids spending both a graph write and an attempt on
- * a verdict the conflict will invalidate anyway.
+ * That normal path WAS merge-blind before that gate was wired: it only
+ * checked `ci === "failing"` before writing a fix-attempt state, so a PR that
+ * was BOTH `CONFLICTING` and red would get a fix-attempt state written and
+ * burn one of a limited attempt budget (`FIX_ATTEMPT_CAP`) against a CI
+ * verdict that actually describes stale pre-merge code — and the fix lane
+ * cannot even run until the conflict clears, since fixing requires merging
+ * origin/main first. Routing that case to `"conflict"` instead is what
+ * `_gate_maybe_interrupt` now does: it declines the interrupt (no
+ * `execution.fix` write, no graph-commit, no attempt consumed) and lets the
+ * candidate fall through to provisioning's conflict lane, avoiding spending
+ * both a graph write and an attempt on a verdict the conflict will
+ * invalidate anyway.
+ *
+ * The sibling arm for a candidate that ALREADY carries an active interrupt
+ * (`graph-select-target`'s `_gate_fix_active`) does NOT consume
+ * `interruptRoute` and stays conflict-blind by design — see the comment
+ * above `_gate_fix_active` in that file for the scope rationale; the two
+ * sites are meant to agree.
  *
  * `UNKNOWN` mergeability is deliberately NOT treated as a conflict: GitHub
  * computes mergeability asynchronously and self-heals `UNKNOWN` to a real

--- a/packages/intentionsutil/src/transitions.ts
+++ b/packages/intentionsutil/src/transitions.ts
@@ -220,6 +220,12 @@ export function incrementAttempt(execution: Execution, phase: string): Execution
 export type Mergeable = "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
 
 /**
+ * The recovery lane `interruptRoute`'s ordered cascade resolves to, or `null`
+ * when no interrupt is due. See `interruptRoute` for the cascade itself.
+ */
+export type InterruptRoute = "fix" | "conflict" | null;
+
+/**
  * The recovery lane a stalled `phase: review` + `reviewed` tactic must be
  * routed to, or `null` when nothing has regressed.
  *
@@ -229,7 +235,7 @@ export type Mergeable = "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
  *    `provision-conflict` hold via `hold-node`), which resolves an
  *    origin/main merge conflict on the node's own branch.
  */
-export type ReviewStallRoute = "fix" | "conflict" | null;
+export type ReviewStallRoute = InterruptRoute;
 
 /**
  * Which recovery lane an armed `phase: review` tactic carrying the `reviewed`
@@ -268,10 +274,53 @@ export type ReviewStallRoute = "fix" | "conflict" | null;
  * GitHub computes mergeability asynchronously and self-heals `UNKNOWN` to a
  * real value on a later sweep — the same no-op posture
  * `dispatch-reconcile-ready` takes on an `UNKNOWN` read.
+ *
+ * The CONFLICTING-outranks-failing ordering documented above now lives in
+ * `interruptRoute`, which this function delegates to at the fixed phase
+ * `"review"` — see `interruptRoute` for the single documented home of the
+ * precedence rule.
  */
 export function reviewStallRoute(ci: CiVerdict, mergeable: Mergeable): ReviewStallRoute {
+  return interruptRoute("review", ci, mergeable);
+}
+
+/**
+ * The single ordered cascade over `(mergeable, ci)` for whether an interrupt is
+ * due at `phase`, and which lane it enters. This is the ONE documented home of
+ * the CONFLICTING-outranks-failing-CI precedence rule described above on
+ * `reviewStallRoute` (see that comment for the full rationale — not restated
+ * here) — consumed by BOTH:
+ *
+ *  - the review-stall sweep (`reviewStallRoute`, which delegates here at the
+ *    fixed phase `"review"`); and
+ *  - the normal selection gate (`graph-select-target`'s
+ *    `_gate_maybe_interrupt`), wired to call this function in a later,
+ *    separate follow-up unit.
+ *
+ * That normal path is CURRENTLY merge-blind: it only checks `ci === "failing"`
+ * before writing a fix-attempt state, so a PR that is BOTH `CONFLICTING` and
+ * red gets a fix-attempt state written and burns one of a limited attempt
+ * budget (`FIX_ATTEMPT_CAP`) against a CI verdict that actually describes
+ * stale pre-merge code — and the fix lane cannot even run until the conflict
+ * clears, since fixing requires merging origin/main first. Routing that case
+ * to `"conflict"` instead avoids spending both a graph write and an attempt on
+ * a verdict the conflict will invalidate anyway.
+ *
+ * `UNKNOWN` mergeability is deliberately NOT treated as a conflict: GitHub
+ * computes mergeability asynchronously and self-heals `UNKNOWN` to a real
+ * value on a later check. Treating `UNKNOWN` as `CONFLICTING` would suppress
+ * every fix interrupt during GitHub's compute window.
+ *
+ * A `null` return means no interrupt is due. The only two conditions that can
+ * produce a non-null route are `ci === "failing"` and `mergeable ===
+ * "CONFLICTING"` — a superset invariant a shell caller may exploit as a cheap
+ * pre-filter (`ci === "failing" || mergeable === "CONFLICTING"`) before paying
+ * for a full call, and which a later test pins so that optimization stays
+ * correct.
+ */
+export function interruptRoute(phase: string, ci: CiVerdict, mergeable: Mergeable): InterruptRoute {
   if (mergeable === "CONFLICTING") return "conflict";
-  if (ci === "failing") return "fix";
+  if (fixInterrupt(phase, ci)) return "fix";
   return null;
 }
 

--- a/packages/intentionsutil/test/transitions.test.ts
+++ b/packages/intentionsutil/test/transitions.test.ts
@@ -11,6 +11,7 @@ import {
   reconcileMergedPhase,
   reconcileClosedPhase,
   reviewStallRoute,
+  interruptRoute,
   hasNeedsMainResidue,
   stampRound,
   inboundBlockers,
@@ -228,6 +229,59 @@ describe("reviewStallRoute", () => {
 
   it("self-heals: an UNKNOWN mergeability with passing CI is not a regression", () => {
     expect(reviewStallRoute("passing", "UNKNOWN")).toBe(null);
+  });
+});
+
+describe("interruptRoute", () => {
+  const INTERRUPTIBLE = ["implement", "qa", "review"] as const;
+
+  it("routes to conflict over fix when both a failing verdict and CONFLICTING hold (the defect case)", () => {
+    for (const phase of INTERRUPTIBLE) {
+      expect(interruptRoute(phase, "failing", "CONFLICTING")).toBe("conflict");
+    }
+  });
+
+  it("routes to fix on a failing verdict at an interruptible phase when mergeable or unknown", () => {
+    for (const phase of INTERRUPTIBLE) {
+      expect(interruptRoute(phase, "failing", "MERGEABLE")).toBe("fix");
+      expect(interruptRoute(phase, "failing", "UNKNOWN")).toBe("fix");
+    }
+  });
+
+  it("routes to conflict regardless of CI verdict when CONFLICTING", () => {
+    for (const phase of INTERRUPTIBLE) {
+      expect(interruptRoute(phase, "passing", "CONFLICTING")).toBe("conflict");
+      expect(interruptRoute(phase, "unknown", "CONFLICTING")).toBe("conflict");
+    }
+  });
+
+  it("returns null when CI is not failing and mergeability is not CONFLICTING", () => {
+    for (const phase of INTERRUPTIBLE) {
+      expect(interruptRoute(phase, "passing", "MERGEABLE")).toBe(null);
+      expect(interruptRoute(phase, "passing", "UNKNOWN")).toBe(null);
+      expect(interruptRoute(phase, "unknown", "MERGEABLE")).toBe(null);
+      expect(interruptRoute(phase, "unknown", "UNKNOWN")).toBe(null);
+    }
+  });
+
+  it("on a non-interruptible phase, a failing+MERGEABLE verdict is null but CONFLICTING still routes to conflict", () => {
+    // The conflict arm is phase-independent by construction: mergeable ===
+    // "CONFLICTING" short-circuits before fixInterrupt (and its phase check)
+    // is ever consulted.
+    for (const phase of ["done", "main-qa"]) {
+      expect(interruptRoute(phase, "failing", "MERGEABLE")).toBe(null);
+      expect(interruptRoute(phase, "failing", "CONFLICTING")).toBe("conflict");
+    }
+  });
+
+  it("returns null whenever neither a failing verdict nor CONFLICTING holds (the shell pre-filter's superset invariant)", () => {
+    for (const phase of ["implement", "qa", "review", "done"]) {
+      for (const ci of ["passing", "unknown"] as const) {
+        for (const mergeable of ["MERGEABLE", "UNKNOWN"] as const) {
+          expect(interruptRoute(phase, ci, mergeable)).toBe(null);
+        }
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## What

The normal graph selector (`.claude/skills/dispatch-propagate/scripts/graph-select-target`) was merge-blind: on a fix-interruptible ladder phase (`implement`/`qa`/`review`) whose PR CI concluded RED, `_gate_maybe_interrupt` wrote `execution.fix` and landed a `graph: enter fix-interrupt` commit on `main` before checking whether the PR was also `CONFLICTING`. A PR that was both `CONFLICTING` and red burned a graph write and one of a 3-attempt fix cap against a CI result describing stale pre-merge code, before provisioning's exit 11 finally routed it to the conflict lane anyway.

The correct precedence (`CONFLICTING` outranks failing CI) already existed as ratified doctrine in `reviewStallRoute` (`packages/intentionsutil/src/transitions.ts`), consumed only by the review-stall sweep. This PR:

- **Unit 1** — collapses the two fragmented halves of the ordering (`fixInterrupt`'s interruptible+failing-CI half, `reviewStallRoute`'s conflict-outranks-failing half) into one ordered cascade, `interruptRoute(phase, ci, mergeable)`, in `packages/intentionsutil/src/transitions.ts`. `reviewStallRoute` now delegates to it at the fixed phase `"review"` (provably behavior-preserving — its existing tests are unmodified). Adds a full `interruptRoute` test suite, including a superset-invariant test pinning that only `ci === "failing"` or `mergeable === "CONFLICTING"` can produce a non-null route.
- **Unit 2** — makes `graph-select-target`'s `_gate_maybe_interrupt` consume `interruptRoute` via the existing `node --import tsx/esm -e` bash↔TS bridge idiom (already established by `reconcile-graph-review-stall`). `_read_pr_ci` now also captures `.mergeable` off the same already-fetched PR view (no extra `gh` call). A `CONFLICTING` PR now declines the fix interrupt entirely — no `apply-fix-state --set-fix`, no `graph-commit`, no attempt burned — and falls through to its normal ladder-phase emission, reaching the conflict lane via the existing `provision-node-worktree` exit-11 path. Adds hermetic bash-fixture tests for the decline, a mergeable-red control (so the defect case isn't vacuous), sensor wiring (including CI pending→unknown normalization), the cost-guard pre-filter, `qa`-phase non-stranding, and eval-failure fail-safe.

## Deliberately out of scope (see node body for the full greenfield/migration rationale)

- The `merged` / active-interrupt / attempt-cap arms (`_gate_fix_active`) stay conflict-blind — a node that entered `fix` *before* the conflict appeared keeps retrying; it still reaches the conflict lane via provisioning's exit 11, so it is not stranded.
- No `execution.conflict` state — that is `tactic-graph-router-conflict-routing`'s scope.
- No change to `dispatch-ci-ready`, `provision-node-worktree`, or `dispatch-graph-execute`.

## Testing

All plan-specified verify blocks pass:
- `bash -n` on `graph-select-target`
- `npx vitest run --project packages/intentionsutil` (766 tests, including the new `interruptRoute` suite; `reviewStallRoute`'s existing tests unmodified and green)
- `run-typecheck.sh --app packages/intentionsutil`
- `test-graph-select-target.sh` (71/71, including 6 new cases)
- `run-lint.sh --prose`
- `run-unit-tests.sh --pr-scripts` (full dispatch script suite, all green)
