### PR TITLE
phase-skill entry: run the mechanical selection-validity gate at every entry point

### DIFF
--- a/.claude/skills/align-tactics/SKILL.md
+++ b/.claude/skills/align-tactics/SKILL.md
@@ -119,6 +119,70 @@ checkout: a concurrent session's dirty tracked file blocks this run's
    origin/main`) before proceeding. Never treat a failed fetch as license to
    proceed on unverified state.
 
+   **Then, unconditionally, on both entry paths — run the shared mechanical
+   selection-validity gate**, in the worktree, after `assert-worktree-fresh`
+   and **before any graph read** (before any `readNode` call or drift grep
+   below). This includes the `provision-node-worktree` path too, even though
+   `provision-node-worktree` already ran `check-node-selection.ts` itself
+   moments earlier: the re-run here is a redundant, idempotent ~0.7s check,
+   and paying it uniformly is the point — a session that provisioned once via
+   `provision-node-worktree` but re-enters later (e.g. a resumed session)
+   would otherwise slip through on re-entry with no fresh gate check at all.
+
+   ```bash
+   .claude/skills/dispatch-propagate/scripts/assert-node-selection "<target-node-id>" align-tactics
+   ```
+
+   `align-tactics` is the correct `<selected-phase>` literal for **both**
+   target kinds this skill handles. For a `strategy-<slug>` target,
+   `check-node-selection.ts` requires the node still be `kind: strategy` at
+   its native null phase and defers wholesale to a helper predicate,
+   `strategyAlignSelectable`. For a `tactic-<slug>` target — draft/raw
+   finalize or soft-frozen re-plan alike — the gate skips the phase-literal
+   comparison and defers wholesale to `frozenTacticSelectable`, which is
+   membership in the selector's own candidate list
+   (`packages/intentionsutil/src/router.ts`). The selector emits an
+   uncapped, fully-sorted candidate list, so a low-ranked draft is still
+   admitted — ranking never causes a false exit 12.
+
+   Route on the exit code:
+
+   - `0` — proceed; stdout is the node's scope fingerprint (discard it here,
+     Step 0 does not consume it).
+   - `12` — the selection is no longer valid: the node advanced past draft
+     and is not soft-frozen, was parked to `office_hours`, was resolved or
+     pruned, or has incomplete blockers. **STOP.** Make **no** graph write,
+     open no PR, and record the terminal disposition so the Stop hook can
+     reap the job, reusing the same call this Step 0 already uses for the
+     held-claim case above:
+     ```bash
+     packages/intentionsutil/scripts/mark-node-terminal "<target-node-id>" no-claim
+     ```
+     `no-claim` is already a validated disposition value in
+     `mark-node-terminal`'s vocabulary (it is the same value the held-claim
+     case above uses) — this is not a new value.
+   - `13` — not reachable at this phase: the gate's scope-chained-phase
+     check only applies to the `fix`/`qa`/`review` phases, not
+     `align-tactics`. Treat it as a mechanical error: report and stop.
+   - any other non-zero — mechanical error (unresolvable project root,
+     failed fetch, malformed store): report and stop. A stale selection
+     (`12`) is NOT an `office_hours` park and NOT a defect; a mechanical
+     error is neither of those either — it is a broken environment to report
+     plainly, per this repo's code-style convention of clear errors over
+     defensive fallbacks.
+
+   **Deliberately not gated by `assert-node-selection`** — each of these has
+   a shape this gate cannot express, so a future session should not "finish
+   the rollout" by wiring it in:
+
+   - `/office-hours` — operates on an **office_hours-parked** node by
+     definition; the gate's park check would reject every legitimate run.
+   - `/align-strategy` — may target a strategy that doesn't exist yet (a
+     new-strategy interview), and strategies carry no phase to gate on.
+   - `/align-init` — has no node target at all.
+   - `/grounding-research` — walks many nodes; there is no single selected
+     target to gate.
+
 ## Tactic target — per-node finalize or re-plan
 
 When the argument is a `tactic-<slug>` (not a `strategy-<slug>`), this

--- a/.claude/skills/dispatch-propagate/scripts/assert-node-selection
+++ b/.claude/skills/dispatch-propagate/scripts/assert-node-selection
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# assert-node-selection — the shared selection-validity gate primitive
+# (tactic-phase-entry-selection-gate, unit 1). Wraps
+# packages/intentionsutil/scripts/check-node-selection.ts (its pure core is
+# evaluateSelection, :182-352) so every phase-skill entry point can run the
+# SAME worker-start re-validation `provision-node-worktree` already runs
+# before it provisions a worktree — a stale/parked/terminal-state selection
+# exits cheaply here instead of doing real work first.
+#
+# Usage: assert-node-selection <node-id> <selected-phase> [--dir <intentions-dir>]
+#
+# Stdout: the node's scope fingerprint (exit 0 only). All diagnostics to stderr.
+#
+# Exit codes (check-node-selection.ts's vocabulary, passed through unchanged):
+#   0   the selection is still valid.
+#   12  stale-selection — pruned, phase advanced, parked, no longer
+#       align-eligible, already carries the `reviewed` marker, or a serving
+#       strategy's substance changed since the stamp. NOT a defect.
+#   13  scope-stale — the tactic's scope changed after the previous phase ran.
+#       NOT a defect; the node wants demoting to `implement`.
+#   1   could not obtain a fresh origin/main intentions store (fetch or
+#       `git archive` failed).
+#   2   usage error, unresolvable project root, or the gate itself failed
+#       mechanically (any check-node-selection exit other than 0/12/13).
+#
+# Requires `dangerouslyDisableSandbox: true` from a Claude session for the
+# `git fetch`/`git archive` it runs when `--dir` is not supplied.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib-graph-worktree.sh"
+
+usage() {
+  echo "usage: assert-node-selection <node-id> <selected-phase> [--dir <intentions-dir>]" >&2
+}
+
+NODE_ID="${1:-}"
+SELECTED_PHASE="${2:-}"
+if [[ -z "$NODE_ID" || -z "$SELECTED_PHASE" ]]; then
+  usage
+  exit 2
+fi
+shift 2 || true
+
+if [[ ! "$NODE_ID" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]]; then
+  echo "assert-node-selection: invalid node id '$NODE_ID' (must match ^[a-z][a-z0-9]*(-[a-z0-9]+)*\$)" >&2
+  exit 2
+fi
+
+DIR_OVERRIDE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir)
+      DIR_OVERRIDE="${2:-}"
+      if [[ -z "$DIR_OVERRIDE" ]]; then
+        echo "assert-node-selection: --dir requires a directory argument" >&2
+        exit 2
+      fi
+      shift 2 ;;
+    *)
+      echo "assert-node-selection: unexpected argument '$1'" >&2
+      usage
+      exit 2 ;;
+  esac
+done
+
+# Project root: the worktree with `main` checked out (substrate clarification
+# 23). resolve_main_worktree honors DISPATCH_GRAPH_MAIN_WORKTREE, the test
+# override, when set; resolve_project_root is the plain git-common-dir
+# fallback when no worktree has `main` checked out (e.g. this script running
+# from inside a plain single-checkout repo). Used for the stamp sidecar path
+# and, absent --dir, as the origin for the fresh-store fetch/archive.
+PROJECT_ROOT=$(resolve_main_worktree 2>/dev/null)
+if [[ -z "$PROJECT_ROOT" || ! -d "$PROJECT_ROOT" ]]; then
+  PROJECT_ROOT=$(resolve_project_root 2>/dev/null) || PROJECT_ROOT=""
+fi
+if [[ -z "$PROJECT_ROOT" || ! -d "$PROJECT_ROOT" ]]; then
+  echo "assert-node-selection: cannot resolve the project root (no worktree with 'main' checked out, and resolve_project_root also failed)" >&2
+  exit 2
+fi
+
+# Stamp path: same sidecar convention provision-node-worktree writes —
+# deliberately outside every checkout so it never dirties a tree. Do not
+# create it here; a missing stamp is handled inside the gate (fails open with
+# a warning on stderr).
+STAMP_PATH="$PROJECT_ROOT/.claude/worktrees/$NODE_ID.scope-fingerprint"
+
+if [[ -n "$DIR_OVERRIDE" ]]; then
+  # The caller asserts this is already a fresh-origin/main snapshot — use it
+  # verbatim, no fetch.
+  DIR="$DIR_OVERRIDE"
+else
+  if ! git -C "$PROJECT_ROOT" fetch origin main --quiet; then
+    echo "assert-node-selection: git fetch origin main failed" >&2
+    exit 1
+  fi
+  SNAP_DIR="$(mktemp -d)" || { echo "assert-node-selection: mktemp failed" >&2; exit 1; }
+  trap 'rm -rf "$SNAP_DIR"' EXIT
+  # The WHOLE intentions/ tree is required, not just the target node file:
+  # evaluateSelection calls listNodes(dir) for the align-eligibility and
+  # fingerprint checks. A single-file snapshot would silently no-op the
+  # serving-strategy lookup (check 4), turning it into a silent hole rather
+  # than an error.
+  if ! git -C "$PROJECT_ROOT" archive origin/main intentions/ | tar -x -C "$SNAP_DIR"; then
+    echo "assert-node-selection: git archive origin/main intentions/ failed" >&2
+    exit 1
+  fi
+  DIR="$SNAP_DIR/intentions"
+fi
+
+# Invoke the gate. set -e is deliberately NOT used (see header): a non-zero
+# exit here (12/13/other) must be captured, not kill the script. Mirrors
+# provision-node-worktree's GATE_FP/GATE_RC capture shape.
+GATE_FP=$(cd "$REPO_ROOT" && npx tsx packages/intentionsutil/scripts/check-node-selection.ts \
+  "$NODE_ID" "$SELECTED_PHASE" --dir "$DIR" --stamp "$STAMP_PATH")
+GATE_RC=$?
+
+case "$GATE_RC" in
+  0)
+    printf '%s\n' "$GATE_FP"
+    exit 0 ;;
+  12|13)
+    # stderr already carries the one-line stale-selection / scope-stale
+    # reason from check-node-selection — emit nothing extra here, re-wrapping
+    # it would bury the detail.
+    exit "$GATE_RC" ;;
+  *)
+    echo "assert-node-selection: check-node-selection failed (exit $GATE_RC)" >&2
+    exit 2 ;;
+esac

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-derive-node-target
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-derive-node-target
@@ -3,9 +3,30 @@
 # the graph-native tactic phase skills (tactic-dispatch-skill-input-contract
 # Unit 1). Replaces each phase skill's hand-rolled branch-name parsing +
 # sed/git-archive dance with one scripted call: validate the node id, confirm
-# the current worktree branch matches it, snapshot the node from origin/main,
-# read it via the intentionsutil store primitives, gate on the expected phase,
-# and (optionally) resolve the open PR.
+# the current worktree branch matches it, snapshot intentions/ from origin/main,
+# read the node via the intentionsutil store primitives, run the FULL mechanical
+# selection-validity gate, and (optionally) resolve the open PR.
+#
+# The gate is no longer a local phase-string comparison
+# (tactic-phase-entry-selection-gate Unit 2): it delegates to
+# `assert-node-selection`, the shared wrapper over
+# packages/intentionsutil/scripts/check-node-selection.ts — the SAME
+# re-validation provision-node-worktree runs. That covers phase/interrupt match,
+# office_hours park (first-class AND squatter), align-eligibility, serving-
+# strategy fingerprint freshness, and scope-chain custody.
+#
+# Two intentional behavior changes came with that switch:
+#
+#   * `review` gains the `reviewed`-marker guard. A node at phase `review` that
+#     already carries the `reviewed` marker now exits 3 instead of proceeding —
+#     the marker means the review pass already ran and the node is awaiting tick
+#     merge/fix. This is the execute-side mirror of the selector's own
+#     reviewed-exclusion, and it catches the hand-run / re-entry case that
+#     bypasses the selector entirely.
+#   * Every phase now gets the park and fingerprint checks. A node parked to
+#     office_hours between selection and skill entry exits 3 at this front door
+#     for all five consuming phase skills — previously only qa-fix had its own
+#     hand-rolled parked check, and it ran elsewhere (later, after real work).
 #
 # Usage: dispatch-derive-node-target <node-id> (--expect-phase <phase> | --expect-fix-active) [--pr-mode none|optional|required]
 #
@@ -13,17 +34,21 @@
 #                     node-id slug regex AND the current checked-out branch
 #                     name (tactic phase worktrees are branch==node-id, mirrors
 #                     dispatch-graph-execute's provisioning contract).
-#   --expect-phase    The phase the caller expects the node to be persisted at.
-#                     Mismatch is a stale-selection signal (exit 3), not a usage
-#                     error — the caller decides how to react. Exactly one of
-#                     --expect-phase / --expect-fix-active must be given.
+#   --expect-phase    The phase the caller expects the node to be selected at.
+#                     Passed through to the gate as its <selected-phase>. A
+#                     rejected selection is exit 3 (or exit 5 for scope-stale),
+#                     not a usage error — the caller decides how to react.
+#                     Exactly one of --expect-phase / --expect-fix-active must
+#                     be given.
 #   --expect-fix-active
 #                     Gate on an active CI-fix interrupt instead of a ladder
-#                     phase: require the node's `execution.fix` to be non-null
-#                     (the /fix-checks lane's real gate — `phase` stays at its
-#                     ladder position and is never the literal "fix"). Null
-#                     `execution.fix` is exit 3 (no active interrupt). Exactly
-#                     one of --expect-phase / --expect-fix-active must be given.
+#                     phase (the /fix-checks lane's real gate — `phase` stays at
+#                     its ladder position and is never the literal "fix").
+#                     Passed to the gate as the literal selected-phase "fix",
+#                     for which check-node-selection.ts replaces phase equality
+#                     with an `execution.fix != null` interrupt-presence check.
+#                     A null `execution.fix` is exit 3. Exactly one of
+#                     --expect-phase / --expect-fix-active must be given.
 #   --pr-mode         none (default): skip PR resolution, never calls gh.
 #                     optional: resolve the open PR if one exists; empty is
 #                     NOT an error.
@@ -44,9 +69,14 @@
 #   1  node-not-found / read-failure (absent from origin/main, or the store
 #      primitives failed to read it)
 #   2  usage error (bad node-id, missing/duplicated gate flag) or branch mismatch
-#   3  gate mismatch: --expect-phase does not match the node's persisted phase,
-#      or --expect-fix-active and the node's execution.fix is null
+#   3  selection no longer valid. The full mechanical gate rejected it:
+#      phase/interrupt mismatch, an office_hours park, a stale serving-strategy
+#      fingerprint, no longer align-eligible, or an already-`reviewed` node
+#      re-selected for review. NOT a defect — the caller stops cleanly and the
+#      next tick re-selects from current state.
 #   4  --pr-mode required and no open PR was found
+#   5  scope-stale. The tactic's scope changed after the previous phase ran.
+#      NOT a defect — the node wants demoting to `implement`.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -117,7 +147,11 @@ if [[ "$CUR_BRANCH" != "$NODE_ID" ]]; then
   exit 2
 fi
 
-# --- Step 3: snapshot intentions/<node-id>.md from origin/main --------------
+# --- Step 3: snapshot the whole intentions/ tree from origin/main ------------
+# The WHOLE tree, not just intentions/<node-id>.md: Step 5's gate
+# (check-node-selection.ts via assert-node-selection) enumerates the store for
+# its align-eligibility and serving-strategy fingerprint checks. A single-file
+# snapshot would silently no-op those checks instead of erroring.
 # Fail loudly on a failed fetch: the whole point of the script is to gate on the
 # LATEST origin/main node state. A silent failure would proceed against a
 # possibly-stale local origin/main ref and make a wrong gate/PR decision.
@@ -129,7 +163,14 @@ git fetch origin main --quiet || {
 SNAP_DIR="$(mktemp -d)" || { echo "dispatch-derive-node-target: mktemp failed" >&2; exit 1; }
 trap 'rm -rf "$SNAP_DIR"' EXIT
 
-if ! git archive origin/main "intentions/$NODE_ID.md" 2>/dev/null | tar -x -C "$SNAP_DIR"; then
+if ! git archive origin/main intentions/ 2>/dev/null | tar -x -C "$SNAP_DIR"; then
+  echo "dispatch-derive-node-target: git archive origin/main intentions/ failed (no intentions tree at origin/main?)" >&2
+  exit 1
+fi
+
+# The widened archive succeeds whether or not the target node is in it, so the
+# exit-1 "node absent from origin/main" contract is preserved explicitly here.
+if [[ ! -f "$SNAP_DIR/intentions/$NODE_ID.md" ]]; then
   echo "dispatch-derive-node-target: node '$NODE_ID' not found at origin/main (intentions/$NODE_ID.md)" >&2
   exit 1
 fi
@@ -145,22 +186,34 @@ if [[ $? -ne 0 || -z "$COMBINED_JSON" ]]; then
   exit 1
 fi
 
-# --- Step 5: gate --------------------------------------------------------
+# --- Step 5: selection-validity gate ----------------------------------------
+# The full mechanical gate, not a phase-string comparison: assert-node-selection
+# wraps check-node-selection.ts, which re-runs every worker-start check
+# (phase/interrupt match, not-parked, align-eligibility, serving-strategy
+# fingerprint freshness, scope-chain custody) against the fresh origin/main
+# snapshot taken above.
+#
+# It runs BEFORE Step 6's PR resolution deliberately: a stale selection must
+# exit before any network call to GitHub.
+#
 # ACTUAL_PHASE is read regardless of gate mode — it is emitted informationally
-# on the PHASE: line (step 7). It is the gate criterion only under --expect-phase.
+# on the PHASE: line (step 7); the gate itself reads the node independently.
 ACTUAL_PHASE="$(jq -r '.node.phase' <<<"$COMBINED_JSON")"
-if [[ "$EXPECT_FIX_ACTIVE" -eq 1 ]]; then
-  ACTUAL_FIX="$(jq -r '.node.execution.fix // "null"' <<<"$COMBINED_JSON")"
-  if [[ "$ACTUAL_FIX" == "null" ]]; then
-    echo "dispatch-derive-node-target: node '$NODE_ID' has no active CI-fix interrupt (execution.fix is null)" >&2
-    exit 3
-  fi
-else
-  if [[ "$ACTUAL_PHASE" != "$EXPECT_PHASE" ]]; then
-    echo "dispatch-derive-node-target: node '$NODE_ID' is at phase '$ACTUAL_PHASE', expected '$EXPECT_PHASE'" >&2
-    exit 3
-  fi
-fi
+
+# --expect-fix-active maps to the literal selected-phase "fix", for which
+# check-node-selection.ts swaps phase equality for an `execution.fix != null`
+# interrupt-presence gate — exactly the old hand-rolled behavior.
+if [[ "$EXPECT_FIX_ACTIVE" -eq 1 ]]; then GATE_PHASE="fix"; else GATE_PHASE="$EXPECT_PHASE"; fi
+# stdout discarded: the gate prints a scope fingerprint, and this script's own
+# stdout is a structured payload that must not gain a stray line.
+"$SCRIPT_DIR/assert-node-selection" "$NODE_ID" "$GATE_PHASE" --dir "$SNAP_DIR/intentions" >/dev/null
+GATE_RC=$?
+case "$GATE_RC" in
+  0)  ;;
+  12) exit 3 ;;
+  13) exit 5 ;;
+  *)  exit 1 ;;
+esac
 
 # --- Step 6: PR resolution ------------------------------------------------
 PR_NUM=""

--- a/.claude/skills/dispatch-propagate/scripts/test-assert-node-selection.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-assert-node-selection.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Tests for assert-node-selection — the shared selection-validity gate
+# primitive (tactic-phase-entry-selection-gate, unit 1).
+#
+# Harness: an ephemeral bare-origin + working-checkout git fixture (mirrors
+# test-dispatch-derive-node-target.sh's make_repo()). DISPATCH_GRAPH_MAIN_WORKTREE
+# is pointed at the working checkout so lib-graph-worktree.sh's
+# resolve_main_worktree resolves it directly without a real `git worktree
+# list` walk (same override test-provision-node-worktree.sh uses).
+#
+# The SUT is run IN PLACE (not copied to a scratch dir), so its own
+# SCRIPT_DIR/REPO_ROOT derivation resolves to the real repo root — which is
+# exactly what lets it invoke the REAL `npx tsx
+# packages/intentionsutil/scripts/check-node-selection.ts` against the fixture
+# snapshot. No npx/gh stubbing: the point of this suite is the plumbing PLUS
+# the verdict, not an isolated unit test of the gate script (that lives in
+# check-node-selection.ts's own test suite).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+source "$SCRIPT_DIR/test-helpers.sh"
+SUT="$SCRIPT_DIR/assert-node-selection"
+
+TMP_ROOT=""
+cleanup() { [ -n "${TMP_ROOT:-}" ] && rm -rf "$TMP_ROOT"; }
+trap cleanup EXIT INT TERM
+TMP_ROOT=$(mktemp -d)
+
+BODY_MARKER="FIXTURE BODY MARKER TEXT"
+
+# Write a valid intentions/<id>.md node file into $1 (a repo working dir).
+# $2 = node id, $3 = phase, $4 = office_hours YAML block (optional; defaults
+# to `office_hours: null`), $5 = attributes YAML block (optional; defaults to
+# `attributes: {}`).
+write_node_fixture() {
+  local repo="$1" id="$2" phase="$3"
+  local office_hours="${4:-office_hours: null}"
+  local attributes="${5:-attributes: {}}"
+  mkdir -p "$repo/intentions"
+  cat > "$repo/intentions/$id.md" <<EOF
+---
+id: $id
+kind: tactic
+statement: Fixture tactic node for assert-node-selection tests
+owner: ai
+status: codified
+parent: null
+phase: $phase
+execution: null
+serves: []
+recovers: []
+clarifications: []
+tooling_goals: []
+validates: []
+blocked_by: []
+$office_hours
+pace_exempt: false
+rounds: null
+$attributes
+rationale: null
+reading: null
+gap: null
+success_signal: null
+attention: null
+---
+# Fixture tactic node
+
+$BODY_MARKER
+EOF
+}
+
+# Build a fresh ephemeral bare-origin + working-checkout fixture, seeded with
+# one placeholder node (so `git archive origin/main intentions/` always has
+# something to archive — an empty tracked dir would make the archive itself
+# fail, manufacturing a false exit 1 unrelated to the case under test). Sets
+# globals: REPO, BARE.
+REPO=""
+BARE=""
+make_repo() {
+  REPO=$(mktemp -d "$TMP_ROOT/repo.XXXXXX")
+  BARE=$(mktemp -d "$TMP_ROOT/bare.XXXXXX")
+
+  git -C "$BARE" init --bare --quiet --initial-branch=main
+
+  git -C "$REPO" init --quiet --initial-branch=main
+  git -C "$REPO" config user.email "test@example.com"
+  git -C "$REPO" config user.name "Test User"
+  git -C "$REPO" remote add origin "$BARE"
+  mkdir -p "$REPO/.claude/worktrees"
+
+  write_node_fixture "$REPO" "placeholder-node" implement
+
+  git -C "$REPO" add -A
+  git -C "$REPO" commit --quiet -m "baseline"
+  git -C "$REPO" push --quiet origin main
+}
+
+# Commit and push whatever is currently in $REPO's working tree to origin/main.
+push_repo() {
+  git -C "$REPO" add -A
+  git -C "$REPO" commit --quiet -m "update"
+  git -C "$REPO" push --quiet origin main
+}
+
+# Run the SUT with CWD inside $REPO, DISPATCH_GRAPH_MAIN_WORKTREE pointed at
+# $REPO so resolve_main_worktree resolves it directly. Sets globals: RC, OUT.
+RC=0
+OUT=""
+run_sut() {
+  local prev_dir
+  prev_dir=$(pwd)
+  cd "$REPO"
+  set +e
+  OUT=$(DISPATCH_GRAPH_MAIN_WORKTREE="$REPO" "$SUT" "$@" 2>&1)
+  RC=$?
+  # The suite runs `set -uo pipefail` and never enables errexit; `set +e`
+  # above only guards this one command substitution.
+  cd "$prev_dir"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: valid selection at phase implement -> exit 0, stdout is a 64-hex
+# fingerprint.
+# ---------------------------------------------------------------------------
+echo "Test 1: valid selection -> exit 0, 64-hex fingerprint"
+make_repo
+write_node_fixture "$REPO" "tactic-valid" implement
+push_repo
+run_sut "tactic-valid" implement
+assert_eq "valid-selection: exit 0" "0" "$RC"
+if [[ "$OUT" =~ ^[0-9a-f]{64}$ ]]; then
+  assert_eq "valid-selection: stdout is 64-hex fingerprint" "0" "0"
+else
+  assert_eq "valid-selection: stdout is 64-hex fingerprint (got: $OUT)" "0" "1"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: phase advanced (qa on disk, implement requested) -> exit 12.
+# ---------------------------------------------------------------------------
+echo "Test 2: phase advanced -> exit 12"
+make_repo
+write_node_fixture "$REPO" "tactic-advanced" qa
+push_repo
+run_sut "tactic-advanced" implement
+assert_eq "phase-advanced: exit 12" "12" "$RC"
+
+# ---------------------------------------------------------------------------
+# Test 3: node absent from origin/main -> exit 12 (check 1: exists).
+# ---------------------------------------------------------------------------
+echo "Test 3: node absent -> exit 12"
+make_repo
+run_sut "tactic-absent" implement
+assert_eq "node-absent: exit 12" "12" "$RC"
+
+# ---------------------------------------------------------------------------
+# Test 4: office_hours populated (first-class) -> exit 12.
+# ---------------------------------------------------------------------------
+echo "Test 4: office_hours populated -> exit 12"
+make_repo
+OFFICE_HOURS_BLOCK=$(cat <<'EOF'
+office_hours:
+  reason: fixture park
+  since: 2026-08-01
+  recommendation: null
+  session_type: other
+EOF
+)
+write_node_fixture "$REPO" "tactic-parked" implement "$OFFICE_HOURS_BLOCK"
+push_repo
+run_sut "tactic-parked" implement
+assert_eq "office-hours-parked: exit 12" "12" "$RC"
+
+# ---------------------------------------------------------------------------
+# Test 5: attributes.office_hours squatter populated, top-level office_hours
+# null -> exit 12 (the squatter case today's front door misses entirely).
+# ---------------------------------------------------------------------------
+echo "Test 5: squatter attributes.office_hours populated -> exit 12"
+make_repo
+ATTRIBUTES_BLOCK=$(cat <<'EOF'
+attributes:
+  office_hours:
+    reason: squatter park
+    since: 2026-08-01
+    recommendation: null
+    session_type: other
+EOF
+)
+write_node_fixture "$REPO" "tactic-squatter-parked" implement "office_hours: null" "$ATTRIBUTES_BLOCK"
+push_repo
+run_sut "tactic-squatter-parked" implement
+assert_eq "squatter-office-hours-parked: exit 12" "12" "$RC"
+
+# ---------------------------------------------------------------------------
+# Test 6: --dir supplied -> no git fetch occurs. Assert by pointing origin at
+# an unreachable path (never pushed there) and still getting exit 0 from the
+# working-tree fixture passed via --dir.
+# ---------------------------------------------------------------------------
+echo "Test 6: --dir supplied -> no fetch, exit 0 even with unreachable origin"
+make_repo
+write_node_fixture "$REPO" "tactic-dir-override" implement
+git -C "$REPO" remote set-url origin "/nonexistent/path/origin.git"
+run_sut "tactic-dir-override" implement --dir "$REPO/intentions"
+assert_eq "dir-override: exit 0" "0" "$RC"
+
+# ---------------------------------------------------------------------------
+# Test 7: invalid node id -> exit 2.
+# ---------------------------------------------------------------------------
+echo "Test 7: invalid node id -> exit 2"
+make_repo
+run_sut "Tactic_Bad" implement
+assert_eq "invalid-node-id: exit 2" "2" "$RC"
+
+# ---------------------------------------------------------------------------
+# Test 8: unknown flag -> exit 2.
+# ---------------------------------------------------------------------------
+echo "Test 8: unknown flag -> exit 2"
+make_repo
+write_node_fixture "$REPO" "tactic-unknown-flag" implement
+push_repo
+run_sut "tactic-unknown-flag" implement --bogus-flag
+assert_eq "unknown-flag: exit 2" "2" "$RC"
+
+report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-derive-node-target.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-derive-node-target.sh
@@ -23,10 +23,15 @@ BODY_MARKER="FIXTURE BODY MARKER TEXT"
 
 # Write a valid intentions/<id>.md node file into $1 (a repo working dir).
 # $2 = node id, $3 = phase, $4 = execution YAML block (optional; defaults to
-# `execution: null`). $4 lets a case seed an active CI-fix interrupt
-# (execution.fix non-null) to exercise the --expect-fix-active gate.
+# `execution: null`), $5 = office_hours YAML block (optional; defaults to
+# `office_hours: null`).
+# $4 lets a case seed an active CI-fix interrupt (execution.fix non-null) to
+# exercise the --expect-fix-active gate, or an execution.markers list (e.g.
+# `reviewed`) to exercise the gate's reviewed-marker guard. $5 lets a case park
+# the node so the gate's not-parked check fires.
 write_node_fixture() {
   local repo="$1" id="$2" phase="$3" execution="${4:-execution: null}"
+  local office_hours="${5:-office_hours: null}"
   mkdir -p "$repo/intentions"
   cat > "$repo/intentions/$id.md" <<EOF
 ---
@@ -44,7 +49,7 @@ clarifications: []
 tooling_goals: []
 validates: []
 blocked_by: []
-office_hours: null
+$office_hours
 pace_exempt: false
 rounds: null
 attributes: {}
@@ -67,6 +72,8 @@ EOF
 # $2 = "with_node:<phase>" to seed intentions/<node-id>.md on origin/main
 #      before push (execution: null); "with_fix:<phase>" to seed it with a
 #      non-null execution.fix (an active CI-fix interrupt) at the given phase;
+#      "with_parked:<phase>" to seed it with a populated office_hours park;
+#      "with_reviewed:<phase>" to seed it with execution.markers: [reviewed];
 #      or empty to omit the node entirely.
 REPO=""
 BARE=""
@@ -81,6 +88,10 @@ make_repo() {
   git -C "$REPO" config user.email "test@example.com"
   git -C "$REPO" config user.name "Test User"
   git -C "$REPO" remote add origin "$BARE"
+  # The selection gate resolves its scope-fingerprint stamp sidecar under
+  # <project-root>/.claude/worktrees/ (run_sut points DISPATCH_GRAPH_MAIN_WORKTREE
+  # here). Untracked — a stamp is a sidecar, never committed.
+  mkdir -p "$REPO/.claude/worktrees"
 
   if [[ "$seed" == with_node:* ]]; then
     local phase="${seed#with_node:}"
@@ -103,6 +114,33 @@ execution:
 FIXEOF
 )
     write_node_fixture "$REPO" "$branch_id" "$phase" "$exec_block"
+  elif [[ "$seed" == with_parked:* ]]; then
+    local phase="${seed#with_parked:}"
+    local park_block
+    park_block=$(cat <<'PARKEOF'
+office_hours:
+  reason: fixture park
+  since: 2026-08-01
+  recommendation: null
+  session_type: other
+PARKEOF
+)
+    write_node_fixture "$REPO" "$branch_id" "$phase" "execution: null" "$park_block"
+  elif [[ "$seed" == with_reviewed:* ]]; then
+    local phase="${seed#with_reviewed:}"
+    local reviewed_block
+    reviewed_block=$(cat <<'REVEOF'
+execution:
+  branch: fixture-branch
+  pr: null
+  attempts: {}
+  markers:
+    - reviewed
+  strategy_fingerprint: null
+  fix: null
+REVEOF
+)
+    write_node_fixture "$REPO" "$branch_id" "$phase" "$reviewed_block"
   else
     printf '%s\n' "# placeholder" > "$REPO/README.md"
   fi
@@ -158,7 +196,12 @@ run_sut() {
   : > "$GH_LOG"
   cd "$REPO"
   set +e
-  OUT=$(PATH="$STUB_DIR:$PATH" GH_LOG="$GH_LOG" GH_PR_NUM="${GH_PR_NUM:-}" "$SUT" "$@" 2>&1)
+  # DISPATCH_GRAPH_MAIN_WORKTREE pins the selection gate's project-root
+  # resolution (lib-graph-worktree.sh's resolve_main_worktree) at the fixture
+  # repo, so its scope-fingerprint stamp sidecar is looked up under
+  # $REPO/.claude/worktrees/ and never touches the real repo.
+  OUT=$(PATH="$STUB_DIR:$PATH" GH_LOG="$GH_LOG" GH_PR_NUM="${GH_PR_NUM:-}" \
+    DISPATCH_GRAPH_MAIN_WORKTREE="$REPO" "$SUT" "$@" 2>&1)
   RC=$?
   # The suite runs `set -uo pipefail` and never enables errexit; `set +e` above
   # only guards this one command substitution. Do NOT force errexit on here —
@@ -287,5 +330,48 @@ echo "Test 13: no gate flag given -> exit 2 (usage error)"
 make_repo "tactic-no-gate" "with_node:implement"
 run_sut "tactic-no-gate" --pr-mode none
 assert_eq "no-gate-flag: exit 2" "2" "$RC"
+
+# ---------------------------------------------------------------------------
+# The cases below cover the routing the shared selection gate
+# (assert-node-selection -> check-node-selection.ts) added to this front door
+# in tactic-phase-entry-selection-gate Unit 2. Test 2 (phase mismatch) and
+# Test 9 (--expect-fix-active with a null execution.fix) above are the same
+# contract, now regression-guarded through the shared gate rather than a local
+# phase-string comparison.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Test 14: node parked to office_hours between selection and entry -> exit 3.
+# Previously only qa-fix caught this, and only later; now every phase does, at
+# the front door, before any gh call.
+# ---------------------------------------------------------------------------
+echo "Test 14: office_hours-parked node -> exit 3"
+make_repo "tactic-parked-node" "with_parked:implement"
+run_sut "tactic-parked-node" --expect-phase implement --pr-mode required
+assert_eq "parked-node: exit 3" "3" "$RC"
+GH_LOG_SIZE=$(wc -c < "$GH_LOG" 2>/dev/null || echo 0)
+assert_eq "parked-node: gate ran before gh (gh log empty)" "0" "$GH_LOG_SIZE"
+
+# ---------------------------------------------------------------------------
+# Test 15: phase:review node already carrying the `reviewed` marker -> exit 3.
+# The execute-side mirror of the selector's reviewed-exclusion — the case a
+# hand-run or re-entry bypasses.
+# ---------------------------------------------------------------------------
+echo "Test 15: review node with the reviewed marker -> exit 3"
+make_repo "tactic-already-reviewed" "with_reviewed:review"
+run_sut "tactic-already-reviewed" --expect-phase review --pr-mode none
+assert_eq "already-reviewed: exit 3" "3" "$RC"
+
+# ---------------------------------------------------------------------------
+# Test 16: scope-stale — a stamp recording a different scope fingerprint than
+# the node's current statement+body -> exit 5. `qa` is one of the
+# scope-chained phases (fix/qa/review) the custody check applies to.
+# ---------------------------------------------------------------------------
+echo "Test 16: scope-stale stamp -> exit 5"
+make_repo "tactic-scope-stale" "with_node:qa"
+printf '%s %s\n' "0000000000000000000000000000000000000000000000000000000000000000" "deadbee" \
+  > "$REPO/.claude/worktrees/tactic-scope-stale.scope-fingerprint"
+run_sut "tactic-scope-stale" --expect-phase qa --pr-mode none
+assert_eq "scope-stale: exit 5" "5" "$RC"
 
 report_results

--- a/.claude/skills/fix-checks/SKILL.md
+++ b/.claude/skills/fix-checks/SKILL.md
@@ -76,10 +76,23 @@ case "$BRANCH" in
           # block (recommend step + $CLAUDE_JOB_DIR/office-hours-reason write).
           echo "ESCALATE-NO-PR: /fix-checks node '$NODE_ID' has no open PR — escalate to office-hours" >&2
           exit 1 ;;
+        3)
+          # The mechanical selection gate rejected the selection (phase/interrupt
+          # mismatch, office_hours park, stale serving-strategy fingerprint, no
+          # longer align-eligible, or an already-reviewed node re-selected). This
+          # is a stale selection, not a defect. End the session; make no graph
+          # write and open no PR.
+          echo "/fix-checks: node '$NODE_ID' selection no longer valid at origin/main (front door exit 3) — stale selection, not a defect; ending with no graph write and no PR" >&2
+          exit 0 ;;
+        5)
+          # Scope changed since the previous phase ran — the node wants demoting
+          # to implement, not a defect. End the session; make no graph write and
+          # open no PR.
+          echo "/fix-checks: node '$NODE_ID' is scope-stale at origin/main (front door exit 5) — wants demoting to implement, not a defect; ending with no graph write and no PR" >&2
+          exit 0 ;;
         *)
           # exit 1 (node not found / read failure), exit 2 (branch mismatch /
-          # bad node id), exit 3 (no active CI-fix interrupt — execution.fix is
-          # null): all real errors for this lane. Stop with a clear message.
+          # bad node id): real errors for this lane. Stop with a clear message.
           echo "/fix-checks: '$BRANCH' is not an actionable fix-checks node target: $DERIVE_OUT" >&2
           exit 1 ;;
       esac

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -68,12 +68,24 @@ case "$BRANCH" in
     fi
     if [ "$rc" -ne 0 ]; then
       case "$rc" in
-        1) echo "/implement: node '$NODE_ID' not found at origin/main (intentions/$NODE_ID.md)" >&2 ;;
-        2) echo "/implement: '$NODE_ID' is not a valid node id, or does not match the current worktree branch" >&2 ;;
-        3) echo "/implement: node '$NODE_ID' is not at phase 'implement' at origin/main" >&2 ;;
-        *) echo "/implement: dispatch-derive-node-target failed (exit $rc)" >&2 ;;
+        1) echo "/implement: node '$NODE_ID' not found at origin/main (intentions/$NODE_ID.md)" >&2; exit 1 ;;
+        2) echo "/implement: '$NODE_ID' is not a valid node id, or does not match the current worktree branch" >&2; exit 1 ;;
+        3)
+          # The mechanical selection gate rejected the selection (phase/interrupt
+          # mismatch, office_hours park, stale serving-strategy fingerprint, no
+          # longer align-eligible, or an already-reviewed node re-selected). This
+          # is a stale selection, not a defect. End the session; make no graph
+          # write and open no PR.
+          echo "/implement: node '$NODE_ID' selection no longer valid at origin/main (front door exit 3) — stale selection, not a defect; ending with no graph write and no PR" >&2
+          exit 0 ;;
+        5)
+          # Scope changed since the previous phase ran — the node wants demoting
+          # to implement, not a defect. End the session; make no graph write and
+          # open no PR.
+          echo "/implement: node '$NODE_ID' is scope-stale at origin/main (front door exit 5) — wants demoting to implement, not a defect; ending with no graph write and no PR" >&2
+          exit 0 ;;
+        *) echo "/implement: dispatch-derive-node-target failed (exit $rc)" >&2; exit 1 ;;
       esac
-      exit 1
     fi
     # Parse the front door's stdout: PR line (<num>|none), NODE-JSON section
     # (compact single-line frontmatter JSON), NODE-BODY section (raw markdown).

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -80,14 +80,24 @@ case "$BRANCH" in
           # mismatch, office_hours park, stale serving-strategy fingerprint, no
           # longer align-eligible, or an already-reviewed node re-selected). This
           # is a stale selection, not a defect. End the session; make no graph
-          # write and open no PR.
+          # write and open no PR. Record the terminal disposition FIRST so the
+          # Stop hook may reap this job — without the marker
+          # `dispatch-self-close --node` HOLDs the job alive and
+          # `dispatch-tick`'s `terminal_without_disposition_sweep` misreads this
+          # legitimate yield as an undeclared session and office_hours-PARKS the
+          # node. `no-claim` is the correct disposition: this session held no
+          # claim and did nothing.
+          packages/intentionsutil/scripts/mark-node-terminal "$NODE_ID" no-claim
           echo "/qa-fix: node '$NODE_ID' selection no longer valid at origin/main (front door exit 3) — stale selection, not a defect; ending with no graph write and no PR" >&2
           exit 0 ;;
         4) echo "/qa-fix: node '$BRANCH' has no open PR — qa-fix requires one" >&2; exit 1 ;;
         5)
           # Scope changed since the previous phase ran — the node wants demoting
           # to implement, not a defect. End the session; make no graph write and
-          # open no PR.
+          # open no PR. Same reap contract as exit 3 above: write the terminal
+          # disposition before returning, or the Stop hook holds the job and the
+          # per-tick sweep office_hours-parks the node.
+          packages/intentionsutil/scripts/mark-node-terminal "$NODE_ID" no-claim
           echo "/qa-fix: node '$NODE_ID' is scope-stale at origin/main (front door exit 5) — wants demoting to implement, not a defect; ending with no graph write and no PR" >&2
           exit 0 ;;
         *) echo "/qa-fix: dispatch-derive-node-target failed for '$NODE_ID' (exit $rc)" >&2; exit 1 ;;

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -74,12 +74,24 @@ case "$BRANCH" in
     rc=$?
     if [ "$rc" -ne 0 ]; then
       case "$rc" in
-        1) echo "/qa-fix: '$BRANCH' is neither a legacy '<N>-…' worktree nor a node with intentions/$NODE_ID.md at origin/main" >&2 ;;
-        3) echo "/qa-fix: node '$NODE_ID' phase is not 'qa' at origin/main (front door exit 3)" >&2 ;;
-        4) echo "/qa-fix: node '$BRANCH' has no open PR — qa-fix requires one" >&2 ;;
-        *) echo "/qa-fix: dispatch-derive-node-target failed for '$NODE_ID' (exit $rc)" >&2 ;;
+        1) echo "/qa-fix: '$BRANCH' is neither a legacy '<N>-…' worktree nor a node with intentions/$NODE_ID.md at origin/main" >&2; exit 1 ;;
+        3)
+          # The mechanical selection gate rejected the selection (phase/interrupt
+          # mismatch, office_hours park, stale serving-strategy fingerprint, no
+          # longer align-eligible, or an already-reviewed node re-selected). This
+          # is a stale selection, not a defect. End the session; make no graph
+          # write and open no PR.
+          echo "/qa-fix: node '$NODE_ID' selection no longer valid at origin/main (front door exit 3) — stale selection, not a defect; ending with no graph write and no PR" >&2
+          exit 0 ;;
+        4) echo "/qa-fix: node '$BRANCH' has no open PR — qa-fix requires one" >&2; exit 1 ;;
+        5)
+          # Scope changed since the previous phase ran — the node wants demoting
+          # to implement, not a defect. End the session; make no graph write and
+          # open no PR.
+          echo "/qa-fix: node '$NODE_ID' is scope-stale at origin/main (front door exit 5) — wants demoting to implement, not a defect; ending with no graph write and no PR" >&2
+          exit 0 ;;
+        *) echo "/qa-fix: dispatch-derive-node-target failed for '$NODE_ID' (exit $rc)" >&2; exit 1 ;;
       esac
-      exit 1
     fi
     N="$NODE_ID"; TARGET_KIND=node
     # Parse the front door's structured stdout into the seams the rest of the
@@ -89,21 +101,10 @@ case "$BRANCH" in
     [ "$PR_NUM" = none ] && PR_NUM=""
     NODE_JSON=$(printf '%s\n' "$FRONT_DOOR" | sed -n '/^=== NODE-JSON ===$/,/^=== NODE-BODY ===$/p' | sed '1d;$d')
     NODE_BODY=$(printf '%s\n' "$FRONT_DOOR" | sed -n '/^=== NODE-BODY ===$/,$p' | sed '1d')
-    # Parked-node re-entry guard. Parking sets office_hours without changing
-    # phase, so a stale self-scheduled wakeup re-firing mid-session (bypassing the
-    # selector's office_hours-null gate) must not re-run qa-fix against a node
-    # already handed to a human. Mirror the canonical selection gate `readParked`
-    # (packages/intentionsutil/scripts/check-node-selection.ts:90-93): a node is
-    # parked iff the first-class `office_hours` is non-null OR a populated
-    # `attributes.office_hours` squatter block is present (the squatter convention
-    # is live until tactic-schema-migration-backfill lands). The front door's
-    # structured NODE-JSON makes this a two-part jq OR instead of a frontmatter
-    # scrape.
-    PARKED=$(jq -r 'if (.office_hours != null) or ((.attributes.office_hours // null) != null) then "1" else "" end' <<<"$NODE_JSON")
-    if [ -n "$PARKED" ]; then
-      echo "/qa-fix: node '$NODE_ID' is already office_hours-parked at origin/main — nothing to do" >&2
-      exit 0
-    fi
+    # The front door's selection gate owns the parked check — first-class
+    # `office_hours` and the `attributes.office_hours` squatter alike
+    # (packages/intentionsutil/scripts/check-node-selection.ts:90-94, applied at
+    # :268-270). A parked node exits 3 above; there is nothing to re-check here.
     .claude/skills/dispatch-propagate/scripts/dispatch-context-pack "$PR_NUM" --pr --phase-log --pr-is-number
     ;;
 esac

--- a/.claude/skills/qa-fix/references/target-resolution.md
+++ b/.claude/skills/qa-fix/references/target-resolution.md
@@ -1,4 +1,4 @@
-# Step 0 — Node-lane target resolution and parked re-entry guard
+# Step 0 — Node-lane target resolution
 
 Node-lane target resolution runs **once**, in `SKILL.md`'s Idempotency preamble,
 through the shared front door `dispatch-derive-node-target`. Step 0 re-derives
@@ -32,8 +32,9 @@ Exit-code routing (`rc`), preserving qa-fix's existing behavior on each path:
 | 0 | success | continue; parse the structured stdout |
 | 1 | node absent from `origin/main` / read failure | hard stop, `exit 1` |
 | 2 | usage error or branch/node-id mismatch | hard stop, `exit 1` |
-| 3 | phase is not `qa` | hard stop, `exit 1` (stderr names the persisted phase) |
+| 3 | the mechanical selection gate rejected the selection (phase, park, fingerprint, align-eligibility, reviewed marker) | clean stop, `exit 0` — a stale selection, not a defect; no graph write, no PR |
 | 4 | `--pr-mode required` and no open PR | hard stop, `exit 1` |
+| 5 | scope-stale — the tactic's scope changed after the previous phase ran | clean stop, `exit 0` — not a defect, the node wants demoting to `implement` |
 
 The stdout sections bind the seams the rest of the skill keys off: the `PR:` line
 → `PR_NUM` (`none` → empty), `=== NODE-JSON ===` → `NODE_JSON` (the full
@@ -41,30 +42,12 @@ frontmatter as one compact JSON line), `=== NODE-BODY ===` → `NODE_BODY` (raw
 markdown, replacing the former whole-file frontmatter-plus-body read everywhere
 downstream).
 
-## Parked re-entry guard
+## Parked re-entry guard — retired
 
-Parking sets `office_hours` without changing `phase`, so a stale self-scheduled
-wakeup re-firing mid-session (bypassing the selector's `office_hours`-null gate)
-must not re-run qa-fix against a node already handed to a human. The guard must
-agree with the canonical selection gate `readParked`
-(`packages/intentionsutil/scripts/check-node-selection.ts:90-93`): a node is
-parked iff the first-class `office_hours` is non-null **OR** a populated
-`attributes.office_hours` squatter block is present (the squatter convention is
-live until `tactic-schema-migration-backfill` lands, and a squatter-parked node
-keeps the literal top-level `office_hours: null` alongside the populated block —
-so a top-level-only check would miss it).
-
-Against the front door's `NODE_JSON` this is a two-part `jq` OR on typed paths,
-not a frontmatter scrape — which also retires the scrape's own hazard of a prose
-body line reading exactly `office_hours: null` being mistaken for state:
-
-```bash
-PARKED=$(jq -r 'if (.office_hours != null) or ((.attributes.office_hours // null) != null) then "1" else "" end' <<<"$NODE_JSON")
-if [ -n "$PARKED" ]; then
-  echo "/qa-fix: node '$NODE_ID' is already office_hours-parked at origin/main — nothing to do" >&2
-  exit 0
-fi
-```
+The front door's selection gate owns the parked check — first-class
+`office_hours` and the `attributes.office_hours` squatter alike
+(`packages/intentionsutil/scripts/check-node-selection.ts:90-94`, applied at
+`:268-270`). A parked node exits 3 above; there is nothing to re-check here.
 
 `$N` keys the remaining steps' `tmp/` filenames (the issue number on the legacy
 lane, the node id on the node lane). `$TARGET_KIND` selects the lane at the seams

--- a/.claude/skills/qa-main/SKILL.md
+++ b/.claude/skills/qa-main/SKILL.md
@@ -69,11 +69,23 @@ case "$BRANCH" in
     rc=$?
     if [ "$rc" -ne 0 ]; then
       case "$rc" in
-        1|2) echo "/qa-main: '$BRANCH' is neither a legacy '<N>-…' worktree nor a node with intentions/$NODE_ID.md at origin/main" >&2 ;;
-        3) echo "/qa-main: node '$NODE_ID' phase is not 'main-qa' at origin/main (front door exit 3)" >&2 ;;
-        *) echo "/qa-main: dispatch-derive-node-target failed for '$NODE_ID' (exit $rc)" >&2 ;;
+        1|2) echo "/qa-main: '$BRANCH' is neither a legacy '<N>-…' worktree nor a node with intentions/$NODE_ID.md at origin/main" >&2; exit 1 ;;
+        3)
+          # The mechanical selection gate rejected the selection (phase/interrupt
+          # mismatch, office_hours park, stale serving-strategy fingerprint, no
+          # longer align-eligible, or an already-reviewed node re-selected). This
+          # is a stale selection, not a defect. End the session; make no graph
+          # write and open no PR.
+          echo "/qa-main: node '$NODE_ID' selection no longer valid at origin/main (front door exit 3) — stale selection, not a defect; ending with no graph write and no PR" >&2
+          exit 0 ;;
+        5)
+          # Scope changed since the previous phase ran — the node wants demoting
+          # to implement, not a defect. End the session; make no graph write and
+          # open no PR.
+          echo "/qa-main: node '$NODE_ID' is scope-stale at origin/main (front door exit 5) — wants demoting to implement, not a defect; ending with no graph write and no PR" >&2
+          exit 0 ;;
+        *) echo "/qa-main: dispatch-derive-node-target failed for '$NODE_ID' (exit $rc)" >&2; exit 1 ;;
       esac
-      exit 1
     fi
     TARGET_KIND=node
     N="$NODE_ID"

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -66,18 +66,35 @@ case "$BRANCH" in
     DERIVE_ERR="tmp/derive-$NODE_ID.err"
     DERIVE_OUT=$(.claude/skills/dispatch-propagate/scripts/dispatch-derive-node-target \
       "$NODE_ID" --expect-phase review --pr-mode required 2>"$DERIVE_ERR")
-    case $? in
+    DERIVE_RC=$?
+    case "$DERIVE_RC" in
       0) ;;
       1|2)
         echo "/review-fix: '$BRANCH' is neither a legacy '<N>-…' worktree nor a node with intentions/$NODE_ID.md at origin/main" >&2
         exit 1 ;;
       3)
-        # Phase mismatch — the front door's stderr already names the persisted phase.
-        echo "/review-fix: node '$NODE_ID' is not at phase 'review' at origin/main: $(cat "$DERIVE_ERR")" >&2
-        exit 1 ;;
+        # The mechanical selection gate rejected the selection (phase/interrupt
+        # mismatch, office_hours park, stale serving-strategy fingerprint, no
+        # longer align-eligible, or an already-reviewed node re-selected — the
+        # front door's stderr names the specifics). This is a stale selection,
+        # not a defect. End the session; make no graph write and open no PR.
+        echo "/review-fix: node '$NODE_ID' selection no longer valid at origin/main (front door exit 3): $(cat "$DERIVE_ERR") — stale selection, not a defect; ending with no graph write and no PR" >&2
+        exit 0 ;;
       4)
         # --pr-mode required found no open PR — preserve review-fix's plain hard stop.
         echo "/review-fix: node '$NODE_ID' has no open PR — review-fix requires one" >&2
+        exit 1 ;;
+      5)
+        # Scope changed since the previous phase ran — the node wants demoting
+        # to implement, not a defect. End the session; make no graph write and
+        # open no PR.
+        echo "/review-fix: node '$NODE_ID' is scope-stale at origin/main (front door exit 5) — wants demoting to implement, not a defect; ending with no graph write and no PR" >&2
+        exit 0 ;;
+      *)
+        # Any exit code not otherwise handled above — a real error. Hard-stop
+        # rather than silently falling through with an empty DERIVE_OUT and
+        # unbound PR_NUM/NODE_JSON.
+        echo "/review-fix: dispatch-derive-node-target failed for '$NODE_ID' (exit $DERIVE_RC): $(cat "$DERIVE_ERR")" >&2
         exit 1 ;;
     esac
     PR_NUM=$(printf '%s\n' "$DERIVE_OUT" | sed -n 's/^PR: *//p' | head -1)


### PR DESCRIPTION
## What

Wires the mechanical selection-validity gate (`packages/intentionsutil/scripts/check-node-selection.ts`) into every phase-skill entry point, not just the fresh-cut `provision-node-worktree` path — so a redundant, stale, parked, or terminal-state selection exits cheaply before any session-boot work, instead of relying on each skill's prose "Idempotency" reasoning.

**Unit 1** — new shared primitive `.claude/skills/dispatch-propagate/scripts/assert-node-selection`, wrapping `check-node-selection.ts`'s pure `evaluateSelection` core. Resolves the stamp/project root, fetches a fresh `origin/main` `intentions/` snapshot (or accepts a caller-supplied `--dir`), invokes the gate, and passes through its exit vocabulary unchanged (0 valid, 12 stale-selection, 13 scope-stale). New test suite `test-assert-node-selection.sh` (10 cases, including the parked and `attributes.office_hours` squatter cases).

**Unit 2** — routes `dispatch-derive-node-target`'s Step 5 (the shared front door all five tactic phase skills use) through the new primitive, replacing its hand-rolled bare phase-string comparison. Widens the `origin/main` snapshot from a single node file to the full `intentions/` tree (the gate's park/align-eligibility/fingerprint checks need the whole store). New exit codes 3 (selection no longer valid) and 5 (scope-stale) surface from the front door. Extended `test-dispatch-derive-node-target.sh` with 4 new cases (25/25 total).

**Unit 3** — updates `implement`, `qa-fix`, `fix-checks`, `review-fix`, and `qa-main`'s `SKILL.md`s to route the front door's new exit 3/5 to a clean stop (`exit 0`, not `exit 1`) — a stale selection is the documented `skipped` disposition, not a defect. Fixes a latent fall-through bug in `review-fix` (no default arm meant an unhandled exit code would continue with unbound `PR_NUM`/`NODE_JSON`). Retires `qa-fix`'s now-redundant hand-rolled parked-node guard (duplicate `jq`/`office_hours` check) now that the front door's gate owns it uniformly.

**Unit 4** — binds the gate to `/align-tactics` Step 0, alongside the existing `assert-worktree-fresh` freshness-only check, so both worktree entry paths (fresh-cut and native re-entry) get full selection validation. Documents the exit routing (0 proceed, 12 `mark-node-terminal ... no-claim` + stop, 13/other mechanical error + stop) and the four skills deliberately left ungated (`/office-hours`, `/align-strategy`, `/align-init`, `/grounding-research`), each for a documented structural reason (parked-by-definition, phase-less target, no target at all, multi-node walk).

## Out of scope

Wiring `mark-node-terminal` into the five tactic phase skills' own stale-selection paths (a separate known gap); any edit to `check-node-selection.ts`, `provision-node-worktree`, or `assert-worktree-fresh` itself; `align-strategy`, `align-init`, `grounding-research`, `office-hours` (deliberately not gated — see Unit 4 above).

## Testing

All plan-specified verify blocks pass locally:

```verify
.claude/skills/dispatch-propagate/scripts/test-assert-node-selection.sh
```
10/10 passed.

```verify
.claude/skills/dispatch-propagate/scripts/test-dispatch-derive-node-target.sh
```
25/25 passed.

```verify
.claude/skills/dispatch-propagate/scripts/test-provision-node-worktree.sh
```
36/36 passed.

```verify
npx vitest run --project packages/intentionsutil --root .
```
766/766 passed.

```verify
bash -n .claude/skills/dispatch-propagate/scripts/assert-node-selection && bash -n .claude/skills/dispatch-propagate/scripts/dispatch-derive-node-target
```
Clean.

Graph node: `tactic-phase-entry-selection-gate`
