### PR TITLE
review-fix: surface/file Lane-A residue when the disposition agent dies

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/review-fix-residue-death-probe.mjs
+++ b/.claude/skills/dispatch-propagate/scripts/review-fix-residue-death-probe.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// review-fix-residue-death-probe.mjs (tactic-review-fix-residue-death-coverage)
+//
+// CI-vector probe for undispositionedResidueRecords in
+// .claude/workflows/review-fix.js. run-unit-tests.sh has no mapping for
+// .claude/workflows/*, so a PR touching only review-fix.js triggers no vitest
+// suite. Its test-*.sh glob over this directory is NOT a fallback either: that
+// glob only runs when RUN_PR_SCRIPTS is set, which auto-detect sets solely for
+// changed paths under .claude/skills/dispatch-propagate/scripts/
+// (run-unit-tests.sh:88). The actual CI vector is the hook-tests job in
+// .github/workflows/unit-tests.yml, which runs test-review-fix-residue-death.sh
+// (this probe's driver) unconditionally on every PR. Keep that step wired —
+// deleting it removes all coverage here.
+//
+// review-fix.js is a Workflow-tool script (top-level await + injected globals),
+// so it CANNOT be imported/executed by node. Instead this probe SLICES the pure
+// residueTruncate + undispositionedResidueRecords text out from between two
+// sentinel comments and evals just that slice, then runs it on a fixture set
+// and prints the results.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Resolve review-fix.js relative to this helper's own location. This helper
+// sits at .claude/skills/dispatch-propagate/scripts/, so review-fix.js is
+// three dirs up at .claude/workflows/review-fix.js.
+const reviewFixPath = fileURLToPath(
+  new URL('../../../workflows/review-fix.js', import.meta.url)
+);
+
+const source = readFileSync(reviewFixPath, 'utf8');
+
+const START =
+  "// >>> residue death coverage: sliced + eval'd by review-fix-residue-death-probe.mjs >>>";
+const END = '// <<< residue death coverage <<<';
+
+// FAIL LOUDLY: each sentinel must appear exactly once.
+function countOccurrences(haystack, needle) {
+  let count = 0;
+  let idx = haystack.indexOf(needle);
+  while (idx !== -1) {
+    count += 1;
+    idx = haystack.indexOf(needle, idx + needle.length);
+  }
+  return count;
+}
+
+const startCount = countOccurrences(source, START);
+const endCount = countOccurrences(source, END);
+if (startCount !== 1) {
+  process.stderr.write(
+    `review-fix-residue-death-probe: START sentinel not found exactly once (count=${startCount}) in ${reviewFixPath}\n`
+  );
+  process.exit(1);
+}
+if (endCount !== 1) {
+  process.stderr.write(
+    `review-fix-residue-death-probe: END sentinel not found exactly once (count=${endCount}) in ${reviewFixPath}\n`
+  );
+  process.exit(1);
+}
+
+// The sliced text is strictly between the end of the START sentinel line and
+// the start of the END sentinel line.
+const startIdx = source.indexOf(START) + START.length;
+const endIdx = source.indexOf(END);
+// .trim() is load-bearing for the same ASI reason the qa-fix-partition-probe
+// documents — but the shape here differs: the slice contains TWO top-level
+// statements (`const residueTruncate = ...` then `function
+// undispositionedResidueRecords...`), not a single expression, so it cannot be
+// wrapped as `new Function('return ' + fnSource)()` the way a single function
+// expression can. Instead the slice is eval'd directly (in an IIFE, to avoid
+// leaking into this module's top level) and the IIFE returns
+// undispositionedResidueRecords, closing over residueTruncate.
+const sliceSource = source.slice(startIdx, endIdx).trim();
+
+if (!sliceSource) {
+  process.stderr.write('review-fix-residue-death-probe: empty slice between sentinels\n');
+  process.exit(1);
+}
+
+const undispositionedResidueRecords = (function () {
+  // eslint-disable-next-line no-eval -- see comment above // type-safety-ok: eval is required (not new Function) because the sliced source has two top-level statements, not a single expression
+  return eval(`(function () { ${sliceSource}\nreturn undispositionedResidueRecords; })()`);
+})();
+
+// Fixture table (Unit 2 of tactic-review-fix-residue-death-coverage).
+
+function item(overrides) {
+  return {
+    description: 'a residue finding',
+    location: 'foo.js:1',
+    recommended_fix: 'do the thing',
+    source: 'code-review',
+    severity: 'medium',
+    ...overrides,
+  };
+}
+
+const results = {};
+
+// all-triaged: both indices present in dispositionedIdx (values irrelevant —
+// only .has() is consulted) → nothing undispositioned.
+results['all-triaged'] = undispositionedResidueRecords(
+  [item({ description: 'first' }), item({ description: 'second' })],
+  new Map([
+    [0, true],
+    [1, false],
+  ]),
+  {}
+);
+
+// total-death: no index triaged → every item surfaces.
+results['total-death'] = undispositionedResidueRecords(
+  [item({ description: 'first' }), item({ description: 'second' })],
+  new Map(),
+  {}
+);
+
+// partial-drop: index 1 triaged, 0 and 2 are not.
+results['partial-drop'] = undispositionedResidueRecords(
+  [
+    item({ description: 'first' }),
+    item({ description: 'second' }),
+    item({ description: 'third' }),
+  ],
+  new Map([[1, true]]),
+  {}
+);
+
+// empty-residue: no items at all.
+results['empty-residue'] = undispositionedResidueRecords([], new Map(), {});
+
+// fields: a single item whose description is well over 200 non-whitespace
+// characters (so the 140-char truncation is real, not a no-op), plus explicit
+// source/recommended_fix/opts to pin the body/short_desc/title/backlink shape.
+const LONG_DESCRIPTION = 'x'.repeat(250);
+results['fields'] = undispositionedResidueRecords(
+  [
+    item({
+      description: LONG_DESCRIPTION,
+      source: 'security-review',
+      recommended_fix: 'RFX',
+    }),
+  ],
+  new Map(),
+  { pr_num: 4242, blocker_issue_nums: [7, 9] }
+);
+
+// independent-blockers: blocker_issue_nums passed through verbatim when it is
+// the sentinel string 'independent' (mirrors the Lane-B blockerNums shape).
+results['independent-blockers'] = undispositionedResidueRecords(
+  [item({ description: 'lone item' })],
+  new Map(),
+  { pr_num: 1, blocker_issue_nums: 'independent' }
+);
+
+process.stdout.write(JSON.stringify(results) + '\n');

--- a/.claude/skills/dispatch-propagate/scripts/test-review-fix-residue-death.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-review-fix-residue-death.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Tests for the residue death coverage helper (residueTruncate +
+# undispositionedResidueRecords, sliced out of .claude/workflows/review-fix.js
+# by review-fix-residue-death-probe.mjs) -- modeled directly on
+# test-review-fix-instrument.sh (tactic-review-fix-residue-death-coverage).
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=dispatch-test-fixture.sh
+source "$FIXTURE_DIR/dispatch-test-fixture.sh"
+
+# ============================================================================
+# === review-fix residue death coverage (tactic-review-fix-residue-death-coverage) ===
+# ============================================================================
+# CI vector: run-unit-tests.sh has no mapping for .claude/workflows/*, so a PR
+# touching only review-fix.js triggers no vitest suite. The hook-tests job
+# (this script) is the only test that runs on every PR, so coverage for
+# undispositionedResidueRecords must live here. The probe slices the pure
+# residueTruncate + undispositionedResidueRecords text out of review-fix.js
+# between sentinel comments and evals just that slice.
+
+echo "Test: review-fix residue death coverage"
+
+out=$(node "$SCRIPT_DIR/review-fix-residue-death-probe.mjs")
+
+# --- all-triaged: every index present in dispositionedIdx → nothing surfaces.
+assert_eq "residue death: all-triaged dispositions empty" "0" \
+  "$(printf '%s' "$out" | jq -r '."all-triaged".dispositions | length')"
+assert_eq "residue death: all-triaged deferred empty" "0" \
+  "$(printf '%s' "$out" | jq -r '."all-triaged".deferred | length')"
+assert_eq "residue death: all-triaged note empty" "" \
+  "$(printf '%s' "$out" | jq -r '."all-triaged".note')"
+
+# --- total-death: no index triaged → every item surfaces, in order, all
+# Deferred, with a note naming the fraction lost.
+assert_eq "residue death: total-death dispositions count" "2" \
+  "$(printf '%s' "$out" | jq -r '."total-death".dispositions | length')"
+assert_eq "residue death: total-death deferred count" "2" \
+  "$(printf '%s' "$out" | jq -r '."total-death".deferred | length')"
+assert_eq "residue death: total-death ids" "residue-0 residue-1" \
+  "$(printf '%s' "$out" | jq -r '[."total-death".dispositions[].id] | join(" ")')"
+assert_eq "residue death: total-death buckets all Deferred" "true" \
+  "$(printf '%s' "$out" | jq -r '[."total-death".dispositions[].bucket] | all(. == "Deferred")')"
+assert_eq "residue death: total-death note non-empty" "true" \
+  "$(printf '%s' "$out" | jq -r '."total-death".note | length > 0')"
+assert_eq "residue death: total-death note contains fraction" "true" \
+  "$(printf '%s' "$out" | jq -r '."total-death".note | contains("2 of 2")')"
+
+# --- partial-drop: only the triaged index (1) is absent from the result.
+assert_eq "residue death: partial-drop record count" "2" \
+  "$(printf '%s' "$out" | jq -r '."partial-drop".dispositions | length')"
+assert_eq "residue death: partial-drop ids" "residue-0 residue-2" \
+  "$(printf '%s' "$out" | jq -r '[."partial-drop".dispositions[].id] | join(" ")')"
+
+# --- empty-residue: no items at all → 0/0, no note.
+assert_eq "residue death: empty-residue dispositions empty" "0" \
+  "$(printf '%s' "$out" | jq -r '."empty-residue".dispositions | length')"
+assert_eq "residue death: empty-residue deferred empty" "0" \
+  "$(printf '%s' "$out" | jq -r '."empty-residue".deferred | length')"
+assert_eq "residue death: empty-residue note empty" "" \
+  "$(printf '%s' "$out" | jq -r '."empty-residue".note')"
+
+# --- fields: truncation, sources, body composition, blocker propagation, and
+# the absence of recommended_fix on the disposition entry (only Fixed/Required
+# buckets carry it elsewhere in review-fix.js; this helper's bucket is always
+# Deferred).
+assert_eq "residue death: fields short_desc truncated to 140" "140" \
+  "$(printf '%s' "$out" | jq -r '."fields".dispositions[0].short_desc | length')"
+assert_eq "residue death: fields title truncated to 80" "80" \
+  "$(printf '%s' "$out" | jq -r '."fields".deferred[0].title | length')"
+assert_eq "residue death: fields sources" "security-review" \
+  "$(printf '%s' "$out" | jq -r '."fields".dispositions[0].sources | join(",")')"
+assert_eq "residue death: fields body contains recommended fix" "true" \
+  "$(printf '%s' "$out" | jq -r '."fields".deferred[0].body | contains("Recommended fix: RFX")')"
+assert_eq "residue death: fields body contains backlink" "true" \
+  "$(printf '%s' "$out" | jq -r '."fields".deferred[0].body | contains("Backlink: #4242")')"
+assert_eq "residue death: fields body contains death rationale" "true" \
+  "$(printf '%s' "$out" | jq -r '."fields".deferred[0].body | contains("died after retries")')"
+assert_eq "residue death: fields blocker_issue_nums array" "7 9" \
+  "$(printf '%s' "$out" | jq -r '."fields".deferred[0].blocker_issue_nums | join(" ")')"
+assert_eq "residue death: fields disposition entry has no recommended_fix key" "false" \
+  "$(printf '%s' "$out" | jq -r '."fields".dispositions[0] | has("recommended_fix")')"
+
+# --- independent-blockers: the 'independent' sentinel passes through verbatim
+# (not treated as an array).
+assert_eq "residue death: independent-blockers blocker_issue_nums" "independent" \
+  "$(printf '%s' "$out" | jq -r '."independent-blockers".deferred[0].blocker_issue_nums')"
+
+# --- call-site / doctrine coverage (anti-regression teeth) ------------------
+# A future edit that keeps undispositionedResidueRecords but stops calling it,
+# or stops wiring its results into laneADispositions/laneADeferred, would
+# otherwise pass every fixture case above. These greps pin the call site and
+# every downstream consumer that must still reference it.
+
+assert_eq "residue death: helper call site present" "1" \
+  "$(grep -c 'undispositionedResidueRecords(laneAResidue, residueResolvedByIdx' "$REPO_ROOT/.claude/workflows/review-fix.js" || true)"
+assert_eq "residue death: results pushed into laneADispositions" "1" \
+  "$(grep -c 'laneADispositions.push(...undisposed.dispositions)' "$REPO_ROOT/.claude/workflows/review-fix.js" || true)"
+assert_eq "residue death: results pushed into laneADeferred" "1" \
+  "$(grep -c 'laneADeferred.push(...undisposed.deferred)' "$REPO_ROOT/.claude/workflows/review-fix.js" || true)"
+
+# coverage_incomplete = true appears at four sites in the current file: the
+# throttle path, the instrument gate, an interior residue-processing site, and
+# this residue-death wire-in. A future edit that drops any site's flag (or
+# adds an unrelated one) should be investigated, not silently absorbed.
+assert_eq "residue death: coverage_incomplete = true site count" "4" \
+  "$(grep -c 'coverage_incomplete = true' "$REPO_ROOT/.claude/workflows/review-fix.js" || true)"
+
+report_results

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -489,6 +489,13 @@ result = {
 }
 ```
 
+`coverage_incomplete` / `coverage_note` are the generic degraded-coverage
+signal, covering three causes: (1) the security probe wave skipped because
+both quality finders died, (2) an unverified instrument, and (3) Lane-A
+residue left undispositioned because the residue-disposition agent died;
+when more than one co-occurs in the same run, `coverage_note` is a
+space-joined composition of the causes.
+
 The Workflow's fix-authoring agents (non-isolated, Opus) have already edited the
 working tree by the time `result` is returned — this includes THREE sources
 of edits merged into the one envelope above: the shared Lane-B Opus fix fan-out,

--- a/.claude/skills/review-fix/references/pr-comment.md
+++ b/.claude/skills/review-fix/references/pr-comment.md
@@ -47,7 +47,11 @@ stands in for the security buckets):
   one-line rationale.
 - **False-positive (security)** — each with a one-line rationale.
 - **Deferred** — out-of-scope code-review findings; each references its
-  follow-up issue `#<N>` from Step 5a.
+  follow-up issue `#<N>` from Step 5a. A Deferred entry may also be an
+  *untriaged* Lane-A residue item the residue phase never reached (the
+  residue-disposition agent died before triaging it) rather than a
+  deliberate defer decision — its follow-up is filed the same way, via
+  Step 5.
 - **Out-of-scope (security)** — pre-existing CodeQL/npm findings; each meaningful
   one references its follow-up issue `#<N>` from Step 5b. CodeQL-sourced findings
   are identified by their `rule.id` and alert number (from `codeql_ref`), linked
@@ -56,8 +60,10 @@ stands in for the security buckets):
 If a security reviewer or inline scan could not run (re-launch / retry exhausted),
 note partial coverage here — name the reviewer or scan whose domain could not be
 reviewed. When `result.coverage_incomplete` is true, include `result.coverage_note`
-in this partial-coverage line (the probe-wave skipped the security finders because
-both quality finders died — the model was likely throttled). If every bucket is
+in this partial-coverage line — the note names the cause: a throttled
+probe wave, an unverified instrument, or Lane-A residue left undispositioned
+by a dead residue-disposition agent — and may name more than one, when
+multiple causes co-occur in the same run. If every bucket is
 empty and there was no security note, the comment is still well-formed (render
 empty buckets as `_None._`).
 

--- a/.claude/workflows/review-fix.js
+++ b/.claude/workflows/review-fix.js
@@ -39,6 +39,9 @@
  *     security_followup_input:[...codeql/npm out-of-scope subset...],
  *     verify_report:[{id, location, verdict, skeptic_votes, rationale}],
  *     deviation:bool, security_note?, coverage_incomplete:bool, coverage_note?:string,
+ *       // coverage_note is a space-joined composition of EVERY degraded-coverage
+ *       // cause this run hit (wave back-off, instrument failures, undispositioned
+ *       // Lane-A residue) — never a single cause's message.
  *     instrument_failures:[{instrument, reason}] }
  *
  * NORMATIVE SPECS for the three inline kernel helpers below are the pure bash/jq
@@ -1613,9 +1616,63 @@ const upheldErosionIds = new Set(
 // fan-out fully resolves so no two agents edit the working tree concurrently.
 phase('residue');
 
+// >>> residue death coverage: sliced + eval'd by review-fix-residue-death-probe.mjs >>>
 // Local truncation — inlined to avoid an ordering dependency on the `truncate`
 // function declaration defined later in file-prep.
 const residueTruncate = (text) => (text || '').trim().replace(/\s+/g, ' ').slice(0, 140);
+
+// Records for Lane-A residue items the disposition phase never triaged — the
+// disposition subagent died after retries (agent() already retries internally, so a
+// null result is a genuine outage), returned a short items list, or echoed refs that
+// mapped to no original item. Without this, those findings are dropped silently:
+// laneADispositions/laneADeferred stay empty, so they reach neither the PR comment
+// nor a follow-up. Mirrors the quality-finder-death and instrument-gate fail-safes.
+//
+// `dispositionedIdx` is read via `.has(idx)` ONLY — pass residueResolvedByIdx (a Map
+// keyed by original residue index); presence, not value, means "was triaged".
+// Pure: no injected globals, no I/O. Slice-tested by
+// .claude/skills/dispatch-propagate/scripts/review-fix-residue-death-probe.mjs.
+function undispositionedResidueRecords(residue, dispositionedIdx, opts) {
+  const list = residue || [];
+  const prNum = (opts && opts.pr_num) || '';
+  const blockerNums = opts && opts.blocker_issue_nums;
+  const dispositions = [];
+  const deferred = [];
+  list.forEach((orig, idx) => {
+    if (!orig) return;
+    if (dispositionedIdx && dispositionedIdx.has(idx)) return;
+    dispositions.push({
+      id: `residue-${idx}`,
+      short_desc: residueTruncate(orig.description),
+      location: orig.location,
+      bucket: 'Deferred',
+      sources: [orig.source],
+    });
+    deferred.push({
+      title: residueTruncate(orig.description).slice(0, 80),
+      body: [
+        orig.description,
+        '',
+        `Recommended fix: ${orig.recommended_fix}`,
+        '',
+        'Rationale: the review-fix residue-disposition agent died after retries, so ' +
+          'this Lane-A finding was never triaged (resolve/defer/ignore). Filed ' +
+          'unconditionally so it is not lost — triage it here.',
+        '',
+        `Backlink: #${prNum}`,
+      ].join('\n'),
+      blocker_issue_nums: blockerNums,
+    });
+  });
+  const note = dispositions.length
+    ? `Lane-A residue disposition degraded: ${dispositions.length} of ${list.length} ` +
+      'finding(s) were never triaged because the residue-disposition agent died after ' +
+      'retries. Each is listed under Deferred and filed as a follow-up.'
+    : '';
+  return { dispositions, deferred, note };
+}
+// <<< residue death coverage <<<
+
 // Blocker-issue attribution for defer filings — mirrors the Lane-B `blockerNums`
 // computation (defined later in file-prep); duplicated here since that const is
 // out of scope at this insertion point.
@@ -1945,6 +2002,24 @@ if (laneAResidue.length === 0) {
     }
     laneADispositions.push(entry);
   }
+  // Any laneAResidue index absent from residueResolvedByIdx got no valid disposition —
+  // total agent death, a short items list, or a ref that mapped to no original. Surface
+  // + file each so it is not silently dropped, and flag degraded coverage.
+  const undisposed = undispositionedResidueRecords(laneAResidue, residueResolvedByIdx, {
+    pr_num: _a.pr_num,
+    blocker_issue_nums: residueBlockerNums,
+  });
+  if (undisposed.dispositions.length) {
+    laneADispositions.push(...undisposed.dispositions);
+    laneADeferred.push(...undisposed.deferred);
+    coverage_incomplete = true;
+    // Preserve any note the throttle / instrument-gate paths already set.
+    coverage_note = [coverage_note, undisposed.note].filter(Boolean).join(' ');
+    log(
+      `residue: ${undisposed.dispositions.length} undispositioned item(s) surfaced as ` +
+        'Deferred and filed as follow-ups (disposition agent died after retries).'
+    );
+  }
   log(
     `residue: ${items.length} dispositioned — fixed=${laneAResidueFixed.length}, ` +
       `deferred=${laneADeferred.length}, audit=${laneADispositions.length}`
@@ -2073,7 +2148,11 @@ const security_followup_input = deduped
 //   - "resolved" means residueResolvedByIdx === true, a working-tree-VERIFIED applied
 //     resolve — an ignore/defer/phantom-resolve leaves the item unresolved and escalates.
 // A high-severity original item with no returned disposition (agent dropped it) has no
-// map entry (!== true) and therefore also escalates.
+// map entry (!== true) and therefore also escalates. Such an item now ALSO gets a
+// Deferred audit entry and a filed follow-up from undispositionedResidueRecords, so
+// escalation and durable capture are independent: capture happens for every dropped
+// residue item regardless of severity or source, and escalation still fires here only
+// for high-severity security-review ones.
 //
 // An unverified instrument escalates UNCONDITIONALLY — it is not severity-scaled,
 // because the failure is not "a finding went unfixed" but "the named review did
@@ -2182,9 +2261,15 @@ return {
   verify_report,
   deviation,
   security_note: _a.security_note,
-  // coverage_incomplete is independent of `deviation`: it flags a launch-efficiency
-  // back-off (wave 2 skipped because the security-review probe finder failed — model
-  // likely throttled), surfaced in the Step 6 partial-coverage comment line.
+  // coverage_incomplete is independent of `deviation`: it flags any way this run's
+  // review coverage came out degraded, surfaced in the Step 6 partial-coverage comment
+  // line. Three causes set it:
+  //   - the security wave was skipped because the quality finder died (a
+  //     launch-efficiency back-off — the model was likely throttled);
+  //   - a named instrument's receipt failed verification, so that stage's payload was
+  //     discarded;
+  //   - Lane-A residue was left undispositioned because the residue-disposition agent
+  //     died after retries (those items are surfaced as Deferred and filed anyway).
   coverage_incomplete,
   coverage_note,
   // One entry per stage whose named-instrument receipt failed verification. A

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -210,6 +210,8 @@ jobs:
         run: .claude/skills/dispatch-propagate/scripts/test-align-tactics-tempref.sh
       - name: Run review-fix instrument-gate tests
         run: .claude/skills/dispatch-propagate/scripts/test-review-fix-instrument.sh
+      - name: Run review-fix residue-death coverage tests
+        run: .claude/skills/dispatch-propagate/scripts/test-review-fix-residue-death.sh
       - name: Run dispatch-verify-instrument-invocation tests
         run: .claude/skills/dispatch-propagate/scripts/test-dispatch-verify-instrument-invocation.sh
       - name: Run dispatch-stop hook tests


### PR DESCRIPTION
## Summary

- Adds `undispositionedResidueRecords`, a pure helper in `.claude/workflows/review-fix.js`'s residue phase, that synthesizes a `Deferred`-bucket disposition and a filed follow-up for every Lane-A residue item the disposition subagent never triaged (total agent death, a short items list, or a ref mapping to no original item).
- Wires the helper into `coverage_incomplete` / `coverage_note` (no new envelope field) so the Step 6 PR comment's partial-coverage line names the degradation, alongside the existing throttle and unverified-instrument causes.
- Adds offline probe + shell test coverage (`review-fix-residue-death-probe.mjs`, `test-review-fix-residue-death.sh`) modeled on the existing instrument-gate probe/test pair, wired unconditionally into the `hook-tests` CI job since `.claude/workflows/*` has no automatic CI vector.
- Updates `review-fix` skill docs (`SKILL.md`, `references/pr-comment.md`) to name the third degraded-coverage cause.

## Test plan

- [x] `.claude/skills/dispatch-propagate/scripts/test-review-fix-residue-death.sh` (29/29 passing)
- [x] `.claude/skills/dispatch-propagate/scripts/test-review-fix-instrument.sh` (30/30 passing, unaffected)
- [x] `node --check .claude/workflows/review-fix.js`
- [x] `.claude/skills/dispatch-propagate/scripts/run-lint.sh --prose`
