### PR TITLE
auto-heal: reap sessions claude rm silently declined; make marker deletion prove the park landed

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
@@ -1,10 +1,22 @@
 #!/usr/bin/env bash
-# dispatch-sweep — reconcile worktrees: reap merged/closed worktrees. Fired by the worker Stop-hook via dispatch-spawn-sweep (the retired /dispatch-propagate router was the old caller).
+# dispatch-sweep — reconcile the fleet's leftovers: reap merged/closed worktrees, AND reap terminal worker sessions the daemon silently declined to remove. Fired by the worker Stop-hook via dispatch-spawn-sweep (the retired /dispatch-propagate router was the old caller).
 #
 # Usage:
-#   dispatch-sweep   — cleanup merged worktrees.
+#   dispatch-sweep   — cleanup merged worktrees and stranded sessions.
 #
-# Behavior, in order:
+# Two arms run per invocation:
+#   A. the WORKTREE arm (steps 1-4 below), which reaps worktrees and their
+#      branches;
+#   B. the SESSION arm (`session_reap_sweep`, lib-session-reap.sh), which reaps
+#      terminal `tactic-*` / `strategy-*` worker SESSIONS that `claude rm` exited
+#      0 on without actually removing. It removes the session's worktree FIRST —
+#      that is what makes the daemon accept the removal — then `claude rm`s, then
+#      VERIFIES the post-state by re-querying rather than trusting exit 0, and
+#      logs REAP_DECLINED when the id survives. Unlike arm A it NEVER deletes a
+#      branch. See that file's header for the full gate list and the reasoning.
+#      Arm B runs last; the placement comment at its call site says why.
+#
+# Behavior of the WORKTREE arm, in order:
 #   1. Enumerate registered worktrees under <project-root>/worktrees/, excluding
 #      the main worktree and detached HEADs.
 #   2. For each worktree, query its PR state directly with `gh pr list --head
@@ -31,9 +43,12 @@
 #                             reach before the NODE arm may reap it. Precedence:
 #                             sweep config nodeMinAgeSeconds -> this env override
 #                             -> baked default (3600).
+#   DISPATCH_SESSION_REAP_*   The SESSION arm's own seams (grace, roots, cap,
+#                             clock) — see lib-session-reap.sh's header.
 #
 # Exit codes:
-#   0  normal sweep completed (merged worktrees removed where possible).
+#   0  normal sweep completed (merged worktrees removed where possible; the
+#      session arm never changes the exit code — it always returns 0).
 #   2  invalid invocation (not in a git repo).
 #
 # NOT set -e: per-worktree errors should not abort the sweep — bookkeeping
@@ -51,6 +66,8 @@ source "$SCRIPT_DIR/lib-claude-agents.sh"
 source "$SCRIPT_DIR/lib-reservation-ledger.sh"
 # shellcheck source=./lib-worktree-reap.sh
 source "$SCRIPT_DIR/lib-worktree-reap.sh"
+# shellcheck source=./lib-session-reap.sh
+source "$SCRIPT_DIR/lib-session-reap.sh"
 
 # Resolve project root via resolve_project_root (lib.sh); native worktrees live
 # under <repo>/.claude/worktrees/ (the standard Claude Code layout).
@@ -521,6 +538,32 @@ if marker_dir=$(reap_marker_dir "$PROJECT_ROOT") && [[ -d "$marker_dir" ]]; then
   done
   shopt -u nullglob
 fi
+
+# ---- Session reap: terminal worker sessions `claude rm` silently declined ---
+# `claude rm <id>` exits 0 while DECLINING to remove a session whose worktree has
+# no verifiable repository, and dispatch-self-close's `exec claude rm` cannot
+# notice (exec replaces the process). The declined session stays registered
+# forever, holding a worker slot and — because worktree_has_live_session is
+# NAME-keyed — making its node permanently unselectable. session_reap_sweep
+# removes the worktree FIRST (which is what makes the daemon accept), then
+# `claude rm`s, then VERIFIES the post-state. See lib-session-reap.sh.
+#
+# PLACEMENT. After the per-worktree loop and the marker GC, and before the
+# held-for-debug metric:
+#   - after the loop, because Step 1 captured WT_PATHS up front: an arm that
+#     removed worktrees earlier would leave the loop iterating over paths that no
+#     longer exist. Running last also means the loop's own merged/closed/node
+#     reaps have already cleared whatever they could, so this arm usually takes
+#     its cheap "no worktree" path;
+#   - before HELD_FOR_DEBUG_COUNT, so that metric reports the state this sweep
+#     LEAVES BEHIND. Counting held sessions first would report sessions the
+#     sweep then removed, and the count exists precisely to show what is stuck.
+# It is passed $LOG_FILE so its disposition lines land in the same timestamped,
+# tagged log as every other decision here. Its stderr copy is deliberately NOT
+# redirected: it is the same text, and it reaches journald for the headless
+# systemd/Stop-hook callers that never read tmp/dispatch-sweep.log.
+# `|| true` is belt-and-suspenders — the function always returns 0 by contract.
+session_reap_sweep "$LOG_FILE" "dispatch-sweep" || true
 
 # ---- Held-for-debug session count (hygiene/observability metric) ------------
 # Log how many worker-keyspace sessions are sitting in a terminal state under

--- a/.claude/skills/dispatch-propagate/scripts/lib-frozen-session-park.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-frozen-session-park.sh
@@ -612,6 +612,38 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
   # session ids). `standdown_recheck_sweep` owns those nodes and parks them itself
   # once the winner is definitely gone.
   #
+  # Marker deletion is the PROOF that the park landed — not a cleanup step that
+  # trusts an exit code. `park-node` lands through `graph-commit`, which pushes to
+  # a contended `refs/graph/landing-lock`, and invariant I2 is explicit that a
+  # `graph-commit` exit 0 is NEVER evidence that anything reached `origin/main`.
+  # The session's `office-hours-reason` / `-recommendation` / `-pr` files are the
+  # ONLY surviving copy of its own escalation text, so deleting them on a bare
+  # exit 0 converts a RECOVERABLE failure — a node held-and-unparked, retryable on
+  # the next tick from the text still on disk — into an UNRECOVERABLE one, on the
+  # very path whose whole job is to prevent that state. That is the worst outcome
+  # available to this function, so an exit code alone does not get to authorize
+  # it.
+  #
+  # Step (13) therefore re-reads the node from a freshly fetched `origin/main`
+  # after every rc-0 park and deletes the markers ONLY when `office_hours` is
+  # non-null there — the park is then PROVEN landed, counted, and logged as
+  # before. `office_hours: null`, an absent `office_hours` key, a node file that
+  # is gone, or a read that fails at all all mean the park did NOT land despite
+  # the exit 0: the markers are KEPT, one loud `park-not-landed` line goes to
+  # stderr, a `park-not-landed` decision record is written (deliberately distinct
+  # from `park-failed` — a park that exited non-zero and a park that exited 0
+  # without landing have different causes and want different operator responses),
+  # and the park is NOT counted. The next tick retries with the session's own text
+  # intact. The confirmation read reuses step (8)'s frontmatter-scoped idiom
+  # verbatim, in the opposite polarity, and the frontmatter scoping is just as
+  # load-bearing here: a column-0 `office_hours:` line in the markdown BODY must
+  # never be able to certify a park that never landed.
+  #
+  # This makes the project's bug-J detect — `find $CLAUDE_JOB_DIR -maxdepth 2
+  # -name office-hours-reason`, where ANY hit is by definition a park that did not
+  # land — double as this heal's OWN success criterion: a marker that survives one
+  # sweep interval is a heal that failed, and it now says so in its own words.
+  #
   # Accepted residuals:
   #   - A session that DID declare but whose `claude rm` reap itself failed
   #     lingers as a terminal row and could be parked spuriously. This is rare;
@@ -636,10 +668,25 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
   #     skill wrote both.
   #
   # Two daemon queries (the `--all` candidate listing, which cannot come from the
-  # tick snapshot, and the snapshot-backed ACTIVE view behind the interlock) and
-  # at most one `git fetch` per invocation; the fetch is LAZY (only once a
-  # candidate has actually aged past the grace). One greppable stderr line per
-  # disposition, and exactly one summary line.
+  # tick snapshot, and the snapshot-backed ACTIVE view behind the interlock).
+  #
+  # The `git fetch` budget is ONE lazy pre-flight fetch per invocation — it runs
+  # only once a candidate has actually aged past the grace, so a sweep with no
+  # aged candidate does no network I/O at all — PLUS one confirmation fetch per
+  # park that returned rc 0. The second kind is not optional and not foldable into
+  # the first: the park itself just pushed, so by construction this checkout's
+  # `origin/main` is stale exactly when step (13) needs it to be current, and a
+  # confirmation read against a pre-park ref would report EVERY park as
+  # not-landed. The budget is therefore `1 + park_max` fetches (3 by default),
+  # bounded by the same park cap that bounds the `park-node` calls the extra
+  # fetches follow — and a `git fetch origin main` is negligible beside the
+  # `park-node` invocation it confirms. This paragraph, not the older "at most one
+  # `git fetch` per invocation" wording, is the contract; `frozen_session_sweep`
+  # (which does not confirm) still holds to the single-fetch form.
+  #
+  # A failed confirmation fetch is non-fatal and reads as NOT LANDED, which is the
+  # fail-safe direction: markers kept, park uncounted, retry next tick. One
+  # greppable stderr line per disposition, and exactly one summary line.
   #
   # Bounded and provenance-checked exactly as `frozen_session_sweep` is, and for
   # the same reasons (see that function's header): this sweep also runs INLINE on
@@ -1059,17 +1106,61 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
       GRAPH_COMMIT_LOCK_WAIT_SECONDS="$lock_wait" \
         "$timeout_bin" "$park_timeout" "$park_node" "${park_args[@]}" >/dev/null </dev/null || rc=$?
       if (( rc == 0 )); then
-        parked_count=$(( parked_count + 1 ))
-        printf 'lib-frozen-session-park: parked %s (terminal-without-disposition after %ss; session=%s)\n' "$name" "$idle" "$sid" >&2
-        _terminal_disposition_log_decision "$name" "$sid" "$idle" "parked"
-        # Clear the session's escalation markers so a later sweep cannot re-land
-        # stale text — mirroring dispatch-stop.sh's on-success cleanup, the one
-        # behaviour of the deleted backstop worth keeping. ONLY for a job dir
-        # this node actually owns: deleting another session's pending escalation
-        # markers would destroy its park evidence.
-        if (( job_owned )); then
-          rm -f "$job_dir/office-hours-reason" "$job_dir/office-hours-recommendation" \
-                "$job_dir/office-hours-pr" 2>/dev/null || true
+        # (13) Confirm the park actually LANDED. `park-node` lands through
+        # `graph-commit`, and invariant I2 says a `graph-commit` exit 0 is never
+        # evidence that anything reached `origin/main` — so the exit code alone
+        # does not get to authorize deleting the session's escalation markers,
+        # which are the only surviving copy of its own escalation text. Re-read
+        # the node from origin/main and require `office_hours` to be non-null
+        # there; marker deletion is the PROOF the park landed, not a cleanup step
+        # that trusts an exit code (see the header).
+        #
+        # The fetch is mandatory here, not latched with step (6)'s: the park we
+        # just ran is exactly what made this checkout's `origin/main` stale, so a
+        # confirmation read against the pre-park ref would report every park as
+        # not-landed. A failed fetch is non-fatal and falls through to a stale
+        # read, which reads as NOT LANDED — the fail-safe direction.
+        git -C "$repo_root" fetch origin main --quiet 2>/dev/null || true
+
+        # Same frontmatter-scoped idiom as step (8), in the OPPOSITE polarity:
+        # there it answers "was this already parked before we touched it", here
+        # "did OUR park land". Non-null under the YAML fences is the only thing
+        # that counts as landed; a null value, a missing `office_hours` key, and
+        # an unreadable/absent node file are all NOT landed. The frontmatter
+        # scoping is load-bearing for the same reason it is there: a column-0
+        # `office_hours:` line in the markdown BODY must never certify a park.
+        local landed=0 confirm_body confirm_frontmatter
+        if confirm_body=$(git -C "$repo_root" show "origin/main:intentions/${name}.md" 2>/dev/null); then
+          confirm_frontmatter=$(awk 'NR==1&&/^---/{f=1;next} f&&/^---[[:space:]]*$/{exit} f' <<<"$confirm_body")
+          if grep -q '^office_hours:' <<<"$confirm_frontmatter"; then
+            if ! grep -qE '^office_hours:[[:space:]]*null[[:space:]]*$' <<<"$confirm_frontmatter"; then
+              landed=1
+            fi
+          fi
+        fi
+
+        if (( landed )); then
+          parked_count=$(( parked_count + 1 ))
+          printf 'lib-frozen-session-park: parked %s (terminal-without-disposition after %ss; session=%s)\n' "$name" "$idle" "$sid" >&2
+          _terminal_disposition_log_decision "$name" "$sid" "$idle" "parked"
+          # Clear the session's escalation markers so a later sweep cannot re-land
+          # stale text — mirroring dispatch-stop.sh's on-success cleanup, the one
+          # behaviour of the deleted backstop worth keeping. Reached ONLY with the
+          # park proven landed on origin/main, and ONLY for a job dir this node
+          # actually owns: deleting another session's pending escalation markers
+          # would destroy its park evidence.
+          if (( job_owned )); then
+            rm -f "$job_dir/office-hours-reason" "$job_dir/office-hours-recommendation" \
+                  "$job_dir/office-hours-pr" 2>/dev/null || true
+          fi
+        else
+          # Exit 0, but nothing landed. Loud and distinctly greppable, because
+          # this is the shape that used to destroy the evidence silently: the
+          # markers are KEPT so the next tick retries with the session's own
+          # text, and the park is NOT counted.
+          printf 'lib-frozen-session-park: park-not-landed for %s — park-node exited 0 but origin/main still shows no office_hours on intentions/%s.md; graph-commit exit 0 is not evidence a write landed (I2). KEEPING the escalation markers; will retry next tick\n' \
+            "$name" "$name" >&2
+          _terminal_disposition_log_decision "$name" "$sid" "$idle" "park-not-landed"
         fi
       elif (( rc == 124 )); then
         # A timeout is just another park failure — same non-fatal handling, the

--- a/.claude/skills/dispatch-propagate/scripts/lib-session-reap.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-session-reap.sh
@@ -1,0 +1,541 @@
+#!/usr/bin/env bash
+# lib-session-reap.sh — sourceable helper that reaps terminal graph-node worker
+# sessions the daemon has DECLINED to remove.
+#
+# The failure this closes: `claude rm <id>` exits 0 while DECLINING to remove a
+# session whose worktree has no verifiable repository — a branch that was never
+# pushed to origin. It prints
+#
+#   kept <id> — worktree has files but no repository to verify them against
+#
+# and exits 0. `dispatch-self-close` ends with `exec "$CLAUDE_CMD" rm "$JOB_ID"`
+# and treats that exec AS the reap: `exec` replaces the process, so nothing
+# survives to check the outcome. A decline is therefore indistinguishable from a
+# removal — no error, no retry, no detection. The session stays registered in
+# `claude agents --json --all` forever, and because `worktree_has_live_session`
+# is NAME-keyed on the node id, that node becomes permanently unselectable while
+# still consuming a live-session slot.
+#
+# It is systemic, not incidental: an `/align-tactics` round lands its work by
+# `graph-commit` direct-push to `main` and never pushes a branch named for the
+# node, so EVERY align-round worker ends in exactly this state. Measured
+# 2026-08-03: 8 sessions cleared by hand in one day, two of three worker slots
+# stranded.
+#
+# `session_reap_sweep` is the fix, and it belongs here rather than in
+# `dispatch-self-close` for one structural reason: the reap must be performed by
+# something that OUTLIVES the session, so the post-state can be verified. A
+# self-closing session cannot verify its own removal — by construction, if the
+# removal worked there is no one left to look.
+#
+# TWO bits are load-bearing, and they are exactly what the `exec claude rm` path
+# lacks:
+#   (a) `git worktree remove` runs BEFORE `claude rm`. Removing the worktree is
+#       what makes the daemon ACCEPT the removal — the decline is about an
+#       unverifiable worktree, so deleting it removes the objection.
+#   (b) the post-state is VERIFIED by re-querying the registry, instead of
+#       trusting exit 0. A still-present id is logged as REAP_DECLINED, loudly,
+#       and left for the operator.
+#
+# BROWNFIELD STEP 1. This ADDS the sweep arm; it deliberately does NOT modify
+# `dispatch-self-close`, whose `exec claude rm` stays for now. The two are safe
+# side by side: a session that self-closed successfully is simply not in the
+# listing this sweep reads, so there is nothing for it to find. Step 2 (deleting
+# that line) happens only after this arm is observed working in production.
+#
+# Usage: source this file, then call:
+#   session_reap_sweep [log-file-path] [log-tag]
+#
+# session_reap_sweep [log-file-path] [log-tag]
+#   Bookkeeping only — it runs inline on a sweep and must never abort it, so it
+#   ALWAYS returns 0, on every path including a daemon failure, an unresolvable
+#   repo root, a failed `git worktree remove`, and a failed `claude rm`. Every
+#   disposition is a single greppable line, and the sweep ends with exactly one
+#   summary line. This is the deliberate exception to
+#   `.claude/rules/code-style.md`'s "prefer clear errors over defensive
+#   fallbacks": the sibling sweeps in this family establish the posture, and a
+#   fatal bookkeeping arm would take the whole sweep down with it.
+#     return 0 — ALWAYS.
+#
+#   Lines go to stderr with a `lib-session-reap:` prefix. When [log-file-path]
+#   is supplied they are ALSO appended as `<ts> [<log-tag>] <msg>`, matching
+#   `worktree_in_sync`'s optional-log convention so the arm's decisions land in
+#   `dispatch-sweep`'s own `tmp/dispatch-sweep.log` rather than vanishing into a
+#   stderr nobody reads. [log-tag] defaults to `dispatch-sweep`.
+#
+#   EVERY gate fails toward KEEP. UNKNOWN is never "none":
+#     - `claude_agents_list_terminal_workers` returning 1 (daemon unqueryable,
+#       non-array, whitespace-only) ABORTS the arm entirely, with a line saying
+#       so. An uncorroborated empty read means "cannot see", not "nothing there".
+#     - an unreadable transcript mtime (grace unmeasurable) skips the session.
+#     - a `gh` failure on the open-PR probe skips the session.
+#     - a `git` error on either worktree gate skips the session.
+#     - an UNKNOWN post-state read is logged as REAP_UNVERIFIED, NOT as success.
+#       Collapsing it into success would reproduce the very silent-PASS bug this
+#       file exists to fix.
+#
+#   The gates, in order, per terminal worker session S:
+#     1. name shape — `^[0-9]+-` is a legacy issue worker, not ours; anything
+#        that is not a valid node id is rejected before it becomes a path
+#        component.
+#     2. session-id shape — `sid` feeds a `find -name` glob, `jid` a job-dir
+#        path; both are validated at this edge.
+#     3. job-dir ownership — `<jobs-root>/<jid>/state.json`'s `.name` must equal
+#        the node id. See the JOB DIR note below.
+#     4. `node-terminal` marker — a valid marker naming S.name must exist. This
+#        is the SAME validation `dispatch-self-close` applies (see MARKER below):
+#        positive evidence that the pass reached a terminal disposition.
+#     5. grace — the transcript must have been idle at least <grace> seconds.
+#     6. reap-safety, ALL of:
+#          - the worktree is clean (`git status --porcelain
+#            --untracked-files=no` empty),
+#          - `git diff origin/main HEAD -- . ':!intentions'` is EMPTY,
+#          - no OPEN PR has this branch as its head.
+#     7. `git worktree remove` FIRST, then `claude rm`, then verify.
+#
+#   WHY THE REAP-SAFETY GATE IS A CONTENT DIFF, NOT A COMMIT COUNT. This was
+#   measured, and it corrects earlier guidance. GitHub squash-merges, so a
+#   branch's individual commits are NEVER ancestors of `main` — only their
+#   CONTENT is. Both sessions reaped by hand on 2026-08-03 read 11 and 12 commits
+#   "ahead" of `origin/main` and were entirely safe. A commit-count gate fails
+#   toward a false "do not touch": it looks conservative while silently stranding
+#   worker slots forever, which is the same class of bug as the silent decline.
+#   `worktree_in_sync` (lib-worktree-in-sync.sh) is exactly that reachability
+#   gate (`rev-list --count HEAD --not --remotes`) and is therefore NOT reused
+#   here. `worktree_merged_in_sync` is closer — it is a tree-identity gate for
+#   the same squash-merge reason — but it compares the WHOLE tree, with no way to
+#   exclude a path, so it cannot express the `intentions/` carve-out below. The
+#   gate is written explicitly rather than bending either helper.
+#
+#   THE `':!intentions'` EXCLUSION. A node's own graph commits legitimately ride
+#   along on its branch and are landed separately by `graph-commit`'s direct push
+#   to `main`. Counting them as unlanded divergence would block the reap of every
+#   node that ever wrote to its own graph record — i.e. all of them.
+#
+#   THE BRANCH IS NEVER DELETED. Removing the WORKTREE is what makes `claude rm`
+#   accept; the branch is not the blocker. The other reap arms in `dispatch-sweep`
+#   delete a branch only on positive merged/closed evidence, and this arm has
+#   none — so it leaves the branch in place.
+#
+#   ABSENT WORKTREE. When nothing exists at `<worktrees-root>/<node-id>` the
+#   three reap-safety gates are vacuous: they exist to protect worktree content
+#   from `git worktree remove`, and there is no worktree to remove and no content
+#   to lose. The arm logs the absence, skips the removal step, and goes straight
+#   to `claude rm`. This is safe because gate 4 already required positive
+#   evidence — a `node-terminal` marker naming this node — that the session
+#   reached a terminal disposition, and because `claude rm` deletes a registry
+#   entry and a job dir, never a transcript (those live under <projects-root>).
+#
+#   JOB DIR. The job dir is keyed on the registry's `.id` column, NOT the
+#   sessionId and NOT a prefix of it: a RESUMED session keeps its original `.id`
+#   while its `.sessionId` changes. `lib-frozen-session-park.sh` step (11)
+#   documents this at length; the same two guards apply here — the `^[0-9a-fA-F-]+$`
+#   shape check (the id becomes a path component) and an OWNERSHIP check
+#   (`state.json`'s `.name`, the field `dispatch-stop` itself reads, must equal
+#   the node id). A row with no `.id` renders as an EMPTY column, which means "no
+#   job dir" and never a match.
+#
+#   MARKER. `<jobs-root>/<jid>/node-terminal` is written by
+#   `packages/intentionsutil/scripts/mark-node-terminal` as exactly two lines:
+#       node=<node-id>
+#       disposition=<advance|demote|park|fix-attempt|align-round|no-claim
+#                    |conflict-resolved|conflict-hold>
+#   `dispatch-self-close:210-212` validates it with
+#       [[ -s "$CLAUDE_JOB_DIR/node-terminal" ]] &&
+#         marked="$(sed -n '/^node=/{s/^node=//;p;q;}' "$CLAUDE_JOB_DIR/node-terminal")"
+#       if [[ "$marked" != "$REQUIRE_NODE" ]]; then  # HOLD
+#   — first `^node=` line only, `disposition=` is diagnostic, a missing or
+#   zero-byte file leaves `marked` empty which never equals a valid node id. This
+#   file applies that check BYTE-FOR-BYTE. Deliberately not looser (a marker for
+#   some OTHER node must not authorize this reap — `mark-node-terminal` enforces
+#   that at write time via state.json, and this is the read-side half) and not
+#   stricter (a stricter check here would refuse to reap sessions self-close
+#   itself considers reapable, re-stranding the slot).
+#
+#   THE GRACE WINDOW. Brownfield step 1 leaves `dispatch-self-close`'s own
+#   `exec claude rm` in place, so a just-terminal session may be mid-reap right
+#   now; racing it would be bad. Idle time is measured the way the sibling
+#   measures it — newest mtime across `<projects-root>/*/<sid>.jsonl`, keyed on
+#   the globally-unique SESSION id (the transcript is keyed on `sid`, the job dir
+#   on `jid`). Unmeasurable means UNKNOWN, which means skip.
+#
+# Environment overrides (test seams — every external dependency has one):
+#   DISPATCH_SESSION_REAP_NOW_EPOCH        "now" in epoch seconds. Default: date -u +%s.
+#   DISPATCH_SESSION_REAP_GRACE_S          Idle grace, seconds. Default: 300.
+#   DISPATCH_SESSION_REAP_MAX              Max reap attempts per sweep. Default: 8.
+#   DISPATCH_SESSION_REAP_PROJECTS_ROOT    Transcript store. Default: $HOME/.claude/projects.
+#   DISPATCH_SESSION_REAP_JOBS_ROOT        Managed-job dirs. Default: $HOME/.claude/jobs.
+#   DISPATCH_SESSION_REAP_REPO_ROOT        Repo root. Default: resolve_project_root.
+#   DISPATCH_SESSION_REAP_WORKTREES_ROOT   Worktree container. Default: <repo-root>/.claude/worktrees.
+#   CLAUDE_AGENTS_CMD                      The `claude` binary, for BOTH the registry
+#                                          query and `claude rm`. Default: `claude`.
+#                                          Same seam lib-claude-agents.sh uses.
+#
+# Sandbox: `claude agents --json --all` and `claude rm` reach the local Claude
+# daemon over a Unix socket, and `gh` needs the host TLS store. Callers MUST run
+# this with `dangerouslyDisableSandbox: true` — see `.claude/rules/sandbox.md`.
+# A sandboxed run yields `[]` from the daemon, which reads as a definite "no
+# terminal workers" and reaps nothing: fail-safe, but also not measured.
+#
+# Safe to source multiple times. Does NOT use set -e (must return, not exit).
+# Side effect: sourcing once sets `-u` and `-o pipefail` in the caller shell (via
+# its own load guard, and transitively via the siblings below).
+
+# Source siblings via BASH_SOURCE dirname, matching lib-frozen-session-park.sh.
+# lib.sh supplies resolve_project_root and gh_pr_list_rest; lib-claude-agents.sh
+# supplies claude_agents_list_terminal_workers; lib-worktree-reap.sh supplies
+# reap_marker_clear. All three are load-guarded or plain function definitions —
+# no source cycle (none of them sources this file).
+_lsr_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$_lsr_dir/lib.sh"
+# shellcheck source=lib-claude-agents.sh
+source "$_lsr_dir/lib-claude-agents.sh"
+# shellcheck source=lib-worktree-reap.sh
+source "$_lsr_dir/lib-worktree-reap.sh"
+
+if [[ -z "${_LIB_SESSION_REAP_LOADED:-}" ]]; then
+  _LIB_SESSION_REAP_LOADED=1
+
+  set -uo pipefail
+
+  # _lsr_log <log-file> <log-tag> <msg> — one greppable disposition line, to
+  # stderr always and to the caller's log file when one was supplied. Mirrors
+  # `_wis_log` in lib-worktree-in-sync.sh so a dispatch-sweep run keeps ONE
+  # timestamped, tagged log format end to end.
+  _lsr_log() {
+    local log_file="$1" log_tag="$2" msg="$3"
+    printf 'lib-session-reap: %s\n' "$msg" >&2
+    if [[ -n "$log_file" ]]; then
+      printf '%s [%s] %s\n' "${DISPATCH_SWEEP_NOW:-$(date -u +%FT%TZ)}" "$log_tag" "$msg" \
+        >>"$log_file" 2>/dev/null || true
+    fi
+    return 0
+  }
+
+  # session_reap_sweep [log-file-path] [log-tag] — see the header for the full
+  # contract. ALWAYS returns 0.
+  session_reap_sweep() {
+    local log_file="${1:-}" log_tag="${2:-dispatch-sweep}"
+
+    # The candidate query — a DIRECT `--all` listing (the tick snapshot is
+    # captured WITHOUT `--all` and so lacks the terminal rows this arm exists to
+    # find). Return 1 is UNKNOWN and ABORTS the arm: an uncorroborated empty read
+    # means "cannot see", never "none".
+    local candidates
+    if ! candidates=$(claude_agents_list_terminal_workers); then
+      _lsr_log "$log_file" "$log_tag" \
+        "SESSION_REAP_UNKNOWN: daemon unqueryable; cannot see the session registry; reaping nothing"
+      return 0
+    fi
+
+    local terminal=0 reaped=0 declined=0 unverified=0 skipped=0
+
+    if [[ -z "$candidates" ]]; then
+      _lsr_log "$log_file" "$log_tag" \
+        "SESSION_REAP_COMPLETE: terminal=$terminal reaped=$reaped declined=$declined unverified=$unverified skipped=$skipped"
+      return 0
+    fi
+
+    # Resolve "now" and the tunables ONCE, before the loop. A non-numeric
+    # override falls back to its baked default — the same integer-guard idiom
+    # `terminal_without_disposition_sweep` uses.
+    local now
+    if [[ "${DISPATCH_SESSION_REAP_NOW_EPOCH:-}" =~ ^[0-9]+$ ]]; then
+      now="$DISPATCH_SESSION_REAP_NOW_EPOCH"
+    else
+      now=$(date -u +%s)
+    fi
+    local grace="${DISPATCH_SESSION_REAP_GRACE_S:-300}"
+    [[ "$grace" =~ ^[0-9]+$ ]] || grace=300
+    # A cap, not because reaping is expensive, but so one pathological sweep
+    # cannot walk the whole registry issuing daemon calls. Excess candidates are
+    # simply retried on the next sweep.
+    local reap_max="${DISPATCH_SESSION_REAP_MAX:-8}"
+    [[ "$reap_max" =~ ^[0-9]+$ ]] || reap_max=8
+    local projects_root="${DISPATCH_SESSION_REAP_PROJECTS_ROOT:-$HOME/.claude/projects}"
+    local jobs_root="${DISPATCH_SESSION_REAP_JOBS_ROOT:-$HOME/.claude/jobs}"
+    local claude_cmd="${CLAUDE_AGENTS_CMD:-claude}"
+
+    local repo_root="${DISPATCH_SESSION_REAP_REPO_ROOT:-}"
+    if [[ -z "$repo_root" ]]; then
+      repo_root=$(resolve_project_root) || repo_root=""
+    fi
+    if [[ -z "$repo_root" ]]; then
+      _lsr_log "$log_file" "$log_tag" \
+        "SESSION_REAP_SKIP_ALL: repo root unresolvable; reaping nothing"
+      _lsr_log "$log_file" "$log_tag" \
+        "SESSION_REAP_COMPLETE: terminal=$terminal reaped=$reaped declined=$declined unverified=$unverified skipped=$skipped"
+      return 0
+    fi
+    local worktrees_root="${DISPATCH_SESSION_REAP_WORKTREES_ROOT:-$repo_root/.claude/worktrees}"
+
+    # Drain the candidate list into an array BEFORE looping, for the reason the
+    # sibling does: the loop body runs git/gh/claude subprocesses that would
+    # otherwise consume the remaining candidates off the loop's stdin.
+    local -a rows=()
+    mapfile -t rows <<<"$candidates"
+
+    local row rest sid jid name cwd
+    for row in "${rows[@]}"; do
+      # Field-split by parameter expansion, NOT `IFS=$'\t' read`: TAB is IFS
+      # WHITESPACE, so `read` collapses a run of tabs into one delimiter, and a
+      # row with a null `.id` (which `@tsv` renders as "") would silently shift
+      # `name` one column left onto the cwd. Rows with a null `.id` are exactly
+      # the ones this arm must still classify correctly — as "no job dir".
+      sid="${row%%$'\t'*}";  rest="${row#*$'\t'}"
+      jid="${rest%%$'\t'*}"; rest="${rest#*$'\t'}"
+      name="${rest%%$'\t'*}"
+      cwd="${rest#*$'\t'}"
+      [[ -n "$sid" && -n "$name" ]] || continue
+      terminal=$(( terminal + 1 ))
+
+      # (1) Name shape. A `<N>-slug` legacy issue worker belongs to the issue
+      # lane's own machinery; this arm owns graph-node workers only. The name
+      # also becomes a path component (the worktree path, the job-dir ownership
+      # comparison), so validate its shape with the SAME node-id regex
+      # `mark-node-terminal:67` and `provision-node-worktree` apply.
+      if [[ "$name" =~ ^[0-9]+- ]]; then
+        skipped=$(( skipped + 1 ))
+        _lsr_log "$log_file" "$log_tag" \
+          "SESSION_REAP_SKIP_ISSUE_WORKER: name=$name session=$sid (legacy issue lane; not a graph node)"
+        continue
+      fi
+      if [[ ! "$name" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]]; then
+        skipped=$(( skipped + 1 ))
+        _lsr_log "$log_file" "$log_tag" \
+          "SESSION_REAP_SKIP_BAD_NAME: name=$name session=$sid (not a valid node id)"
+        continue
+      fi
+
+      # (2) Session-id shape. `sid` feeds a `find -name` glob below.
+      if [[ ! "$sid" =~ ^[0-9a-fA-F-]+$ ]]; then
+        skipped=$(( skipped + 1 ))
+        _lsr_log "$log_file" "$log_tag" \
+          "SESSION_REAP_SKIP_BAD_SESSION_ID: name=$name session=$sid"
+        continue
+      fi
+
+      # (3) Job dir, keyed on the registry's `.id` — see the JOB DIR note in the
+      # header. Shape check first (the id becomes a path component), then the
+      # OWNERSHIP check against state.json's `.name`. An empty `.id` column means
+      # "no job dir", never a match.
+      if [[ -z "$jid" || ! "$jid" =~ ^[0-9a-fA-F-]+$ ]]; then
+        skipped=$(( skipped + 1 ))
+        _lsr_log "$log_file" "$log_tag" \
+          "SESSION_REAP_SKIP_NO_JOB_DIR: name=$name session=$sid id=${jid:-<empty>} (no usable job id; cannot read a terminal marker)"
+        continue
+      fi
+      local job_dir="$jobs_root/$jid" job_name
+      # shell-json.md: jq reads the file directly; never `echo "$VAR" | jq`.
+      job_name=$(jq -r '.name // empty' "$job_dir/state.json" 2>/dev/null) || job_name=""
+      if [[ -z "$job_name" || "$job_name" != "$name" ]]; then
+        skipped=$(( skipped + 1 ))
+        _lsr_log "$log_file" "$log_tag" \
+          "SESSION_REAP_SKIP_FOREIGN_JOB_DIR: name=$name session=$sid job_dir=$job_dir state_json_name=${job_name:-<unreadable>}"
+        continue
+      fi
+
+      # (4) The `node-terminal` marker. Byte-for-byte the check
+      # dispatch-self-close:210-212 applies — `-s` on the file, first `^node=`
+      # line only, compared to this node id.
+      local marked=""
+      [[ -s "$job_dir/node-terminal" ]] &&
+        marked="$(sed -n '/^node=/{s/^node=//;p;q;}' "$job_dir/node-terminal")"
+      if [[ "$marked" != "$name" ]]; then
+        skipped=$(( skipped + 1 ))
+        _lsr_log "$log_file" "$log_tag" \
+          "SESSION_REAP_SKIP_NO_TERMINAL_MARKER: name=$name session=$sid job_dir=$job_dir marker_node=${marked:-<none>} (no positive terminal-disposition evidence)"
+        continue
+      fi
+
+      # (5) Grace. The transcript lives at <projects-root>/<project>/<sid>.jsonl
+      # — keyed on the globally-unique SESSION id. Take the NEWEST mtime across
+      # matches. No match, or an unreadable mtime, is UNKNOWN: keep.
+      local matches transcript best="" cur
+      matches=$(find "$projects_root" -mindepth 2 -maxdepth 2 -name "${sid}.jsonl" 2>/dev/null)
+      if [[ -n "$matches" ]]; then
+        while IFS= read -r transcript; do
+          [[ -n "$transcript" ]] || continue
+          cur=$(stat -c %Y "$transcript" 2>/dev/null) || continue
+          [[ "$cur" =~ ^[0-9]+$ ]] || continue
+          if [[ -z "$best" ]] || (( cur > best )); then
+            best="$cur"
+          fi
+        done <<<"$matches"
+      fi
+      if [[ -z "$best" ]]; then
+        skipped=$(( skipped + 1 ))
+        _lsr_log "$log_file" "$log_tag" \
+          "SESSION_REAP_SKIP_UNMEASURABLE: name=$name session=$sid (transcript unreadable — idle time unmeasurable)"
+        continue
+      fi
+      local idle=$(( now - best ))
+      # A negative (future-stamped) idle is `< grace` too, so it is kept — the
+      # safe direction.
+      if (( idle < grace )); then
+        skipped=$(( skipped + 1 ))
+        _lsr_log "$log_file" "$log_tag" \
+          "SESSION_REAP_SKIP_GRACE: name=$name session=$sid idle_seconds=$idle grace_seconds=$grace (self-close may still be mid-reap)"
+        continue
+      fi
+
+      # (6) Cap. Excess candidates are retried on the next sweep.
+      if (( reaped + declined + unverified >= reap_max )); then
+        skipped=$(( skipped + 1 ))
+        _lsr_log "$log_file" "$log_tag" \
+          "SESSION_REAP_DEFER: name=$name session=$sid (reap cap $reap_max reached this sweep)"
+        continue
+      fi
+
+      # (7) The worktree. Its path is derived, never taken from the registry's
+      # `cwd`: provision-node-worktree puts a node's checkout at exactly
+      # <project-root>/.claude/worktrees/<node-id> on a branch of the same name.
+      local wt_path="$worktrees_root/$name"
+      local branch="$name"
+      local wt_present=0
+      [[ -d "$wt_path" ]] && wt_present=1
+
+      if (( wt_present )); then
+        # Prefer the worktree's ACTUAL branch for the PR probe when it can be
+        # read; fall back to the node id. A detached HEAD reads back as the
+        # literal "HEAD", which is not a branch.
+        local head_ref
+        head_ref=$(git -C "$wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null) || head_ref=""
+        if [[ -n "$head_ref" && "$head_ref" != "HEAD" ]]; then
+          branch="$head_ref"
+        fi
+
+        # (7a) Clean tree. `--untracked-files=no`: untracked residue is build
+        # output and scratch, not work — the CONTENT gate below is what protects
+        # actual work. A `git status` failure is UNKNOWN → keep.
+        local status_out
+        if ! status_out=$(git -C "$wt_path" status --porcelain --untracked-files=no 2>/dev/null); then
+          skipped=$(( skipped + 1 ))
+          _lsr_log "$log_file" "$log_tag" \
+            "SESSION_REAP_SKIP_STATUS_ERROR: name=$name session=$sid worktree=$wt_path (git status failed)"
+          continue
+        fi
+        if [[ -n "$status_out" ]]; then
+          skipped=$(( skipped + 1 ))
+          _lsr_log "$log_file" "$log_tag" \
+            "SESSION_REAP_SKIP_DIRTY: name=$name session=$sid worktree=$wt_path (uncommitted changes)"
+          continue
+        fi
+
+        # (7b) CONTENT gate — see the header for why this is a content diff and
+        # not a commit count. `--quiet` exits 0 for "no diff", 1 for "diff", >1
+        # for an error (which is UNKNOWN → keep). `-C` puts the cwd at the
+        # worktree root, so `.` and `:!intentions` are both anchored there.
+        local diff_rc=0
+        git -C "$wt_path" diff --quiet origin/main HEAD -- . ':!intentions' 2>/dev/null || diff_rc=$?
+        case "$diff_rc" in
+          0) ;;
+          1)
+            skipped=$(( skipped + 1 ))
+            _lsr_log "$log_file" "$log_tag" \
+              "SESSION_REAP_SKIP_UNLANDED_CONTENT: name=$name session=$sid worktree=$wt_path branch=$branch (tree differs from origin/main outside intentions/)"
+            continue
+            ;;
+          *)
+            skipped=$(( skipped + 1 ))
+            _lsr_log "$log_file" "$log_tag" \
+              "SESSION_REAP_SKIP_DIFF_ERROR: name=$name session=$sid worktree=$wt_path (git diff vs origin/main failed, rc=$diff_rc)"
+            continue
+            ;;
+        esac
+
+        # (7c) No OPEN PR on this branch. A `gh` failure fails toward KEEP —
+        # never toward reap.
+        local pr_json open_count
+        if ! pr_json=$(gh_pr_list_rest --head "$branch" --state all 2>/dev/null); then
+          skipped=$(( skipped + 1 ))
+          _lsr_log "$log_file" "$log_tag" \
+            "SESSION_REAP_SKIP_PR_FETCH_FAILED: name=$name session=$sid branch=$branch (gh_pr_list_rest failed)"
+          continue
+        fi
+        open_count=$(jq '[.[] | select(.state == "OPEN")] | length' <<<"$pr_json" 2>/dev/null) || open_count=""
+        if [[ ! "$open_count" =~ ^[0-9]+$ ]]; then
+          skipped=$(( skipped + 1 ))
+          _lsr_log "$log_file" "$log_tag" \
+            "SESSION_REAP_SKIP_PR_FETCH_FAILED: name=$name session=$sid branch=$branch (PR list unparseable)"
+          continue
+        fi
+        if (( open_count > 0 )); then
+          skipped=$(( skipped + 1 ))
+          _lsr_log "$log_file" "$log_tag" \
+            "SESSION_REAP_SKIP_OPEN_PR: name=$name session=$sid branch=$branch open_prs=$open_count"
+          continue
+        fi
+
+        # (7d) Remove the worktree — FIRST, before `claude rm`. THIS is what
+        # makes the daemon accept the removal: it declines while the worktree has
+        # files it cannot verify against a repository. NOT `--force`: the gates
+        # above already proved the tree clean, so a plain remove that still fails
+        # is telling us something we did not model, and the safe answer is to
+        # keep. The BRANCH is deliberately left alone (see the header).
+        if ! git -C "$repo_root" worktree remove "$wt_path" 2>/dev/null; then
+          skipped=$(( skipped + 1 ))
+          _lsr_log "$log_file" "$log_tag" \
+            "SESSION_REAP_SKIP_WORKTREE_REMOVE_FAILED: name=$name session=$sid worktree=$wt_path"
+          continue
+        fi
+        git -C "$repo_root" worktree prune 2>/dev/null || true
+        # Clear any not-in-sync grace marker, exactly as the other reap arms in
+        # dispatch-sweep do, so a future same-named worktree cannot inherit a
+        # stale grace timestamp.
+        reap_marker_clear "$repo_root" "$name" || true
+        _lsr_log "$log_file" "$log_tag" \
+          "SESSION_REAP_WORKTREE_REMOVED: name=$name session=$sid worktree=$wt_path branch=$branch (branch retained)"
+      else
+        # Absent worktree — the reap-safety gates are vacuous. See the header.
+        _lsr_log "$log_file" "$log_tag" \
+          "SESSION_REAP_NO_WORKTREE: name=$name session=$sid worktree=$wt_path (nothing to remove; proceeding to claude rm)"
+      fi
+
+      # (8) `claude rm` — on the JOB id (`.id`), which is what dispatch-self-close
+      # passes and what the daemon keys removals on. Its exit code is recorded
+      # but NOT trusted: exiting 0 while declining is the entire bug.
+      local rm_rc=0
+      "$claude_cmd" rm "$jid" >/dev/null 2>&1 || rm_rc=$?
+
+      # (9) Verify the POST-STATE by re-querying, instead of believing exit 0.
+      # THREE outcomes, never two. The candidates were terminal going in, so a
+      # session the daemon declined to remove is still terminal and still in this
+      # listing; absence from it is a genuine removal.
+      local post
+      if ! post=$(claude_agents_list_terminal_workers); then
+        unverified=$(( unverified + 1 ))
+        _lsr_log "$log_file" "$log_tag" \
+          "SESSION_REAP_UNVERIFIED: name=$name session=$sid id=$jid claude_rm_rc=$rm_rc (daemon unqueryable on the post-state read; removal NOT confirmed)"
+        continue
+      fi
+      local still=0 prow prest pjid
+      if [[ -n "$post" ]]; then
+        while IFS= read -r prow; do
+          [[ -n "$prow" ]] || continue
+          prest="${prow#*$'\t'}"
+          pjid="${prest%%$'\t'*}"
+          if [[ -n "$pjid" && "$pjid" == "$jid" ]]; then
+            still=1
+            break
+          fi
+        done <<<"$post"
+      fi
+      if (( still )); then
+        declined=$(( declined + 1 ))
+        _lsr_log "$log_file" "$log_tag" \
+          "REAP_DECLINED: name=$name session=$sid id=$jid claude_rm_rc=$rm_rc — the daemon still reports this session after \`claude rm\`; it is holding a worker slot and its node is unselectable. Left for the operator."
+        continue
+      fi
+      reaped=$(( reaped + 1 ))
+      _lsr_log "$log_file" "$log_tag" \
+        "SESSION_REAPED: name=$name session=$sid id=$jid idle_seconds=$idle worktree_present=$wt_present cwd=$cwd"
+    done
+
+    _lsr_log "$log_file" "$log_tag" \
+      "SESSION_REAP_COMPLETE: terminal=$terminal reaped=$reaped declined=$declined unverified=$unverified skipped=$skipped"
+    return 0
+  }
+
+fi

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-sweep.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-sweep.sh
@@ -64,6 +64,11 @@ sweep_setup() {
   # dispatch-sweep sources lib-worktree-reap.sh (marker ledger + quarantine) from
   # its SCRIPT_DIR — required for the not-in-sync reap path.
   cp "$SCRIPT_DIR/lib-worktree-reap.sh" "$TMPDIR_TEST/scripts/lib-worktree-reap.sh"
+  # dispatch-sweep sources lib-session-reap.sh (the SESSION arm) from its
+  # SCRIPT_DIR. Without this copy the `source` fails, `session_reap_sweep` is
+  # undefined, the call site's `|| true` swallows the command-not-found, and the
+  # arm silently never runs while every test still passes — a vacuous green.
+  cp "$SCRIPT_DIR/lib-session-reap.sh" "$TMPDIR_TEST/scripts/lib-session-reap.sh"
   # dispatch-sweep resolves the grace window by shelling out to dispatch-config-load
   # ("$SCRIPT_DIR/dispatch-config-load" sweep). Without this copy the binary is
   # absent, the call exits non-zero, and the whole config branch (config-file
@@ -293,6 +298,18 @@ FAKE
   # config-path test opts in by writing sweep.json into this dir.
   mkdir -p "$STUB_DIR/config"
   export DISPATCH_CONFIG_DIR="$STUB_DIR/config"
+
+  # SESSION-arm leak guard. lib-session-reap.sh defaults its job/transcript roots
+  # to $HOME/.claude/{jobs,projects} — the developer's REAL managed jobs. A fake
+  # registry row whose `.id` happened to match a real job dir would be read, and
+  # (if it passed the marker gate) the suite would issue a real `claude rm`
+  # against the operator's own session. Redirect all three roots into the tmp
+  # sandbox so that is impossible by construction, in the same spirit as the
+  # host-systemd and decision-log guards.
+  mkdir -p "$STUB_DIR/session-reap/jobs" "$STUB_DIR/session-reap/projects"
+  export DISPATCH_SESSION_REAP_JOBS_ROOT="$STUB_DIR/session-reap/jobs"
+  export DISPATCH_SESSION_REAP_PROJECTS_ROOT="$STUB_DIR/session-reap/projects"
+  export DISPATCH_SESSION_REAP_WORKTREES_ROOT="$TMPDIR_TEST/project/worktrees"
 }
 
 sweep_teardown() {
@@ -308,6 +325,9 @@ sweep_teardown() {
   unset DISPATCH_SWEEP_NOW_EPOCH DISPATCH_SWEEP_NOT_IN_SYNC_GRACE_S SWEEP_FORMAT_PATCH_FAIL
   # NODE-arm seams (minimum age, origin/main availability) — same no-leak rule.
   unset DISPATCH_SWEEP_NODE_MIN_AGE_S SWEEP_NO_ORIGIN_MAIN
+  # SESSION-arm roots — never leak the tmp-sandbox redirection into later suites.
+  unset DISPATCH_SESSION_REAP_JOBS_ROOT DISPATCH_SESSION_REAP_PROJECTS_ROOT \
+        DISPATCH_SESSION_REAP_WORKTREES_ROOT
 }
 
 # Helper: register a worktree in the porcelain list AND create its directory.
@@ -1970,6 +1990,85 @@ if grep -q "HELD_FOR_DEBUG_COUNT: n=UNKNOWN (daemon unqueryable)" "$DISPATCH_SWE
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: N8b HELD_FOR_DEBUG_COUNT logs UNKNOWN, never a literal 0"
   echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
+fi
+sweep_teardown
+
+# --- Test N9a: the SESSION arm is wired in and runs -------------------------
+#
+# Guards the wiring, not the arm's own logic (that is test-lib-session-reap.sh).
+# The failure mode this catches is a silent one: if the `source
+# lib-session-reap.sh` line is dropped or the file is missing, dispatch-sweep
+# (which is `set -uo pipefail`, NOT `set -e`) keeps going, `session_reap_sweep`
+# is undefined, and the call site's `|| true` swallows the command-not-found —
+# leaving every other test green with the arm never running. A summary line in
+# the log is the proof it ran.
+echo "Test: N9a the session-reap arm runs and logs its summary"
+sweep_setup
+WT_PATH="$TMPDIR_TEST/project/worktrees/65-session-arm"
+sweep_register_wt "$WT_PATH" "65-session-arm"
+echo "OPEN" > "$STUB_DIR/issue-state-65.txt"
+key=$(sweep_path_key "$WT_PATH")
+: > "$STUB_DIR/status${key}.txt"
+echo "0" > "$STUB_DIR/revlist${key}.txt"
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>"$STUB_DIR/sweep-stderr.txt"); rc=$?
+assert_eq "N9a sweep exits 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if grep -q 'SESSION_REAP_COMPLETE:' "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: N9a the session arm logged its summary"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: N9a the session arm logged its summary"
+  echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
+fi
+# The command-not-found diagnostic goes to STDERR, not the log file — check it
+# there, or the assertion is vacuous.
+TOTAL=$((TOTAL + 1))
+if grep -q 'session_reap_sweep' "$STUB_DIR/sweep-stderr.txt" 2>/dev/null; then
+  FAIL=$((FAIL + 1)); echo "  FAIL: N9a session_reap_sweep resolved (lib-session-reap.sh sourced)"
+  echo "    stderr:"; sed 's/^/      /' "$STUB_DIR/sweep-stderr.txt" 2>/dev/null
+else
+  PASS=$((PASS + 1)); echo "  PASS: N9a session_reap_sweep resolved (lib-session-reap.sh sourced)"
+fi
+# Ordering: the arm must log AFTER the worktree loop and BEFORE the
+# held-for-debug metric — see the placement comment at its call site.
+# `|| true` on the greps: an absent line must FAIL this assertion, not abort the
+# suite via set -e/pipefail on the assignment.
+TOTAL=$((TOTAL + 1))
+SESSION_LINE=$(grep -n 'SESSION_REAP_COMPLETE:' "$DISPATCH_SWEEP_LOG_FILE" | head -n1 | cut -d: -f1) || SESSION_LINE=""
+HELD_LINE=$(grep -n 'HELD_FOR_DEBUG_COUNT:' "$DISPATCH_SWEEP_LOG_FILE" | head -n1 | cut -d: -f1) || HELD_LINE=""
+if [[ -n "$SESSION_LINE" && -n "$HELD_LINE" && "$SESSION_LINE" -lt "$HELD_LINE" ]]; then
+  PASS=$((PASS + 1)); echo "  PASS: N9a the session arm runs before HELD_FOR_DEBUG_COUNT"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: N9a the session arm runs before HELD_FOR_DEBUG_COUNT"
+  echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
+fi
+sweep_teardown
+
+# --- Test N9b: an unqueryable daemon aborts the SESSION arm, not the sweep ---
+echo "Test: N9b an unqueryable daemon leaves the session arm saying it cannot see"
+sweep_setup
+fake="$TMPDIR_TEST/fake/claude"
+cat > "$fake" <<'FAKE'
+#!/usr/bin/env bash
+exit 1
+FAKE
+chmod +x "$fake"
+export CLAUDE_AGENTS_CMD="$fake"
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "N9b sweep exits 0" "0" "$rc"
+TOTAL=$((TOTAL + 1))
+if grep -q 'SESSION_REAP_UNKNOWN: daemon unqueryable' "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: N9b the session arm reports it cannot see the registry"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: N9b the session arm reports it cannot see the registry"
+  echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
+fi
+TOTAL=$((TOTAL + 1))
+if grep -q 'SESSION_REAP_COMPLETE:' "$DISPATCH_SWEEP_LOG_FILE"; then
+  FAIL=$((FAIL + 1)); echo "  FAIL: N9b UNKNOWN never degrades into a zero-candidate summary"
+else
+  PASS=$((PASS + 1)); echo "  PASS: N9b UNKNOWN never degrades into a zero-candidate summary"
 fi
 sweep_teardown
 

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-frozen-session-park.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-frozen-session-park.sh
@@ -708,12 +708,30 @@ td_teardown() {
         DISPATCH_STANDDOWN_DIR || true
 }
 
-# td_write_park_node <exit-code> [sleep-seconds] — install the fake park-node: it
-# logs its argc, each positional argument and the inherited
+# td_write_park_node <exit-code> [sleep-seconds] [landing-mode] — install the fake
+# park-node: it logs its argc, each positional argument and the inherited
 # GRAPH_COMMIT_LOCK_WAIT_SECONDS, optionally sleeps (to exercise the `timeout`
-# bound), then exits <exit-code>.
+# bound), then LANDS the park on origin/main and exits <exit-code>.
+#
+# The landing half exists because the sweep's step (13) confirms every rc-0 park
+# by re-reading the node from origin/main: marker deletion is the PROOF the park
+# landed, not a cleanup step that trusts an exit code. A fake that only exits 0
+# would therefore model a park-node that returned success without landing — the
+# real defect — so the DEFAULT fake lands, and each not-landed shape is an
+# explicit opt-in:
+#   land    (default) rewrite the node's frontmatter `office_hours: null` into a
+#           park block and republish origin/main — a park that really landed.
+#   none    exit 0 and change nothing — `graph-commit` exit 0 with no write on
+#           origin/main, the shape this suite regression-tests.
+#   delete  remove the node file and republish — the node unreadable at
+#           origin/main after an rc-0 park.
+#   body    append a column-0 `office_hours:` block to the markdown BODY while
+#           the frontmatter stays `null` — the frontmatter-scoping trap.
+# Landing is skipped entirely for a non-zero <exit-code>: a park-node that fails
+# does not land, and a hang killed by `timeout` never reaches this code at all
+# (the sleep comes first).
 td_write_park_node() {
-  local sleep_s="${2:-0}"
+  local rc="$1" sleep_s="${2:-0}" mode="${3:-land}"
   cat > "$TD_PARK" <<PARK
 #!/usr/bin/env bash
 {
@@ -722,7 +740,21 @@ td_write_park_node() {
   printf 'LOCK=%s\n' "\${GRAPH_COMMIT_LOCK_WAIT_SECONDS:-unset}"
 } >> "$TD_PARKLOG"
 sleep $sleep_s
-exit $1
+if [ "$rc" = 0 ] && [ "$mode" != none ]; then
+  # The sweep may prefix the positionals with '--pr <n>'.
+  node="\$1"
+  [ "\$node" = "--pr" ] && node="\$3"
+  f="$TD_REPO/intentions/\$node.md"
+  case "$mode" in
+    land)   sed -i 's/^office_hours: null\$/office_hours:\n  reason: landed by the fake park-node\n  recommendation: null/' "\$f" ;;
+    body)   printf '\noffice_hours:\n  reason: a BODY line, not frontmatter\n' >> "\$f" ;;
+    delete) rm -f "\$f" ;;
+  esac
+  git -C "$TD_REPO" add -A
+  git -C "$TD_REPO" commit -q -m 'fake park-node: $mode'
+  git -C "$TD_REPO" update-ref refs/remotes/origin/main HEAD
+fi
+exit $rc
 PARK
   chmod +x "$TD_PARK"
 }
@@ -1166,6 +1198,9 @@ assert_eq "park-fail: stderr reports the failure" "yes" \
 assert_eq "park-fail: the decision record says park-failed" "park-failed" "$(td_log_dispositions)"
 assert_eq "park-fail: the reason marker is retained" "present" \
   "$([[ -e "$TD_JOBS/cdb0aaaa/office-hours-reason" ]] && printf 'present' || printf 'gone')"
+# A non-zero exit is a park FAILURE, not an unlanded park: the two have different
+# causes and different operator responses, so their lines must stay distinct.
+assert_eq "park-fail: it is not reported as an unlanded park" "no" "$(td_contains 'park-not-landed')"
 assert_eq "park-fail: summary counts zero parks" "yes" \
   "$(td_contains 'terminal-disposition sweep complete (terminal=1 parked=0 observing=0 unmeasurable=0 deferred=0)')"
 td_teardown
@@ -1193,14 +1228,17 @@ assert_eq "cap: summary counts the deferrals" "yes" \
   "$(td_contains 'terminal-disposition sweep complete (terminal=4 parked=2 observing=0 unmeasurable=0 deferred=2)')"
 td_teardown
 
-# --- Test 33: at most one `git fetch` per sweep ------------------------------
+# --- Test 33: the fetch budget — one lazy pre-flight + one per confirmed park --
 #
-# The fetch is lazy AND latched: two eligible candidates must still produce
-# exactly one fetch. Counted with a `git` wrapper on PATH that logs a line for
-# every invocation carrying the `fetch` subcommand and then delegates to the
-# real binary.
+# The pre-flight fetch is lazy AND latched: two eligible candidates still produce
+# exactly ONE of it. Step (13)'s confirmation fetch is a second kind and is NOT
+# latched — the park itself is what makes origin/main stale, so a confirmation
+# read against the pre-park ref would report every park as not-landed. Two parks
+# therefore cost 1 + 2 = 3 fetches, bounded by the park cap. Counted with a `git`
+# wrapper on PATH that logs a line for every invocation carrying the `fetch`
+# subcommand and then delegates to the real binary.
 
-echo "Test: two eligible candidates trigger exactly one git fetch"
+echo "Test: two eligible candidates cost one pre-flight fetch plus one confirmation fetch each"
 td_setup
 TD_REAL_GIT=$(command -v git)
 mkdir -p "$TD_DIR/bin"
@@ -1227,7 +1265,8 @@ td_run
 PATH="$TD_OLD_PATH"
 assert_eq "fetch: sweep returns 0" "0" "$TD_RC"
 assert_eq "fetch: both candidates parked" "2" "$(td_park_calls)"
-assert_eq "fetch: exactly one fetch for the whole sweep" "1" "$(wc -l < "$TD_DIR/fetch.log" | tr -d ' ')"
+assert_eq "fetch: one pre-flight fetch plus one confirmation fetch per park" "3" \
+  "$(wc -l < "$TD_DIR/fetch.log" | tr -d ' ')"
 td_teardown
 
 # --- Test 34: each park is bounded — short lock wait, and a hang is killed ----
@@ -1264,6 +1303,9 @@ assert_eq "td-timeout: stderr reports the timeout" "yes" \
 assert_eq "td-timeout: the decision record names the timeout" "park-timeout" "$(td_log_dispositions)"
 assert_eq "td-timeout: the marker survives for the retry" "present" \
   "$([[ -e "$TD_JOBS/fcb0aaaa/office-hours-reason" ]] && printf 'present' || printf 'gone')"
+# A killed park is a park-timeout, never an unlanded park — the timeout branch
+# does no confirmation read at all.
+assert_eq "td-timeout: it is not reported as an unlanded park" "no" "$(td_contains 'park-not-landed')"
 assert_eq "td-timeout: summary counts zero parks" "yes" \
   "$(td_contains 'terminal-disposition sweep complete (terminal=1 parked=0 observing=0 unmeasurable=0 deferred=0)')"
 td_teardown
@@ -1430,6 +1472,132 @@ assert_eq "td-nullid: park-node invoked once" "1" "$(td_park_calls)"
 assert_eq "td-nullid: the node id survived the parse" "tactic-td-nullid" "$(td_park_arg 1)"
 assert_eq "td-nullid: stderr reports the unusable job id" "yes" \
   "$(td_contains 'terminal worker tactic-td-nullid has no usable job id')"
+td_teardown
+
+# --- Test 42: rc 0 with nothing landed retains the markers -------------------
+#
+# THE regression test. `park-node` lands through `graph-commit`, which pushes to
+# a contended `refs/graph/landing-lock` and can exit 0 in situations where the
+# write never reached origin/main (invariant I2: a graph-commit exit 0 is never
+# evidence anything landed). The old code deleted the session's escalation
+# markers on that exit code alone — destroying the ONLY copy of the session's own
+# escalation text while leaving the node held-and-unparked, i.e. turning a
+# recoverable failure into an unrecoverable one on the path whose job is to
+# prevent exactly that. The park must now be PROVEN landed on origin/main before
+# a single marker is removed.
+
+echo "Test: park-node exits 0 but origin/main still shows office_hours: null → markers retained"
+td_setup
+td_write_park_node 0 0 none
+td_write_node "tactic-td-notlanded" working
+td_commit_nodes
+td_write_transcript "0aae-3030" $(( TD_NOW - 4000 ))
+td_add_session "0aae-3030" "tactic-td-notlanded" "done" "aae03030"
+td_write_job_file "aae03030" "tactic-td-notlanded" office-hours-reason "reason that must survive an unlanded park"
+td_write_job_file "aae03030" "tactic-td-notlanded" office-hours-recommendation "recommendation that must survive"
+td_write_job_file "aae03030" "tactic-td-notlanded" office-hours-pr "3117"
+td_install_claude 0
+td_run
+assert_eq "not-landed: sweep returns 0" "0" "$TD_RC"
+assert_eq "not-landed: park-node was invoked" "1" "$(td_park_calls)"
+assert_eq "not-landed: stderr carries the loud, distinctly greppable line" "yes" \
+  "$(td_contains 'park-not-landed for tactic-td-notlanded — park-node exited 0 but origin/main still shows no office_hours')"
+assert_eq "not-landed: the decision record says park-not-landed" "park-not-landed" "$(td_log_dispositions)"
+assert_eq "not-landed: the reason marker is retained" "present" \
+  "$([[ -e "$TD_JOBS/aae03030/office-hours-reason" ]] && printf 'present' || printf 'gone')"
+assert_eq "not-landed: the recommendation marker is retained" "present" \
+  "$([[ -e "$TD_JOBS/aae03030/office-hours-recommendation" ]] && printf 'present' || printf 'gone')"
+assert_eq "not-landed: the pr marker is retained" "present" \
+  "$([[ -e "$TD_JOBS/aae03030/office-hours-pr" ]] && printf 'present' || printf 'gone')"
+assert_eq "not-landed: the success line is NOT logged" "no" \
+  "$(td_contains 'parked tactic-td-notlanded (terminal-without-disposition')"
+assert_eq "not-landed: the sweep counts no park" "yes" \
+  "$(td_contains 'terminal-disposition sweep complete (terminal=1 parked=0 observing=0 unmeasurable=0 deferred=0)')"
+td_teardown
+
+# --- Test 43: a park confirmed on origin/main is counted and clears the markers -
+#
+# The other half of the same gate: a park that genuinely landed still behaves
+# exactly as before. The final assertion reads origin/main directly, so a fixture
+# that silently stopped landing could not make this test vacuous.
+
+echo "Test: a park proven non-null on origin/main is counted and clears the markers"
+td_setup
+td_write_node "tactic-td-landed" working
+td_commit_nodes
+td_write_transcript "0bbf-3131" $(( TD_NOW - 4000 ))
+td_add_session "0bbf-3131" "tactic-td-landed" "done" "bbf03131"
+td_write_job_file "bbf03131" "tactic-td-landed" office-hours-reason "the worker's own reason"
+td_install_claude 0
+td_run
+assert_eq "landed: sweep returns 0" "0" "$TD_RC"
+assert_eq "landed: park-node invoked once" "1" "$(td_park_calls)"
+assert_eq "landed: stderr reports the park" "yes" \
+  "$(td_contains 'parked tactic-td-landed (terminal-without-disposition after 4000s')"
+assert_eq "landed: the decision record says parked" "parked" "$(td_log_dispositions)"
+assert_eq "landed: no unlanded-park line" "no" "$(td_contains 'park-not-landed')"
+assert_eq "landed: the reason marker was removed" "gone" \
+  "$([[ -e "$TD_JOBS/bbf03131/office-hours-reason" ]] && printf 'present' || printf 'gone')"
+assert_eq "landed: the sweep counts the park" "yes" \
+  "$(td_contains 'terminal-disposition sweep complete (terminal=1 parked=1 observing=0 unmeasurable=0 deferred=0)')"
+assert_eq "landed: origin/main really carries the park (the fixture is not vacuous)" "1" \
+  "$(git -C "$TD_REPO" show 'origin/main:intentions/tactic-td-landed.md' | grep -c '^office_hours:$')"
+td_teardown
+
+# --- Test 44: an unreadable node after an rc-0 park is NOT landed -------------
+#
+# UNKNOWN is never "landed". If the node file cannot be read from origin/main at
+# all after the park returned 0, the sweep has no evidence the park landed, so
+# the markers stay.
+
+echo "Test: a node absent from origin/main after an rc-0 park is treated as not landed"
+td_setup
+td_write_park_node 0 0 delete
+td_write_node "tactic-td-vanished" working
+td_commit_nodes
+td_write_transcript "0ccf-3232" $(( TD_NOW - 4000 ))
+td_add_session "0ccf-3232" "tactic-td-vanished" "done" "ccf03232"
+td_write_job_file "ccf03232" "tactic-td-vanished" office-hours-reason "reason that must survive an unreadable node"
+td_install_claude 0
+td_run
+assert_eq "vanished: sweep returns 0" "0" "$TD_RC"
+assert_eq "vanished: stderr reports the unlanded park" "yes" \
+  "$(td_contains 'park-not-landed for tactic-td-vanished')"
+assert_eq "vanished: the decision record says park-not-landed" "park-not-landed" "$(td_log_dispositions)"
+assert_eq "vanished: the reason marker is retained" "present" \
+  "$([[ -e "$TD_JOBS/ccf03232/office-hours-reason" ]] && printf 'present' || printf 'gone')"
+assert_eq "vanished: the sweep counts no park" "yes" \
+  "$(td_contains 'terminal-disposition sweep complete (terminal=1 parked=0 observing=0 unmeasurable=0 deferred=0)')"
+td_teardown
+
+# --- Test 45: the confirmation read is frontmatter-scoped ---------------------
+#
+# The trap step (8)'s idiom exists to prevent, read in the opposite polarity: a
+# column-0 `office_hours:` line in the markdown BODY (documentation of the
+# serialization) must never be mistaken for park state — here, must never certify
+# a park that never landed and so authorize deleting the session's only copy of
+# its escalation text.
+
+echo "Test: a body-only office_hours line never certifies a park (frontmatter scoping)"
+td_setup
+td_write_park_node 0 0 body
+td_write_node "tactic-td-bodyonly" working
+td_commit_nodes
+td_write_transcript "0ddb-3333" $(( TD_NOW - 4000 ))
+td_add_session "0ddb-3333" "tactic-td-bodyonly" "done" "ddb03333"
+td_write_job_file "ddb03333" "tactic-td-bodyonly" office-hours-reason "reason that must survive a body-only office_hours"
+td_install_claude 0
+td_run
+assert_eq "body-only: sweep returns 0" "0" "$TD_RC"
+assert_eq "body-only: the body line did not certify the park" "yes" \
+  "$(td_contains 'park-not-landed for tactic-td-bodyonly')"
+assert_eq "body-only: the decision record says park-not-landed" "park-not-landed" "$(td_log_dispositions)"
+assert_eq "body-only: the reason marker is retained" "present" \
+  "$([[ -e "$TD_JOBS/ddb03333/office-hours-reason" ]] && printf 'present' || printf 'gone')"
+assert_eq "body-only: origin/main really carries the body line (the fixture is not vacuous)" "1" \
+  "$(git -C "$TD_REPO" show 'origin/main:intentions/tactic-td-bodyonly.md' | grep -c '^office_hours:$')"
+assert_eq "body-only: the sweep counts no park" "yes" \
+  "$(td_contains 'terminal-disposition sweep complete (terminal=1 parked=0 observing=0 unmeasurable=0 deferred=0)')"
 td_teardown
 
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-session-reap.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-session-reap.sh
@@ -1,0 +1,728 @@
+#!/usr/bin/env bash
+# Tests for lib-session-reap.sh — the dispatch-sweep arm that reaps terminal
+# graph-node worker sessions `claude rm` silently DECLINED to remove.
+#
+# Everything the arm touches is faked, but the git side is REAL: the fixture
+# builds an actual scratch repo with actual `git worktree add` checkouts, so the
+# clean-tree gate, the `origin/main` content diff and the `git worktree remove`
+# itself exercise real git semantics rather than a shim's idea of them. That
+# matters most for the squash-merge test, whose whole point is that a branch can
+# be many commits "ahead" of origin/main with an EMPTY content diff — a property
+# no stub can honestly reproduce.
+#
+# Faked:
+#   `claude`  via CLAUDE_AGENTS_CMD — serves `agents --json --all` from
+#             payload.json and implements `rm <id>` per the mode file:
+#               accept        removes the entry from payload.json (a real reap)
+#               decline       prints the daemon's real decline line and exits 0
+#                             WITHOUT removing anything (THE BUG)
+#               unknown-list  the very first `agents` query fails
+#               unknown-post  `agents` succeeds once, then fails (the post-state
+#                             read is UNKNOWN)
+#   `gh`      via a PATH shim, driving gh_pr_list_rest's two calls.
+#   `git`     via a PATH shim that LOGS any `worktree remove` invocation and then
+#             execs the real git. Together with the fake `claude`'s own log line
+#             this gives a single ordered call log, which is how the
+#             "worktree remove BEFORE claude rm" ordering is asserted — that
+#             ordering is load-bearing behavior (removing the worktree is what
+#             makes the daemon accept), not an implementation detail.
+#   transcripts via DISPATCH_SESSION_REAP_PROJECTS_ROOT (mtimes set by `touch -d`)
+#   job dirs    via DISPATCH_SESSION_REAP_JOBS_ROOT
+#   the clock   via DISPATCH_SESSION_REAP_NOW_EPOCH
+#
+# session_reap_sweep always returns 0, but every call is still wrapped in an `if`
+# to capture the code — the test shell runs under `set -e`.
+set -euo pipefail
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=dispatch-test-fixture.sh
+source "$FIXTURE_DIR/dispatch-test-fixture.sh"
+
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib-session-reap.sh"
+
+echo ""
+echo "=== lib-session-reap.sh ==="
+
+# The real git, resolved BEFORE the PATH shim is installed — the shim execs it.
+REAL_GIT="$(command -v git)"
+
+# A fixed clock. Transcript mtimes are expressed relative to it.
+SR_NOW=1700000000
+
+SR_DIR=""
+SR_REPO=""
+SR_WTROOT=""
+SR_PROJ=""
+SR_JOBS=""
+SR_BIN=""
+SR_CALLS=""
+SR_FAKE=""
+SR_ENTRIES=()
+SR_RC=0
+SR_ERR=""
+SR_SAVED_PATH="$PATH"
+
+sr_setup() {
+  SR_DIR=$(mktemp -d)
+  SR_REPO="$SR_DIR/repo"
+  SR_WTROOT="$SR_REPO/.claude/worktrees"
+  SR_PROJ="$SR_DIR/projects"
+  SR_JOBS="$SR_DIR/jobs"
+  SR_BIN="$SR_DIR/bin"
+  SR_CALLS="$SR_DIR/calls"
+  SR_FAKE="$SR_DIR/fake-claude"
+  SR_ENTRIES=()
+  mkdir -p "$SR_REPO" "$SR_PROJ/proj-a" "$SR_JOBS" "$SR_BIN"
+  : > "$SR_CALLS"
+  printf 'accept' > "$SR_DIR/mode"
+  printf '[]' > "$SR_DIR/payload.json"
+
+  # A real scratch repo. HEAD is set to `main` explicitly — CI has no
+  # init.defaultBranch, so a bare `git init` would land on `master`.
+  "$REAL_GIT" -C "$SR_REPO" init -q
+  "$REAL_GIT" -C "$SR_REPO" symbolic-ref HEAD refs/heads/main
+  "$REAL_GIT" -C "$SR_REPO" config user.email "test@example.com"
+  "$REAL_GIT" -C "$SR_REPO" config user.name "Test"
+  mkdir -p "$SR_REPO/intentions"
+  # The worktree container lives inside the repo (mirroring the real
+  # .claude/worktrees layout), so keep it out of the parent's index.
+  printf '.claude/\n' > "$SR_REPO/.gitignore"
+  printf 'seed\n' > "$SR_REPO/README.md"
+  printf 'seed\n' > "$SR_REPO/intentions/seed.md"
+  "$REAL_GIT" -C "$SR_REPO" add -A
+  "$REAL_GIT" -C "$SR_REPO" commit -q -m "seed"
+  # No bare remote is needed: the arm only READS origin/main.
+  "$REAL_GIT" -C "$SR_REPO" update-ref refs/remotes/origin/main HEAD
+  mkdir -p "$SR_WTROOT"
+
+  sr_write_shims
+
+  DISPATCH_SESSION_REAP_NOW_EPOCH="$SR_NOW"
+  DISPATCH_SESSION_REAP_REPO_ROOT="$SR_REPO"
+  DISPATCH_SESSION_REAP_WORKTREES_ROOT="$SR_WTROOT"
+  DISPATCH_SESSION_REAP_PROJECTS_ROOT="$SR_PROJ"
+  DISPATCH_SESSION_REAP_JOBS_ROOT="$SR_JOBS"
+  export DISPATCH_SESSION_REAP_NOW_EPOCH DISPATCH_SESSION_REAP_REPO_ROOT \
+         DISPATCH_SESSION_REAP_WORKTREES_ROOT DISPATCH_SESSION_REAP_PROJECTS_ROOT \
+         DISPATCH_SESSION_REAP_JOBS_ROOT
+  unset DISPATCH_SESSION_REAP_GRACE_S DISPATCH_SESSION_REAP_MAX || true
+  # gh_pr_list_rest retries through gh_retry; zero the backoff so a deliberate
+  # failure test does not sleep.
+  export GH_RETRY_BASE_DELAY=0
+  # The arm must never read a tick snapshot — CLAUDE_AGENTS_CMD is the fake we
+  # want exercised. (claude_agents_list_terminal_workers queries --all directly,
+  # but unset it anyway so a leaked snapshot from another suite cannot confuse a
+  # future reader.)
+  unset DISPATCH_AGENTS_SNAPSHOT || true
+  CLAUDE_AGENTS_CMD="$SR_FAKE"
+  export CLAUDE_AGENTS_CMD
+}
+
+sr_teardown() {
+  export PATH="$SR_SAVED_PATH"
+  # Detach every worktree registration before deleting the tree, so a failed
+  # test cannot leave stale admin dirs behind in the tmp repo.
+  rm -rf "$SR_DIR"
+  SR_DIR=""
+  unset CLAUDE_AGENTS_CMD DISPATCH_SESSION_REAP_NOW_EPOCH \
+        DISPATCH_SESSION_REAP_REPO_ROOT DISPATCH_SESSION_REAP_WORKTREES_ROOT \
+        DISPATCH_SESSION_REAP_PROJECTS_ROOT DISPATCH_SESSION_REAP_JOBS_ROOT \
+        DISPATCH_SESSION_REAP_GRACE_S DISPATCH_SESSION_REAP_MAX \
+        GH_RETRY_BASE_DELAY || true
+}
+
+# sr_write_shims — install the PATH shims (git, gh) and the fake `claude`.
+sr_write_shims() {
+  # git: log every `worktree remove` into the shared call log, then exec the
+  # REAL git. Passthrough, so the reap-safety gates run against real git.
+  cat > "$SR_BIN/git" <<GITSHIM
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree remove"*) printf 'git-worktree-remove %s\n' "\$*" >> "$SR_CALLS" ;;
+esac
+exec "$REAL_GIT" "\$@"
+GITSHIM
+  chmod +x "$SR_BIN/git"
+
+  # gh: gh_pr_list_rest --head issues two calls — owner resolution, then the
+  # REST pulls query. Per-branch fixtures live at pr-<branch>.json in REST shape
+  # ({state:"open"|"closed", merged_at, number, created_at, title}); absent means
+  # "no PRs". A gh-fail sentinel forces the pulls call to fail.
+  cat > "$SR_BIN/gh" <<GHSTUB
+#!/usr/bin/env bash
+D="$SR_DIR"
+args="\$*"
+case "\$args" in
+  "repo view --json owner"*)
+    echo natb1
+    ;;
+  api*pulls*)
+    if [[ -f "\$D/gh-fail" ]]; then
+      echo "gh stub: simulated pulls failure" >&2
+      exit 1
+    fi
+    br=\$(printf '%s' "\$args" | grep -oE 'head=natb1:[^ ]+' | sed 's/head=natb1://')
+    f="\$D/pr-\${br}.json"
+    if [[ -f "\$f" ]]; then cat "\$f"; else echo '[]'; fi
+    ;;
+  *)
+    echo "gh stub: unknown invocation: \$args" >&2
+    exit 1
+    ;;
+esac
+GHSTUB
+  chmod +x "$SR_BIN/gh"
+
+  export PATH="$SR_BIN:$SR_SAVED_PATH"
+
+  # claude: `rm <id>` and `agents --json --all`, both logged; behavior driven by
+  # the mode file.
+  cat > "$SR_FAKE" <<CLAUDEFAKE
+#!/usr/bin/env bash
+D="$SR_DIR"
+CALLS="$SR_CALLS"
+MODE=\$(cat "\$D/mode" 2>/dev/null || printf 'accept')
+
+if [[ "\${1:-}" == "rm" ]]; then
+  id="\${2:-}"
+  printf 'claude-rm %s\n' "\$id" >> "\$CALLS"
+  if [[ "\$MODE" == "decline" ]]; then
+    # The daemon's REAL decline: a message on stdout and exit 0, with the
+    # session left registered. This is the bug under test.
+    printf 'kept %s — worktree has files but no repository to verify them against\n' "\$id"
+    exit 0
+  fi
+  tmp=\$(mktemp)
+  jq --arg id "\$id" 'map(select(.id != \$id))' "\$D/payload.json" > "\$tmp" && mv "\$tmp" "\$D/payload.json"
+  exit 0
+fi
+
+# \`agents --json --all\`
+n=\$(cat "\$D/agents-count" 2>/dev/null || printf '0')
+n=\$(( n + 1 ))
+printf '%s' "\$n" > "\$D/agents-count"
+printf 'claude-agents %s\n' "\$n" >> "\$CALLS"
+if [[ "\$MODE" == "unknown-list" ]]; then
+  exit 1
+fi
+if [[ "\$MODE" == "unknown-post" && "\$n" -ge 2 ]]; then
+  exit 1
+fi
+cat "\$D/payload.json"
+exit 0
+CLAUDEFAKE
+  chmod +x "$SR_FAKE"
+}
+
+# sr_mode <accept|decline|unknown-list|unknown-post>
+sr_mode() { printf '%s' "$1" > "$SR_DIR/mode"; }
+
+# sr_add_session <sid> <id-or-null> <name> [state] — append one registry entry.
+sr_add_session() {
+  local sid="$1" id="$2" name="$3" state="${4:-done}" idfield
+  if [[ "$id" == "null" ]]; then idfield="null"; else idfield="\"$id\""; fi
+  SR_ENTRIES+=("{\"sessionId\":\"$sid\",\"id\":$idfield,\"name\":\"$name\",\"state\":\"$state\",\"cwd\":\"$SR_WTROOT/$name\"}")
+}
+
+# sr_install_registry — write the accumulated entries into payload.json.
+sr_install_registry() {
+  local payload
+  payload=$( IFS=,; printf '[%s]' "${SR_ENTRIES[*]-}" )
+  printf '%s' "$payload" > "$SR_DIR/payload.json"
+}
+
+# sr_job <jid> <state-json-name> [marker-node] — create the managed-job dir.
+# <state-json-name> is what state.json's `.name` says (the ownership gate).
+# [marker-node] writes a node-terminal marker in mark-node-terminal's exact byte
+# format naming that node; "none" (or omitted) writes no marker; "malformed"
+# writes a marker with no `^node=` line at all.
+sr_job() {
+  local jid="$1" owner="$2" marker="${3:-none}"
+  mkdir -p "$SR_JOBS/$jid"
+  printf '{"name":"%s"}\n' "$owner" > "$SR_JOBS/$jid/state.json"
+  case "$marker" in
+    none) ;;
+    malformed) printf 'disposition=align-round\n' > "$SR_JOBS/$jid/node-terminal" ;;
+    *) printf 'node=%s\ndisposition=align-round\n' "$marker" > "$SR_JOBS/$jid/node-terminal" ;;
+  esac
+}
+
+# sr_transcript <sid> <mtime-epoch>
+sr_transcript() {
+  printf '{}\n' > "$SR_PROJ/proj-a/$1.jsonl"
+  touch -d "@$2" "$SR_PROJ/proj-a/$1.jsonl"
+}
+
+# sr_worktree <node-id> <clean|squash|content|intentions|dirty>
+# Create a real worktree on a branch named for the node (what
+# provision-node-worktree does), then shape its divergence from origin/main.
+sr_worktree() {
+  # Split assignments: `local` expands every word before assigning any of them,
+  # so `w="$SR_WTROOT/$name"` on the same line would read an unset $name under
+  # `set -u`.
+  local name="$1" kind="$2" i
+  local w="$SR_WTROOT/$name"
+  "$REAL_GIT" -C "$SR_REPO" worktree add -q "$w" -b "$name" main
+  case "$kind" in
+    clean) ;;
+    dirty)
+      printf 'uncommitted\n' >> "$w/README.md"
+      ;;
+    content)
+      printf 'changed\n' > "$w/README.md"
+      "$REAL_GIT" -C "$w" add -A
+      "$REAL_GIT" -C "$w" commit -q -m "content change"
+      ;;
+    intentions)
+      printf 'node body\n' > "$w/intentions/$name.md"
+      "$REAL_GIT" -C "$w" add -A
+      "$REAL_GIT" -C "$w" commit -q -m "graph record"
+      ;;
+    squash)
+      # Many commits "ahead" of origin/main whose NET tree is identical to it —
+      # exactly the shape a squash-merged branch has. A commit-count gate would
+      # refuse to reap this; the content gate must not.
+      for i in 1 2 3 4 5; do
+        printf '%s\n' "$i" > "$w/scratch.txt"
+        "$REAL_GIT" -C "$w" add -A
+        "$REAL_GIT" -C "$w" commit -q -m "step $i"
+      done
+      rm "$w/scratch.txt"
+      "$REAL_GIT" -C "$w" add -A
+      "$REAL_GIT" -C "$w" commit -q -m "net zero"
+      ;;
+  esac
+}
+
+# sr_open_pr <branch> — install a REST fixture with one OPEN PR on that branch.
+sr_open_pr() {
+  printf '[{"number":77,"state":"open","merged_at":null,"title":"wip","created_at":"2026-01-01T00:00:00Z"}]\n' \
+    > "$SR_DIR/pr-$1.json"
+}
+
+sr_run() {
+  if session_reap_sweep 2>"$SR_DIR/err"; then SR_RC=0; else SR_RC=$?; fi
+  SR_ERR=$(cat "$SR_DIR/err")
+}
+
+sr_contains() {
+  case "$SR_ERR" in *"$1"*) printf 'yes' ;; *) printf 'no' ;; esac
+}
+
+sr_calls() { cat "$SR_CALLS"; }
+
+# sr_line_of <pattern> — 1-based index of the first matching call-log line, or
+# "none".
+sr_line_of() {
+  local n
+  n=$(grep -n -- "$1" "$SR_CALLS" 2>/dev/null | head -n1 | cut -d: -f1) || n=""
+  printf '%s' "${n:-none}"
+}
+
+sr_rm_calls() {
+  local c
+  c=$(grep -c '^claude-rm ' "$SR_CALLS" 2>/dev/null) || c=0
+  [[ -n "$c" ]] || c=0
+  printf '%s' "$c"
+}
+
+# --- Test 1: happy path — worktree removed FIRST, rm accepted, id gone -------
+
+echo "Test: a terminal align-round worker is reaped — worktree removed before claude rm"
+sr_setup
+sr_worktree "tactic-happy" clean
+sr_job "aaaa1111" "tactic-happy" "tactic-happy"
+sr_transcript "0aa1-1111" $(( SR_NOW - 4000 ))
+sr_add_session "0aa1-1111" "aaaa1111" "tactic-happy"
+sr_install_registry
+sr_run
+assert_eq "happy: sweep returns 0" "0" "$SR_RC"
+assert_eq "happy: the reap is reported" "yes" "$(sr_contains 'SESSION_REAPED: name=tactic-happy')"
+assert_eq "happy: no decline is reported" "no" "$(sr_contains 'REAP_DECLINED')"
+assert_eq "happy: summary counts one reap" "yes" \
+  "$(sr_contains 'SESSION_REAP_COMPLETE: terminal=1 reaped=1 declined=0 unverified=0 skipped=0')"
+assert_eq "happy: the worktree is gone from disk" "gone" \
+  "$([[ -d "$SR_WTROOT/tactic-happy" ]] && printf 'present' || printf 'gone')"
+assert_eq "happy: the branch is NOT deleted" "0" \
+  "$("$REAL_GIT" -C "$SR_REPO" rev-parse --verify --quiet refs/heads/tactic-happy >/dev/null 2>&1; echo $?)"
+assert_eq "happy: claude rm was called once" "1" "$(sr_rm_calls)"
+assert_eq "happy: claude rm got the JOB id, not the session id" "yes" \
+  "$(case "$(sr_calls)" in *"claude-rm aaaa1111"*) printf 'yes' ;; *) printf 'no' ;; esac)"
+# ORDERING — load-bearing: removing the worktree is what makes the daemon accept.
+SR_WT_LINE=$(sr_line_of '^git-worktree-remove ')
+SR_RM_LINE=$(sr_line_of '^claude-rm ')
+assert_eq "happy: worktree remove was logged" "yes" \
+  "$([[ "$SR_WT_LINE" != "none" ]] && printf 'yes' || printf 'no')"
+assert_eq "happy: worktree remove happened BEFORE claude rm" "yes" \
+  "$([[ "$SR_WT_LINE" != "none" && "$SR_RM_LINE" != "none" && "$SR_WT_LINE" -lt "$SR_RM_LINE" ]] && printf 'yes' || printf 'no')"
+sr_teardown
+
+# --- Test 2: THE REGRESSION — `claude rm` exits 0 but declines ---------------
+#
+# The bug this file exists to fix. `claude rm` prints its decline line and exits
+# 0; the session is still in the follow-up listing. Trusting exit 0 (what
+# dispatch-self-close's `exec claude rm` does) would report success. The arm must
+# report REAP_DECLINED and must NOT count a reap.
+
+echo "Test: claude rm exits 0 while declining — REAP_DECLINED, never success"
+sr_setup
+sr_mode decline
+sr_worktree "tactic-declined" clean
+sr_job "bbbb2222" "tactic-declined" "tactic-declined"
+sr_transcript "0bb2-2222" $(( SR_NOW - 4000 ))
+sr_add_session "0bb2-2222" "bbbb2222" "tactic-declined"
+sr_install_registry
+sr_run
+assert_eq "decline: sweep returns 0" "0" "$SR_RC"
+assert_eq "decline: REAP_DECLINED is logged loudly" "yes" \
+  "$(sr_contains 'REAP_DECLINED: name=tactic-declined session=0bb2-2222 id=bbbb2222')"
+assert_eq "decline: the decline says the slot is still held" "yes" \
+  "$(sr_contains 'it is holding a worker slot and its node is unselectable')"
+assert_eq "decline: success is NOT reported" "no" "$(sr_contains 'SESSION_REAPED')"
+assert_eq "decline: summary counts the decline, not a reap" "yes" \
+  "$(sr_contains 'SESSION_REAP_COMPLETE: terminal=1 reaped=0 declined=1 unverified=0 skipped=0')"
+assert_eq "decline: claude rm was still attempted" "1" "$(sr_rm_calls)"
+sr_teardown
+
+# --- Test 3: UNKNOWN from the candidate lister aborts the arm ----------------
+
+echo "Test: an unqueryable daemon aborts the arm — it reaps nothing and says it cannot see"
+sr_setup
+sr_mode unknown-list
+sr_worktree "tactic-unknown" clean
+sr_job "cccc3333" "tactic-unknown" "tactic-unknown"
+sr_transcript "0cc3-3333" $(( SR_NOW - 4000 ))
+sr_add_session "0cc3-3333" "cccc3333" "tactic-unknown"
+sr_install_registry
+sr_run
+assert_eq "unknown-list: sweep returns 0" "0" "$SR_RC"
+assert_eq "unknown-list: the arm says it cannot see" "yes" \
+  "$(sr_contains 'SESSION_REAP_UNKNOWN: daemon unqueryable')"
+assert_eq "unknown-list: no summary claiming zero candidates" "no" \
+  "$(sr_contains 'SESSION_REAP_COMPLETE')"
+assert_eq "unknown-list: claude rm never called" "0" "$(sr_rm_calls)"
+assert_eq "unknown-list: the worktree is untouched" "present" \
+  "$([[ -d "$SR_WTROOT/tactic-unknown" ]] && printf 'present' || printf 'gone')"
+sr_teardown
+
+# --- Test 4: UNKNOWN on the POST-STATE read is not success -------------------
+
+echo "Test: an unqueryable post-state read is UNVERIFIED, never a reported reap"
+sr_setup
+sr_mode unknown-post
+sr_worktree "tactic-unverified" clean
+sr_job "dddd4444" "tactic-unverified" "tactic-unverified"
+sr_transcript "0dd4-4444" $(( SR_NOW - 4000 ))
+sr_add_session "0dd4-4444" "dddd4444" "tactic-unverified"
+sr_install_registry
+sr_run
+assert_eq "unknown-post: sweep returns 0" "0" "$SR_RC"
+assert_eq "unknown-post: the unverified outcome is logged" "yes" \
+  "$(sr_contains 'SESSION_REAP_UNVERIFIED: name=tactic-unverified')"
+assert_eq "unknown-post: it says the removal is not confirmed" "yes" \
+  "$(sr_contains 'removal NOT confirmed')"
+assert_eq "unknown-post: success is NOT reported" "no" "$(sr_contains 'SESSION_REAPED')"
+assert_eq "unknown-post: no false decline either" "no" "$(sr_contains 'REAP_DECLINED')"
+assert_eq "unknown-post: summary counts it as unverified" "yes" \
+  "$(sr_contains 'SESSION_REAP_COMPLETE: terminal=1 reaped=0 declined=0 unverified=1 skipped=0')"
+sr_teardown
+
+# --- Test 5: a dirty worktree blocks the reap --------------------------------
+
+echo "Test: a dirty worktree blocks the reap"
+sr_setup
+sr_worktree "tactic-dirty" dirty
+sr_job "eeee5555" "tactic-dirty" "tactic-dirty"
+sr_transcript "0ee5-5555" $(( SR_NOW - 4000 ))
+sr_add_session "0ee5-5555" "eeee5555" "tactic-dirty"
+sr_install_registry
+sr_run
+assert_eq "dirty: sweep returns 0" "0" "$SR_RC"
+assert_eq "dirty: the skip is logged" "yes" \
+  "$(sr_contains 'SESSION_REAP_SKIP_DIRTY: name=tactic-dirty')"
+assert_eq "dirty: claude rm never called" "0" "$(sr_rm_calls)"
+assert_eq "dirty: the worktree survives" "present" \
+  "$([[ -d "$SR_WTROOT/tactic-dirty" ]] && printf 'present' || printf 'gone')"
+sr_teardown
+
+# --- Test 6: unlanded content blocks the reap --------------------------------
+
+echo "Test: a branch whose content differs from origin/main blocks the reap"
+sr_setup
+sr_worktree "tactic-content" content
+sr_job "ffff6666" "tactic-content" "tactic-content"
+sr_transcript "0ff6-6666" $(( SR_NOW - 4000 ))
+sr_add_session "0ff6-6666" "ffff6666" "tactic-content"
+sr_install_registry
+sr_run
+assert_eq "content: sweep returns 0" "0" "$SR_RC"
+assert_eq "content: the skip is logged" "yes" \
+  "$(sr_contains 'SESSION_REAP_SKIP_UNLANDED_CONTENT: name=tactic-content')"
+assert_eq "content: claude rm never called" "0" "$(sr_rm_calls)"
+sr_teardown
+
+# --- Test 7: an OPEN PR on the branch blocks the reap ------------------------
+
+echo "Test: an OPEN PR whose head is this branch blocks the reap"
+sr_setup
+sr_worktree "tactic-openpr" clean
+sr_open_pr "tactic-openpr"
+sr_job "1111aaaa" "tactic-openpr" "tactic-openpr"
+sr_transcript "0117-7777" $(( SR_NOW - 4000 ))
+sr_add_session "0117-7777" "1111aaaa" "tactic-openpr"
+sr_install_registry
+sr_run
+assert_eq "open-pr: sweep returns 0" "0" "$SR_RC"
+assert_eq "open-pr: the skip is logged" "yes" \
+  "$(sr_contains 'SESSION_REAP_SKIP_OPEN_PR: name=tactic-openpr session=0117-7777 branch=tactic-openpr open_prs=1')"
+assert_eq "open-pr: claude rm never called" "0" "$(sr_rm_calls)"
+assert_eq "open-pr: the worktree survives" "present" \
+  "$([[ -d "$SR_WTROOT/tactic-openpr" ]] && printf 'present' || printf 'gone')"
+sr_teardown
+
+# --- Test 8: a gh failure fails toward KEEP ----------------------------------
+
+echo "Test: a gh failure on the PR probe fails toward KEEP"
+sr_setup
+sr_worktree "tactic-ghfail" clean
+: > "$SR_DIR/gh-fail"
+sr_job "2222bbbb" "tactic-ghfail" "tactic-ghfail"
+sr_transcript "0228-8888" $(( SR_NOW - 4000 ))
+sr_add_session "0228-8888" "2222bbbb" "tactic-ghfail"
+sr_install_registry
+sr_run
+assert_eq "gh-fail: sweep returns 0" "0" "$SR_RC"
+assert_eq "gh-fail: the skip is logged" "yes" \
+  "$(sr_contains 'SESSION_REAP_SKIP_PR_FETCH_FAILED: name=tactic-ghfail')"
+assert_eq "gh-fail: claude rm never called" "0" "$(sr_rm_calls)"
+assert_eq "gh-fail: the worktree survives" "present" \
+  "$([[ -d "$SR_WTROOT/tactic-ghfail" ]] && printf 'present' || printf 'gone')"
+sr_teardown
+
+# --- Test 9: THE SQUASH-MERGE CORRECTION -------------------------------------
+#
+# GitHub squash-merges, so a branch's individual commits are never ancestors of
+# main — only their content is. A commit-count gate would read this branch as 6
+# commits "ahead" and refuse forever, stranding the slot while looking
+# conservative. The CONTENT gate must reap it.
+
+echo "Test: a branch many commits ahead of origin/main with an EMPTY content diff is reaped"
+sr_setup
+sr_worktree "tactic-squash" squash
+sr_job "3333cccc" "tactic-squash" "tactic-squash"
+sr_transcript "0339-9999" $(( SR_NOW - 4000 ))
+sr_add_session "0339-9999" "3333cccc" "tactic-squash"
+sr_install_registry
+SR_AHEAD=$("$REAL_GIT" -C "$SR_WTROOT/tactic-squash" rev-list --count HEAD --not --remotes)
+assert_eq "squash: the fixture really is many commits ahead" "6" "$SR_AHEAD"
+sr_run
+assert_eq "squash: sweep returns 0" "0" "$SR_RC"
+assert_eq "squash: the reap proceeds despite the commit count" "yes" \
+  "$(sr_contains 'SESSION_REAPED: name=tactic-squash')"
+assert_eq "squash: no unlanded-content skip" "no" "$(sr_contains 'SESSION_REAP_SKIP_UNLANDED_CONTENT')"
+assert_eq "squash: the worktree is gone" "gone" \
+  "$([[ -d "$SR_WTROOT/tactic-squash" ]] && printf 'present' || printf 'gone')"
+sr_teardown
+
+# --- Test 10: the ':!intentions' exclusion -----------------------------------
+
+echo "Test: a branch whose only divergence is under intentions/ is reaped"
+sr_setup
+sr_worktree "tactic-graphonly" intentions
+sr_job "4444dddd" "tactic-graphonly" "tactic-graphonly"
+sr_transcript "0440-0000" $(( SR_NOW - 4000 ))
+sr_add_session "0440-0000" "4444dddd" "tactic-graphonly"
+sr_install_registry
+sr_run
+assert_eq "intentions: sweep returns 0" "0" "$SR_RC"
+assert_eq "intentions: the reap proceeds" "yes" "$(sr_contains 'SESSION_REAPED: name=tactic-graphonly')"
+assert_eq "intentions: no unlanded-content skip" "no" "$(sr_contains 'SESSION_REAP_SKIP_UNLANDED_CONTENT')"
+sr_teardown
+
+# --- Test 11: a missing node-terminal marker skips ---------------------------
+
+echo "Test: a missing node-terminal marker skips the session"
+sr_setup
+sr_worktree "tactic-nomarker" clean
+sr_job "5555eeee" "tactic-nomarker" none
+sr_transcript "0551-1111" $(( SR_NOW - 4000 ))
+sr_add_session "0551-1111" "5555eeee" "tactic-nomarker"
+sr_install_registry
+sr_run
+assert_eq "no-marker: sweep returns 0" "0" "$SR_RC"
+assert_eq "no-marker: the skip is logged" "yes" \
+  "$(sr_contains 'SESSION_REAP_SKIP_NO_TERMINAL_MARKER: name=tactic-nomarker')"
+assert_eq "no-marker: claude rm never called" "0" "$(sr_rm_calls)"
+sr_teardown
+
+# --- Test 12: a malformed marker (no ^node= line) skips ----------------------
+
+echo "Test: a marker with no ^node= line skips the session"
+sr_setup
+sr_worktree "tactic-badmarker" clean
+sr_job "6666ffff" "tactic-badmarker" malformed
+sr_transcript "0662-2222" $(( SR_NOW - 4000 ))
+sr_add_session "0662-2222" "6666ffff" "tactic-badmarker"
+sr_install_registry
+sr_run
+assert_eq "bad-marker: sweep returns 0" "0" "$SR_RC"
+assert_eq "bad-marker: the skip is logged" "yes" \
+  "$(sr_contains 'SESSION_REAP_SKIP_NO_TERMINAL_MARKER: name=tactic-badmarker')"
+assert_eq "bad-marker: claude rm never called" "0" "$(sr_rm_calls)"
+sr_teardown
+
+# --- Test 13: a marker naming a DIFFERENT node skips -------------------------
+
+echo "Test: a marker naming another node cannot authorize this session's reap"
+sr_setup
+sr_worktree "tactic-othermarker" clean
+sr_job "7777aaaa" "tactic-othermarker" "tactic-somewhere-else"
+sr_transcript "0773-3333" $(( SR_NOW - 4000 ))
+sr_add_session "0773-3333" "7777aaaa" "tactic-othermarker"
+sr_install_registry
+sr_run
+assert_eq "other-marker: sweep returns 0" "0" "$SR_RC"
+assert_eq "other-marker: the skip names the foreign marker" "yes" \
+  "$(sr_contains 'marker_node=tactic-somewhere-else')"
+assert_eq "other-marker: claude rm never called" "0" "$(sr_rm_calls)"
+sr_teardown
+
+# --- Test 14: a foreign-owned job dir skips ----------------------------------
+#
+# The job dir is keyed on the registry's `.id`, and a RESUMED session keeps its
+# original `.id` while its `.sessionId` changes — so `.id` collisions across
+# sessions are the failure mode the ownership gate exists for. Even with a
+# perfectly valid marker inside, a job dir whose state.json names a DIFFERENT
+# node must not be trusted.
+
+echo "Test: a job dir whose state.json names another node is not trusted"
+sr_setup
+sr_worktree "tactic-foreignjob" clean
+sr_job "8888bbbb" "tactic-someone-else" "tactic-foreignjob"
+sr_transcript "0884-4444" $(( SR_NOW - 4000 ))
+sr_add_session "0884-4444" "8888bbbb" "tactic-foreignjob"
+sr_install_registry
+sr_run
+assert_eq "foreign-job: sweep returns 0" "0" "$SR_RC"
+assert_eq "foreign-job: the skip is logged" "yes" \
+  "$(sr_contains 'SESSION_REAP_SKIP_FOREIGN_JOB_DIR: name=tactic-foreignjob')"
+assert_eq "foreign-job: it names the state.json owner" "yes" \
+  "$(sr_contains 'state_json_name=tactic-someone-else')"
+assert_eq "foreign-job: claude rm never called" "0" "$(sr_rm_calls)"
+sr_teardown
+
+# --- Test 15: grace not yet elapsed skips ------------------------------------
+
+echo "Test: a session inside the grace window is skipped (self-close may be mid-reap)"
+sr_setup
+sr_worktree "tactic-young" clean
+sr_job "9999cccc" "tactic-young" "tactic-young"
+sr_transcript "0995-5555" $(( SR_NOW - 60 ))
+sr_add_session "0995-5555" "9999cccc" "tactic-young"
+sr_install_registry
+sr_run
+assert_eq "grace: sweep returns 0" "0" "$SR_RC"
+assert_eq "grace: the skip reports idle vs grace" "yes" \
+  "$(sr_contains 'SESSION_REAP_SKIP_GRACE: name=tactic-young session=0995-5555 idle_seconds=60 grace_seconds=300')"
+assert_eq "grace: claude rm never called" "0" "$(sr_rm_calls)"
+sr_teardown
+
+# --- Test 16: an unmeasurable transcript skips -------------------------------
+
+echo "Test: an unreadable transcript is UNKNOWN and skips the session"
+sr_setup
+sr_worktree "tactic-notranscript" clean
+sr_job "aaaa9999" "tactic-notranscript" "tactic-notranscript"
+sr_add_session "0aa6-6666" "aaaa9999" "tactic-notranscript"
+sr_install_registry
+sr_run
+assert_eq "unmeasurable: sweep returns 0" "0" "$SR_RC"
+assert_eq "unmeasurable: the skip is logged" "yes" \
+  "$(sr_contains 'SESSION_REAP_SKIP_UNMEASURABLE: name=tactic-notranscript')"
+assert_eq "unmeasurable: claude rm never called" "0" "$(sr_rm_calls)"
+sr_teardown
+
+# --- Test 17: a legacy issue worker is not ours ------------------------------
+
+echo "Test: a ^[0-9]+- issue-worker session is skipped"
+sr_setup
+sr_job "bbbb8888" "1234-some-issue" "1234-some-issue"
+sr_transcript "0bb7-7777" $(( SR_NOW - 4000 ))
+sr_add_session "0bb7-7777" "bbbb8888" "1234-some-issue"
+sr_install_registry
+sr_run
+assert_eq "issue-worker: sweep returns 0" "0" "$SR_RC"
+assert_eq "issue-worker: the skip is logged" "yes" \
+  "$(sr_contains 'SESSION_REAP_SKIP_ISSUE_WORKER: name=1234-some-issue')"
+assert_eq "issue-worker: claude rm never called" "0" "$(sr_rm_calls)"
+sr_teardown
+
+# --- Test 18: an absent worktree goes straight to claude rm ------------------
+
+echo "Test: with no worktree on disk the reap-safety gates are vacuous and claude rm runs"
+sr_setup
+sr_job "cccc7777" "tactic-noworktree" "tactic-noworktree"
+sr_transcript "0cc8-8888" $(( SR_NOW - 4000 ))
+sr_add_session "0cc8-8888" "cccc7777" "tactic-noworktree"
+sr_install_registry
+sr_run
+assert_eq "no-worktree: sweep returns 0" "0" "$SR_RC"
+assert_eq "no-worktree: the absence is logged" "yes" \
+  "$(sr_contains 'SESSION_REAP_NO_WORKTREE: name=tactic-noworktree')"
+assert_eq "no-worktree: the reap proceeds" "yes" "$(sr_contains 'SESSION_REAPED: name=tactic-noworktree')"
+assert_eq "no-worktree: claude rm was called once" "1" "$(sr_rm_calls)"
+assert_eq "no-worktree: no worktree remove was attempted" "none" "$(sr_line_of '^git-worktree-remove ')"
+sr_teardown
+
+# --- Test 19: a null `.id` column must not shift the name column -------------
+#
+# `@tsv` renders a null `.id` as an empty column, and TAB is IFS whitespace — so
+# `IFS=$'\t' read -r sid jid name cwd` would collapse it and slide `name` onto
+# the cwd. The row must reach the documented "no usable job id" skip with its
+# node name intact, never be silently misclassified.
+
+echo "Test: a registry row with a null id keeps its node-name column"
+sr_setup
+sr_worktree "tactic-nullid" clean
+sr_transcript "0dd9-9999" $(( SR_NOW - 4000 ))
+sr_add_session "0dd9-9999" "null" "tactic-nullid"
+sr_install_registry
+sr_run
+assert_eq "null-id: sweep returns 0" "0" "$SR_RC"
+assert_eq "null-id: the node name survived the parse" "yes" \
+  "$(sr_contains 'SESSION_REAP_SKIP_NO_JOB_DIR: name=tactic-nullid session=0dd9-9999 id=<empty>')"
+assert_eq "null-id: claude rm never called" "0" "$(sr_rm_calls)"
+sr_teardown
+
+# --- Test 20: an empty registry is a definite zero, not an abort -------------
+
+echo "Test: no terminal workers at all completes with a zero summary"
+sr_setup
+sr_install_registry
+sr_run
+assert_eq "empty: sweep returns 0" "0" "$SR_RC"
+assert_eq "empty: summary is all zeros" "yes" \
+  "$(sr_contains 'SESSION_REAP_COMPLETE: terminal=0 reaped=0 declined=0 unverified=0 skipped=0')"
+assert_eq "empty: claude rm never called" "0" "$(sr_rm_calls)"
+sr_teardown
+
+# --- Test 21: the optional log file gets the same dispositions ---------------
+
+echo "Test: dispositions also land in the caller's log file, timestamped and tagged"
+sr_setup
+sr_worktree "tactic-logged" clean
+sr_job "dddd6666" "tactic-logged" "tactic-logged"
+sr_transcript "0ee1-1112" $(( SR_NOW - 4000 ))
+sr_add_session "0ee1-1112" "dddd6666" "tactic-logged"
+sr_install_registry
+if session_reap_sweep "$SR_DIR/sweep.log" "dispatch-sweep" 2>"$SR_DIR/err"; then SR_RC=0; else SR_RC=$?; fi
+SR_ERR=$(cat "$SR_DIR/err")
+assert_eq "logfile: sweep returns 0" "0" "$SR_RC"
+assert_eq "logfile: the reap line is in the log file" "yes" \
+  "$(grep -q 'SESSION_REAPED: name=tactic-logged' "$SR_DIR/sweep.log" && printf 'yes' || printf 'no')"
+assert_eq "logfile: the line carries the dispatch-sweep tag" "yes" \
+  "$(grep -q '\[dispatch-sweep\] SESSION_REAP_COMPLETE' "$SR_DIR/sweep.log" && printf 'yes' || printf 'no')"
+sr_teardown
+
+report_results


### PR DESCRIPTION
Implements the auto-heal for bug **AH**, and closes an invariant-I2 violation on
the bug **J** heal path. Both are the same class: **a recovery step whose failure
mode is indistinguishable from success.**

## Bug AH — `claude rm` exits 0 while declining

Reproduced verbatim:

```
$ claude rm e2636150
kept e2636150 — worktree has files but no repository to verify them against
$ echo $?
0
```

`dispatch-self-close` ends with `exec "$CLAUDE_CMD" rm "$JOB_ID"` and treats that
exec as the reap. `exec` **replaces the process**, so nothing survives to check.
A decline is therefore indistinguishable from a removal: no error, no retry, no
detect. The session stays registered forever, and because
`worktree_has_live_session` is NAME-keyed on the node id, its node becomes
permanently unselectable while consuming a worker slot.

**Systemic, not incidental.** The unverifiable-worktree condition holds whenever
the node's branch was never pushed — and an `/align-tactics` round lands by
`graph-commit` direct-push to `main`, never pushing a node branch. So every
align-round worker ends in this state. Measured 2026-08-03: 8 sessions cleared by
hand in a single day, with a fresh instance appearing mid-session; two of three
worker slots stranded; `effective_live` reading 1–2 against a cap of 3 while the
top of the queue sat unreachable.

### What this adds

New `lib-session-reap.sh`, wired into `dispatch-sweep` — a supervisor that
outlives the session, which is the whole point: the post-state can only be
verified from a process that is still alive to read it.

Every gate fails toward KEEP: worker-keyspace name, a valid `node-terminal`
marker in a job dir the node owns, a grace window, clean tree, empty content
diff, no open PR. Then:

1. `git worktree remove` **first** — this is what makes the daemon accept;
2. `claude rm`;
3. a re-query distinguishing **three** outcomes — removed, `REAP_DECLINED`, and
   `SESSION_REAP_UNVERIFIED` when the daemon cannot be reached.

Collapsing UNVERIFIED into success would reproduce the exact bug being fixed.

### The reap-safety gate is a content diff, not a commit count

GitHub squash-merges, so a branch's individual commits are never ancestors of
`main` — only their content is. Both sessions reaped by hand on 08-03 read 11 and
12 commits "ahead" yet were entirely safe. A commit-count gate fails toward a
false *"do not touch"*, which is why it went unnoticed: it strands slots while
looking conservative. The gate is
`git diff origin/main HEAD -- . ':!intentions'` being empty; the `':!intentions'`
exclusion is because a node's graph commits legitimately ride along on its branch
and land separately by direct-push.

### This is brownfield step 1 of 2

`dispatch-self-close` is **deliberately unchanged**. The arm is safe alongside its
`exec claude rm` — a session self-close already removed is simply absent from the
listing. Deleting that line is step 2, and only once this arm is observed reaping
within one sweep interval.

## Bug J — markers deleted on an unverified park

`terminal_without_disposition_sweep` deleted a session's `office-hours-*` markers
on `park-node` **exit 0**. Invariant I2: a `graph-commit` exit 0 is never evidence
anything reached `origin/main`. On a park that exited 0 without landing, the
markers — the only surviving copy of the session's own escalation text — were
destroyed, leaving the node held-and-unparked with its evidence gone. The path
whose whole job is preventing that state was creating it.

Step (13) now re-reads the node from `origin/main` after the park and requires
`office_hours` non-null before deleting anything. **Marker deletion becomes the
proof the park landed.** Not-landed keeps the markers, logs a distinct
`park-not-landed` disposition, and does not count the park; the next tick retries
with the session's own text.

This also makes the existing bug-J detect double as the heal's own success
criterion — a marker surviving one sweep interval is a heal that failed, and says
so.

The confirmation read takes its own fetch and cannot share step (6)'s lazy latch:
the park itself is what made `origin/main` stale, so a latched read would report
**every** park as not-landed. The documented fetch budget therefore changes from
one per sweep to `1 + park_max` (3 by default), bounded by the same cap — and the
header is updated to match rather than left to drift.

## Tests

125 new assertions. Both regression tests were confirmed against a **pre-fix
control**, because a green run proves nothing on its own:

| suite | pre-fix control | with fix |
|---|---|---|
| `test-lib-session-reap.sh` (new) | **80/88, 8 failed** | 88/88 |
| `test-lib-frozen-session-park.sh` | **193/209, 16 failed** | 209/209 |
| `test-dispatch-sweep.sh` | 131/135 (source removed) | 135/135 |

Coverage worth naming: reap/`rm` **ordering** asserted explicitly; each safety
gate blocking independently; the squash-merge case (many commits ahead, empty
content diff ⇒ reap proceeds); UNKNOWN from either the candidate lister or the
post-state re-list never reported as success; and frontmatter-scoped park
confirmation, so a column-0 `office_hours:` line in a node **body** can never
certify a park.

The new suite ships mode **100755** — two suites in this repo previously shipped
`100644` and died in CI on `Permission denied` while looking exactly like
coverage. `run-unit-tests.sh` globs `test-*.sh`, so no workflow registration is
needed.

## Known residual, deliberately not fixed here

If the confirmation read is a **false negative** — the park landed but the fetch
failed — the markers are kept, and the next tick's step (8) sees the node already
parked and skips. Nothing then deletes those markers, so the bug-J detect fires
forever on a node that is genuinely parked (held-and-parked, i.e. benign but
noisy). This shape already exists at HEAD for the "non-zero exit but the write
landed anyway" case; this change makes it reachable through one more door. The
closure is small and belongs to whoever owns the marker lifecycle — flagged
rather than widened into silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Coverage: this heals the silent-decline class, not every stranded session

Stated up front because the measured proportion runs the other way. Of the 8
sessions cleared by hand on 2026-08-03, **3** were bug AH (valid `node-terminal`
marker, `disposition=align-round`, no remote branch) and **5** were the marker
gap tracked by `tactic-qa-fix-node-terminal-declaration` — no marker at all, so
`dispatch-self-close` HOLDs them, correctly. A ninth instance appeared while this
PR was being written (`tactic-review-domain-lens-consolidation`, 19:40Z) and was
also the marker gap.

This arm requires a valid marker, because Invariant 2 is unchanged: reaping a
session that never declared a disposition would destroy the very signal that its
node still owes the author a park. **So it covers the minority of observed
instances by construction, and the marker-gap class still needs a human.**

The follow-up that suggests — recorded on the node rather than taken here,
because it is a design call: once `terminal_without_disposition_sweep` has parked
a marker-less session's node and that park is *proven landed* on `origin/main`
(which the second half of this PR now guarantees), the park is itself a
disposition — supplied by the supervisor instead of by the session. Reaping on
that proof would close the remaining class without weakening Invariant 2, since
the evidence the invariant protects has by then been produced and verified.
Whether the terminal-disposition contract should admit a supervisor-supplied
disposition is an author premise, not an implementation detail.
