### PR TITLE
Make audit-written routing policy loop advisory

### DIFF
--- a/.claude/skills/dispatch-token-audit/SKILL.md
+++ b/.claude/skills/dispatch-token-audit/SKILL.md
@@ -126,6 +126,7 @@ Ranking (step 5) stays on `price_proxy_usd`. `cost_usd` is reported alongside it
      - The evidence rows from the script (error signatures with counts, phase-model rows, etc.).
      - A concrete, specific suggestion (not a vague "consider X" — name the phase, the model, the script, the error signature).
    - **All ten lenses represented**: lenses with negligible measured impact appear at the bottom with their measured magnitude and a note that the data shows near-zero impact.
+   - **Routing recommendations**: a separate labeled section, rendered on EVERY run, AFTER the ranked opportunities list. It is **not** an eleventh lens and is **not** ranked by `price_proxy_usd` (it is a yield lens, not a cost-magnitude one) — do not merge it into the numbered ranked list and do not reorder it by the Step 5 ranking rule. Build it at report-generation time from the `by_phase_outcome` rates slice plus the static phase→model map, exactly as specified in "Rendering routing recommendations in the report" below. Entries tagged `untrusted` are rendered but explicitly excluded from the actionable set. This section does not depend on `DISPATCH_AUDIT_AGGREGATES_ENABLED` — it is produced whether or not the optional Firestore persist path is on.
 
 7. **Report-only.** The skill writes no control artifacts, creates NO GitHub issues, and modifies NO dispatch workflow files. The user reads the report and decides what to file. This keeps the skill from racing or duplicating the optimization issues it surfaces (e.g. #1171, #1172).
 
@@ -164,13 +165,20 @@ jq '.by_phase_outcome.qa.disposition_distribution' tmp/usage-audit.json
 
 # Top 10 worker sessions by per-run hit_rate
 jq '[.sessions[] | select(.outcome_rates.hit_rate != null)] | sort_by(-.outcome_rates.hit_rate) | .[0:10] | map({id, hit_rate: .outcome_rates.hit_rate})' tmp/usage-audit.json
+
+# Routing-recommendation input: the three pooled rates per phase, one row per phase key.
+# This is the ONLY data-side input the report's "Routing recommendations" section needs;
+# the phase->model side is the static map stated inline below (not in the JSON).
+jq '.by_phase_outcome | to_entries | map({phase:.key, hit_rate:.value.hit_rate, actionability:.value.actionability, fix_rate:.value.fix_rate, sessions:.value.sessions, findings_surfaced:.value.findings_surfaced, findings_actionable:.value.findings_actionable, fixes_applied:.value.fixes_applied})' tmp/usage-audit.json
 ```
 
-These slices are yield metrics, not cost metrics — they do not sort into the ranked token-reduction report. Read them alongside the report to correlate phase spend with phase effectiveness.
+These slices are yield metrics, not cost metrics — they do not sort into the ranked token-reduction report. Read them alongside the report to correlate phase spend with phase effectiveness. The last slice above is also the input to the report's **Routing recommendations** section (Step 6) — see "Rendering routing recommendations in the report" below.
 
-### `routing_recommendations` (advisory, persisted-doc only)
+### `routing_recommendations` (advisory, persisted aggregate doc)
 
-When the optional Firestore persist path is enabled (`DISPATCH_AUDIT_AGGREGATES_ENABLED=1` — see Step 2), `audit-aggregate-writer.mjs` derives a `routing_recommendations` array from `by_phase_outcome` and adds it to the persisted doc. It is NOT part of `tmp/usage-audit.json` and NOT part of the markdown report; it exists only on the persisted aggregate.
+When the optional Firestore persist path is enabled (`DISPATCH_AUDIT_AGGREGATES_ENABLED=1` — see Step 2), `audit-aggregate-writer.mjs` derives a `routing_recommendations` array from `by_phase_outcome` and adds it to the persisted doc. It is NOT part of `tmp/usage-audit.json`; it exists on the persisted aggregate only.
+
+**Two mechanisms, one computation.** The same recommendations are ALSO rendered as the report's "Routing recommendations" section on every run (Step 6). The two are deliberate duplicates of one computation, differing only in where and when they run: this one is JS-computed by `audit-aggregate-writer.mjs` on the persisted doc, and only when the optional persist gate is on; the report section is LLM-computed at report time from the same `by_phase_outcome` slice and the same static map, on every run including the (usual) runs with the persist path off. Both apply the identical grounding rule below, so they must agree for any window where both are produced. Neither applies anything — both are advisory.
 
 One entry per phase key present in `by_phase_outcome`:
 
@@ -189,12 +197,71 @@ One entry per phase key present in `by_phase_outcome`:
 
 The field is a recommendation surface only. The writer never writes `dispatch-phase-model`, `dispatch-phase-effort`, or any other routing-policy file — no routing change is ever applied automatically (strategy-token-economy clarification 10 / condition 3).
 
+### Rendering routing recommendations in the report
+
+Step 6 emits a **Routing recommendations** section on every run. There is no rendering
+script — compute it in-session, the same way the ten lenses are interpreted. Inputs:
+
+1. The `by_phase_outcome` rates slice (last jq slice in the block above): one row per
+   phase key with `hit_rate`, `actionability`, `fix_rate`.
+2. The **static phase→model map**, stated inline here because `dispatch-phase-model` is
+   a bash `case` statement and cannot be queried with `jq`:
+
+   | phase | current model |
+   | --- | --- |
+   | `qa` | `sonnet` |
+   | `review` | `sonnet` |
+   | `fix-checks` | `sonnet` |
+   | `fix-conflicts` | `sonnet` |
+   | `main-qa` | `sonnet` |
+   | anything else | unmapped — inherits the session default (render as `default`) |
+
+   **Keep this table in sync by hand with
+   `.claude/skills/dispatch-propagate/scripts/dispatch-phase-model`, which is the single
+   source of truth.** (`audit-aggregate-writer.mjs`'s `PHASE_MODEL_MAP` is a third mirror
+   of the same map; all three must agree.) If a run's data shows a phase key absent from
+   this table, treat it as unmapped rather than guessing.
+
+Per phase key present in `by_phase_outcome`, emit one entry:
+
+- **Yield metric selection.** Use the phase's primary metric — `review` → `hit_rate`,
+  `qa` → `actionability`. If that metric is `null` for the window (denominator 0), or the
+  phase is not one of those two, fall back to the first non-null of `hit_rate`,
+  `actionability`, `fix_rate`. If all three are `null`, the metric value is `null`.
+- **Untrusted rule (verbatim, same as the writer's).** An entry is `untrusted` when its
+  selected metric value is `null`, OR when the phase+metric pair has known-unverified
+  accounting. The current unverified list is exactly: **`qa` + `hit_rate`** and
+  **`qa` + `fix_rate`** — both put `fixes_applied` in the numerator and qa's
+  `fixes_applied` accounting gap is presently open (qa-fix delegates its fixes to
+  `/implement-unit`; see `.claude/docs/outcome-envelope.md`). `qa` + `actionability` and
+  `review` + `hit_rate` are NOT subject to that gap. No other pair is unverified today.
+- **Recommendation.** Recommend a model change only when the entry is trusted AND its
+  metric value is `>= 0.5` AND the phase is unmapped in the table above — in that case
+  recommend `sonnet`, with quality-preservation evidence of the form
+  "verified `<metric>` `<value>` >= 0.5; phase orchestrator delegates generative work to
+  `agent()`/subagents". Otherwise render "no change recommended".
+
+Render as a table or list, each entry carrying: **phase**, **current model → recommended
+model** (or "no change recommended"), **yield metric name + value** with whether it is
+verified, and **quality-preservation evidence** (or, when untrusted, the reason the
+accounting is unverified in place of evidence).
+
+Then, immediately under the section, state which entries are excluded: list every
+`untrusted` entry by phase and say explicitly that they are **excluded from the actionable
+set** and must not be acted on. Never rank or present an untrusted entry alongside the
+verified ones as if it were actionable.
+
+The section is advisory output only. Applying a recommendation is a hand edit by the
+author (next subsection); this skill's report step writes no file other than the report.
+
 ### Acting on routing recommendations
 
 `routing_recommendations` is advisory input to a human decision, never an auto-apply
 queue. The loop:
 
-1. The audit surfaces `routing_recommendations` on the persisted aggregate doc (above).
+1. The audit surfaces the recommendations — in the report's "Routing recommendations"
+   section on every run, and additionally as `routing_recommendations` on the persisted
+   aggregate doc when the optional persist path is enabled (both above).
 2. The author reviews them at office-hours, excluding any entry tagged `untrusted: true`
    per the grounding rule above.
 3. An approved change is applied **by hand**: the author edits the static map directly —

--- a/.claude/skills/dispatch-token-audit/SKILL.md
+++ b/.claude/skills/dispatch-token-audit/SKILL.md
@@ -168,6 +168,27 @@ jq '[.sessions[] | select(.outcome_rates.hit_rate != null)] | sort_by(-.outcome_
 
 These slices are yield metrics, not cost metrics — they do not sort into the ranked token-reduction report. Read them alongside the report to correlate phase spend with phase effectiveness.
 
+### `routing_recommendations` (advisory, persisted-doc only)
+
+When the optional Firestore persist path is enabled (`DISPATCH_AUDIT_AGGREGATES_ENABLED=1` — see Step 2), `audit-aggregate-writer.mjs` derives a `routing_recommendations` array from `by_phase_outcome` and adds it to the persisted doc. It is NOT part of `tmp/usage-audit.json` and NOT part of the markdown report; it exists only on the persisted aggregate.
+
+One entry per phase key present in `by_phase_outcome`:
+
+```
+{
+  phase: "qa" | "review" | ...,
+  current_model: <the phase's model per the static dispatch-phase-model map, or null if unmapped>,
+  recommended_model: <proposed model change, or null when no change is recommended>,
+  yield_metric: { name: "hit_rate" | "actionability" | "fix_rate", value: <number|null>, verified: <boolean> },
+  quality_preservation_evidence: <short string, or null>,
+  untrusted: <boolean>
+}
+```
+
+**Grounding rule.** A recommendation is `untrusted: true` whenever the metric it rests on has unverified accounting (or no rate was available for the window). The writer encodes this as a named list of phase+metric pairs with known accounting gaps: `qa` + `hit_rate` and `qa` + `fix_rate` both put `fixes_applied` in the numerator, and qa's `fixes_applied` accounting gap is presently open (qa-fix delegates its fixes to `/implement-unit` — see `.claude/docs/outcome-envelope.md`). `review` + `hit_rate` is not subject to that gap. **Entries tagged `untrusted: true` must be excluded from any actionable or acted-upon set.**
+
+The field is a recommendation surface only. The writer never writes `dispatch-phase-model`, `dispatch-phase-effort`, or any other routing-policy file — no routing change is ever applied automatically (strategy-token-economy clarification 10 / condition 3).
+
 ## Per-session artifact join
 
 The `artifact` field on each `.sessions[]` entry carries the per-session GitHub join record. Its `{repo, issue, pr, base_sha, branch}` shape, the session-id join key, and the sidecar's role as the authoritative source for the overlapping join keys are described in Step 3 above. `base_sha` is the worktree HEAD at session start — preserved across resume — so it anchors each session to the repository state it began from. The field is `null` for sessions with no sidecar — subagent transcripts, router ticks, pre-#1861 worker sessions, and any non-worker session that did not write one.

--- a/.claude/skills/dispatch-token-audit/SKILL.md
+++ b/.claude/skills/dispatch-token-audit/SKILL.md
@@ -189,6 +189,28 @@ One entry per phase key present in `by_phase_outcome`:
 
 The field is a recommendation surface only. The writer never writes `dispatch-phase-model`, `dispatch-phase-effort`, or any other routing-policy file — no routing change is ever applied automatically (strategy-token-economy clarification 10 / condition 3).
 
+### Acting on routing recommendations
+
+`routing_recommendations` is advisory input to a human decision, never an auto-apply
+queue. The loop:
+
+1. The audit surfaces `routing_recommendations` on the persisted aggregate doc (above).
+2. The author reviews them at office-hours, excluding any entry tagged `untrusted: true`
+   per the grounding rule above.
+3. An approved change is applied **by hand**: the author edits the static map directly —
+   `.claude/skills/dispatch-propagate/scripts/dispatch-phase-model` for a model change,
+   or `.claude/skills/dispatch-propagate/scripts/dispatch-phase-effort` for an effort
+   change — and commits it.
+4. That commit is the auditable record of the approved change. There is no separate
+   approval log; the diff and its commit message are the record.
+
+No automated path ever writes either map. This is the same invariant #2872 established
+when it retired the learned/adaptive phase-model-policy (see the design-invariant
+comment at the top of `dispatch-phase-model`), and it is required by
+strategy-token-economy clarification 10 / condition 3: no audit-driven routing change
+may ever be applied automatically. A future change must not reintroduce an auto-write
+path for either map — any such mechanism would violate that condition.
+
 ## Per-session artifact join
 
 The `artifact` field on each `.sessions[]` entry carries the per-session GitHub join record. Its `{repo, issue, pr, base_sha, branch}` shape, the session-id join key, and the sidecar's role as the authoritative source for the overlapping join keys are described in Step 3 above. `base_sha` is the worktree HEAD at session start — preserved across resume — so it anchors each session to the repository state it began from. The field is `null` for sessions with no sidecar — subagent transcripts, router ticks, pre-#1861 worker sessions, and any non-worker session that did not write one.

--- a/.claude/skills/dispatch-token-audit/scripts/audit-aggregate-writer.mjs
+++ b/.claude/skills/dispatch-token-audit/scripts/audit-aggregate-writer.mjs
@@ -310,6 +310,10 @@ function loadPayload(raw) {
     byPhase: projectBucketMap(obj.by_phase, "by_phase"),
     byModel: projectBucketMap(obj.by_model, "by_model"),
     priceModel,
+    // OPTIONAL — absent on windows predating the outcome envelope. Carried raw
+    // for the advisory routing-recommendation projection; never validated as
+    // required (its absence is a normal case, not an error).
+    byPhaseOutcome: obj.by_phase_outcome,
   };
 }
 
@@ -319,6 +323,138 @@ function requireString(obj, path, field) {
     fail(`payload field ${path}.${field} must be a non-empty string`);
   }
   return v;
+}
+
+// ---------------------------------------------------------------------------
+// ROUTING RECOMMENDATIONS (advisory only)
+//
+// The persisted doc carries a `routing_recommendations` array: a structured,
+// per-phase "current model → recommended model, justified by metric X" record
+// derived from the payload's by_phase_outcome yield rates.
+//
+// REPORT-ONLY, NEVER AUTO-APPLIED. This writer computes a RECOMMENDATION and
+// persists it for a human to read; it never writes dispatch-phase-model,
+// dispatch-phase-effort, or any other routing-policy file. Acting on a
+// recommendation is a hand-edit of the static map by the author
+// (strategy-token-economy clarification 10 / condition 3).
+// ---------------------------------------------------------------------------
+
+// Static mirror of the phase→model map in
+// .claude/skills/dispatch-propagate/scripts/dispatch-phase-model. MUST BE KEPT
+// IN SYNC with that file by hand: it is a bash script, and this pure-projection
+// writer cannot cheaply shell out to it. `null` (unmapped) means the phase
+// inherits the session default model.
+const PHASE_MODEL_MAP = {
+  qa: "sonnet",
+  review: "sonnet",
+  "fix-checks": "sonnet",
+  "fix-conflicts": "sonnet",
+  "main-qa": "sonnet",
+};
+
+// The metric each phase is READ ON, per .claude/docs/outcome-envelope.md
+// ("Which rate reflects which phase"). Phases not listed fall through to the
+// generic preference order below.
+const PHASE_PRIMARY_METRIC = {
+  review: "hit_rate",
+  qa: "actionability",
+};
+
+// Fallback preference order when a phase's primary metric is null (its
+// denominator was 0 for the window) or the phase is unlisted.
+const METRIC_PREFERENCE = ["hit_rate", "actionability", "fix_rate"];
+
+// Phase+metric pairs whose ACCOUNTING is known to be unverified. A
+// recommendation grounded on one of these is tagged `untrusted: true` and MUST
+// be excluded from any actionable/acted-upon set.
+//
+// qa + hit_rate/fix_rate: both put `fixes_applied` in the numerator, and qa's
+// `fixes_applied` accounting gap is presently OPEN — qa-fix delegates its fixes
+// to /implement-unit, so pooled fixes_applied is structurally near 0 regardless
+// of how well the phase performed (.claude/docs/outcome-envelope.md, "Which
+// rate reflects which phase"). Named pairs, not a blanket rule, so the list is
+// auditable and extendable as accounting gaps open and close.
+const UNVERIFIED_ACCOUNTING = [
+  {
+    phase: "qa",
+    metrics: ["hit_rate", "fix_rate"],
+    reason:
+      "qa fixes_applied accounting gap is open (fixes delegated to /implement-unit); see .claude/docs/outcome-envelope.md",
+  },
+];
+
+// A yield metric at or above this value is read as "the phase is producing its
+// designed output" — the evidence a cheaper orchestrator would not compromise
+// quality. Below it, no model change is recommended.
+const QUALITY_PRESERVING_YIELD = 0.5;
+
+function isAccountingUnverified(phase, metricName) {
+  return UNVERIFIED_ACCOUNTING.some(
+    (e) => e.phase === phase && e.metrics.includes(metricName),
+  );
+}
+
+// Pick the metric name + value a phase's recommendation rests on. Returns
+// `{name, value}`; value is null when no rate is available.
+function selectYieldMetric(phase, rates) {
+  const primary = PHASE_PRIMARY_METRIC[phase];
+  const order = primary
+    ? [primary, ...METRIC_PREFERENCE.filter((m) => m !== primary)]
+    : METRIC_PREFERENCE;
+  for (const name of order) {
+    if (isFiniteNumber(rates?.[name])) {
+      return { name, value: rates[name] };
+    }
+  }
+  return { name: primary ?? METRIC_PREFERENCE[0], value: null };
+}
+
+// Build the advisory routing_recommendations array. TOLERANT by design:
+// `by_phase_outcome` is OPTIONAL (windows predating the outcome envelope lack
+// it), so a missing or malformed value yields an empty list rather than a new
+// failure path — this must never widen the fail-closed validation contract.
+export function computeRoutingRecommendations(byPhaseOutcome) {
+  if (
+    byPhaseOutcome === null ||
+    typeof byPhaseOutcome !== "object" ||
+    Array.isArray(byPhaseOutcome)
+  ) {
+    return [];
+  }
+
+  const out = [];
+  for (const [phase, entry] of Object.entries(byPhaseOutcome)) {
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+      continue;
+    }
+    const currentModel = Object.prototype.hasOwnProperty.call(PHASE_MODEL_MAP, phase)
+      ? PHASE_MODEL_MAP[phase]
+      : null;
+    const metric = selectYieldMetric(phase, entry);
+    const verified = metric.value !== null && !isAccountingUnverified(phase, metric.name);
+
+    let recommendedModel = null;
+    let evidence = null;
+    if (verified && metric.value >= QUALITY_PRESERVING_YIELD && currentModel === null) {
+      // Unmapped phase inherits the session default (possibly Opus) while its
+      // verified yield shows the phase delivering its designed output — so a
+      // cheaper orchestrator is proposed for the author to weigh.
+      recommendedModel = "sonnet";
+      evidence = `verified ${metric.name} ${metric.value} >= ${QUALITY_PRESERVING_YIELD}; phase orchestrator delegates generative work to agent()/subagents`;
+    }
+
+    out.push({
+      phase,
+      current_model: currentModel,
+      recommended_model: recommendedModel,
+      yield_metric: { name: metric.name, value: metric.value, verified },
+      quality_preservation_evidence: evidence,
+      // Excluded from any actionable set: the justifying accounting is not
+      // verified (or no rate was available for the window).
+      untrusted: !verified,
+    });
+  }
+  return out;
 }
 
 // Compute the deterministic, idempotent doc id. A pure function of the payload
@@ -338,6 +474,8 @@ export function assembleDoc(payload, config, mkTimestamp) {
     byPhase: payload.byPhase,
     byModel: payload.byModel,
     priceModel: payload.priceModel,
+    // Advisory only — surfaced for author review, never auto-applied.
+    routing_recommendations: computeRoutingRecommendations(payload.byPhaseOutcome),
     windowDays: payload.windowDays,
     computedAt: mkTimestamp(config.nowEpochSeconds),
     groupId: config.groupId,

--- a/.claude/skills/dispatch-token-audit/scripts/test-audit-aggregate-writer.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-audit-aggregate-writer.sh
@@ -122,6 +122,35 @@ OUT3=$(printf '%s' "$PAYLOAD" | DISPATCH_AUDIT_AGGREGATES_NOW=1790000000 node "$
 ID3=$(jq -r '.id' <<<"$OUT3")
 assert_eq "doc id unchanged when NOW changes" "$ID" "$ID3"
 
+# --- Case 8b: routing_recommendations (advisory projection) -----------------
+# The fixture PAYLOAD has NO by_phase_outcome (windows predating the outcome
+# envelope lack it), so the field must be present and EMPTY — never a failure.
+assert_eq "doc has routing_recommendations" "true" \
+  "$(jq -c '.doc | has("routing_recommendations")' <<<"$OUT")"
+assert_eq "routing_recommendations empty without by_phase_outcome" "[]" \
+  "$(jq -c '.doc.routing_recommendations' <<<"$OUT")"
+
+# With a qa entry grounded on hit_rate (fixes_applied in the numerator — the
+# open qa accounting gap), the recommendation MUST be tagged untrusted.
+WITH_QA_OUTCOME=$(jq -c '.by_phase_outcome = {"qa": {"sessions": 4, "findings_surfaced": 10, "fixes_applied": 1, "hit_rate": 0.1}}' <<<"$PAYLOAD")
+QA_OUT=$(printf '%s' "$WITH_QA_OUTCOME" | node "$WRITER_MJS" --dry-run 2>/dev/null)
+assert_eq "qa recommendation entry present" "qa" \
+  "$(jq -r '.doc.routing_recommendations[0].phase' <<<"$QA_OUT")"
+assert_eq "qa hit_rate recommendation is untrusted" "true" \
+  "$(jq -c '.doc.routing_recommendations[0].untrusted' <<<"$QA_OUT")"
+assert_eq "qa yield_metric unverified" '{"name":"hit_rate","value":0.1,"verified":false}' \
+  "$(jq -c '.doc.routing_recommendations[0].yield_metric' <<<"$QA_OUT")"
+assert_eq "qa current_model from static map" "sonnet" \
+  "$(jq -r '.doc.routing_recommendations[0].current_model' <<<"$QA_OUT")"
+assert_eq "untrusted entry recommends no model change" "null" \
+  "$(jq -c '.doc.routing_recommendations[0].recommended_model' <<<"$QA_OUT")"
+
+# A review entry on hit_rate has no known accounting gap → verified/trusted.
+WITH_REVIEW_OUTCOME=$(jq -c '.by_phase_outcome = {"review": {"sessions": 3, "findings_surfaced": 10, "fixes_applied": 8, "hit_rate": 0.8}}' <<<"$PAYLOAD")
+REVIEW_OUT=$(printf '%s' "$WITH_REVIEW_OUTCOME" | node "$WRITER_MJS" --dry-run 2>/dev/null)
+assert_eq "review hit_rate recommendation is trusted" "false" \
+  "$(jq -c '.doc.routing_recommendations[0].untrusted' <<<"$REVIEW_OUT")"
+
 # --- Case 9: fail-closed validation branches --------------------------------
 # Each branch must exit non-zero and print exactly the matching one-line stderr
 # diagnostic prefixed "audit-aggregate-writer:". assert_fail captures both the


### PR DESCRIPTION
Makes the audit-written routing policy loop advisory: `/dispatch-token-audit` now surfaces structured, verified-yield routing recommendations for explicit author approval instead of leaving routing changes as unstructured prose.

Per `strategy-token-economy` clarification 10 / condition 3, no audit-driven routing change may ever be applied automatically. The actuator-side auto-write mechanism was already retired in #2872 (`dispatch-phase-model` is a static map). What was missing was a crisp recommendation surface with mechanically-enforced grounding on verified yield metrics — this PR adds that.

## Changes

- `audit-aggregate-writer.mjs`: adds an advisory `routing_recommendations` array to the persisted Firestore aggregate doc (when the optional persist path is enabled), computed from `by_phase_outcome` and a static phase→model map mirroring `dispatch-phase-model`. Entries resting on unverified accounting (currently `qa` + `hit_rate`/`fix_rate`, per the open `fixes_applied` gap) are tagged `untrusted` and excluded from any actionable set. Never writes any routing-policy file.
- `SKILL.md`: documents the persisted-doc field, adds the same "Routing recommendations" section to the interactive report itself (rendered on every run, independent of the Firestore persist gate), and adds an "Acting on routing recommendations" section spelling out the manual approval-and-apply convention — an approved change is a hand edit to `dispatch-phase-model`/`dispatch-phase-effort`, recorded by its own commit.
- `test-audit-aggregate-writer.sh`: new test cases covering the `routing_recommendations` field, including the untrusted-tagging behavior.

Tactic node: `tactic-audit-routing-advisory-gate`.
