### PR TITLE
graph: outcome envelope node-lane parity (tactic-outcome-envelope-node-lane-parity)

### DIFF
--- a/.claude/docs/outcome-envelope.md
+++ b/.claude/docs/outcome-envelope.md
@@ -43,7 +43,8 @@ envelope.
 | `schema` | string | no | const `"dispatch.outcome.v1"` |
 | `phase` | string | no | enum `{review, qa}`, extensible to future phases |
 | `repo` | string | no | e.g. `natb1/commons.systems` |
-| `issue` | integer | no | the dispatch issue number |
+| `issue` | integer | yes | the dispatch issue number on the issue lane, or `null` on the node lane |
+| `node_id` | string | yes | the intention-graph node id on the node lane, or `null` on the issue lane |
 | `pr` | integer | yes | the PR number, or `null` when no PR exists yet |
 | `base_sha` | string | yes | the merge base the phase ran against, or `null` |
 | `findings_surfaced` | integer ≥ 0 | no | total deduped findings the phase surfaced |
@@ -53,6 +54,10 @@ envelope.
 | `subagents_launched` | integer ≥ 0 | no | total subagents spawned (see semantics below) |
 | `disposition` | string | no | enum `{completed, completed_with_fixes, escalated}` |
 | `terminated_reason` | string | yes | escalation reason on `escalated`, else `null` |
+
+Exactly one of `issue` / `node_id` is non-null: the issue lane sets `issue`
+(`node_id` null), the node lane sets `node_id` (`issue` null) — mirroring the
+session sidecar's dual `issue`/`node_id` shape (`dispatch-stamp-session`).
 
 ## `disposition` enum
 
@@ -205,6 +210,7 @@ follow-ups, and spawned 11 subagents — a `completed_with_fixes` outcome:
   "phase": "review",
   "repo": "natb1/commons.systems",
   "issue": 1860,
+  "node_id": null,
   "pr": 1871,
   "base_sha": "0a454453c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6",
   "findings_surfaced": 8,
@@ -221,3 +227,6 @@ follow-ups, and spawned 11 subagents — a `completed_with_fixes` outcome:
 For these counts the reader computes `hit_rate = 3/8 = 0.375`,
 `actionability = 5/8 = 0.625`, and `fix_rate = 3/5 = 0.6` (and
 `0.625 × 0.6 = 0.375`, matching `hit_rate`).
+
+On the graph-native node lane the same envelope instead carries `"issue":
+null, "node_id": "tactic-example-node"` — every other field is unchanged.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome
@@ -4,7 +4,7 @@
 # Usage: dispatch-emit-outcome \
 #          --phase <phase> \
 #          --repo <owner/repo> \
-#          --issue <issue-num> \
+#          (--issue <issue-num> | --node-id <node-id>) \
 #          [--pr <pr-num>] \
 #          [--base-sha <sha>] \
 #          --findings-surfaced <n> \
@@ -21,6 +21,13 @@
 #
 # The envelope contract is defined in .claude/docs/outcome-envelope.md.
 # That doc is the single source of truth for fields, enums, and formulas.
+#
+# --issue / --node-id: exactly one of these two must be given. --issue is the
+#   legacy gh-issue lane (a positive integer). --node-id is the graph-native
+#   lane's target: a non-numeric intention-node id (e.g. tactic-foo), mirroring
+#   the session sidecar's dual issue/node_id nullable shape
+#   (dispatch-stamp-session:15-19). Both or neither given is a validation
+#   error (exit 2).
 #
 # --phase: one of the ALLOWED_PHASES set (review, qa). Extensible: update
 #   ALLOWED_PHASES below to add future phases.
@@ -57,6 +64,7 @@ ALLOWED_DISPOSITIONS=("completed" "completed_with_fixes" "escalated")
 PHASE=""
 REPO=""
 ISSUE=""
+NODE_ID=""
 PR=""
 BASE_SHA=""
 FINDINGS_SURFACED=""
@@ -73,7 +81,7 @@ usage() {
 usage: dispatch-emit-outcome \
          --phase <phase> \
          --repo <owner/repo> \
-         --issue <issue-num> \
+         (--issue <issue-num> | --node-id <node-id>) \
          [--pr <pr-num>] \
          [--base-sha <sha>] \
          --findings-surfaced <n> \
@@ -85,6 +93,9 @@ usage: dispatch-emit-outcome \
          [--terminated-reason <reason>]
 
   --phase        one of: review qa
+  --issue        legacy gh-issue lane target (positive integer)
+  --node-id      graph-native lane target (lowercase node-id slug);
+                 exactly one of --issue / --node-id is required
   --disposition  one of: completed completed_with_fixes escalated
   --terminated-reason  required when disposition=escalated, forbidden otherwise
 EOF
@@ -105,6 +116,9 @@ while [[ $# -gt 0 ]]; do
     --issue)
       [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --issue requires a value" >&2; exit 2; }
       ISSUE="$2"; shift 2 ;;
+    --node-id)
+      [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --node-id requires a value" >&2; exit 2; }
+      NODE_ID="$2"; shift 2 ;;
     --pr)
       [[ $# -ge 2 ]] || { echo "dispatch-emit-outcome: --pr requires a value" >&2; exit 2; }
       PR="$2"; shift 2 ;;
@@ -153,7 +167,18 @@ _require() {
 
 _require phase          "$PHASE"
 _require repo           "$REPO"
-_require issue          "$ISSUE"
+
+# --issue / --node-id: exactly one of these two must be given. Neither given,
+# or both given, is a clear validation error rather than a silent fallback.
+if [[ -z "$ISSUE" && -z "$NODE_ID" ]]; then
+  echo "dispatch-emit-outcome: exactly one of --issue / --node-id is required (neither given)" >&2
+  exit 2
+fi
+if [[ -n "$ISSUE" && -n "$NODE_ID" ]]; then
+  echo "dispatch-emit-outcome: exactly one of --issue / --node-id is required (both given)" >&2
+  exit 2
+fi
+
 _require findings-surfaced   "$FINDINGS_SURFACED"
 _require findings-actionable "$FINDINGS_ACTIONABLE"
 _require fixes-applied       "$FIXES_APPLIED"
@@ -202,7 +227,20 @@ _require_pos_int() {
   fi
 }
 
-_require_pos_int issue               "$ISSUE"
+_require_node_id() {
+  local flag="$1" val="$2"
+  if [[ ! "$val" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]] || [[ "$val" =~ ^[0-9] ]]; then
+    echo "dispatch-emit-outcome: invalid --${flag} '${val}' (expected a lowercase node-id slug; numeric-prefixed names are the legacy gh lane)" >&2
+    exit 2
+  fi
+}
+
+if [[ -n "$ISSUE" ]]; then
+  _require_pos_int issue "$ISSUE"
+fi
+if [[ -n "$NODE_ID" ]]; then
+  _require_node_id node-id "$NODE_ID"
+fi
 _require_nonneg_int findings-surfaced   "$FINDINGS_SURFACED"
 _require_nonneg_int findings-actionable "$FINDINGS_ACTIONABLE"
 _require_nonneg_int fixes-applied       "$FIXES_APPLIED"
@@ -235,6 +273,18 @@ fi
 # Absent nullable fields bind to JSON null via --argjson.
 # ---------------------------------------------------------------------------
 
+if [[ -n "$ISSUE" ]]; then
+  issue_arg=(--argjson issue "$ISSUE")
+else
+  issue_arg=(--argjson issue "null")
+fi
+
+if [[ -n "$NODE_ID" ]]; then
+  node_id_arg=(--arg node_id "$NODE_ID")
+else
+  node_id_arg=(--argjson node_id "null")
+fi
+
 if [[ -n "$PR" ]]; then
   pr_arg=(--argjson pr "$PR")
 else
@@ -264,7 +314,8 @@ jq -n \
   --arg     schema              "dispatch.outcome.v1" \
   --arg     phase               "$PHASE" \
   --arg     repo                "$REPO" \
-  --argjson issue               "$ISSUE" \
+  "${issue_arg[@]}" \
+  "${node_id_arg[@]}" \
   "${pr_arg[@]}" \
   "${base_sha_arg[@]}" \
   --argjson findings_surfaced   "$FINDINGS_SURFACED" \
@@ -279,6 +330,7 @@ jq -n \
     phase:                $phase,
     repo:                 $repo,
     issue:                $issue,
+    node_id:              $node_id,
     pr:                   $pr,
     base_sha:             $base_sha,
     findings_surfaced:    $findings_surfaced,

--- a/.claude/skills/dispatch-propagate/scripts/test-emit-outcome.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-emit-outcome.sh
@@ -168,4 +168,60 @@ _in_set_local "completed" "${_test_arr[@]}" \
   && assert_eq "partial word does not match multi-word element" "1" "0" \
   || assert_eq "partial word does not match multi-word element" "1" "1"
 
+# ============================================================================
+# Suite 4: --node-id node-lane parity (tactic-outcome-envelope-node-lane-parity)
+#
+# Verifies the --issue / --node-id exactly-one-of contract: --node-id is the
+# graph-native lane's alternative to --issue, mirroring the session sidecar's
+# dual issue/node_id nullable shape (dispatch-stamp-session:15-19).
+# ============================================================================
+
+echo ""
+echo "Testing dispatch-emit-outcome --node-id node-lane parity..."
+echo ""
+
+# COMMON_NO_ISSUE mirrors COMMON but omits --issue, so the node-id tests
+# below can supply --issue / --node-id themselves.
+COMMON_NO_ISSUE=(--phase review --repo natb1/commons.systems
+  --findings-surfaced 0 --findings-actionable 0 --fixes-applied 0
+  --followups-filed 0 --subagents-launched 0 --disposition completed)
+
+run_sut_no_issue() {
+  set +e
+  OUT=$("$SUT" "${COMMON_NO_ISSUE[@]}" "$@" 2>&1)
+  RC=$?
+  set -e
+}
+
+echo "--- (a) --node-id tactic-foo, no --issue ---"
+run_sut_no_issue --node-id tactic-foo
+assert_eq "node-id only: exit 0" "0" "$RC"
+ISSUE_VAL=$(printf '%s\n' "$OUT" | sed -n '/^```json$/,/^```$/p' | sed '1d;$d' | jq -r '.issue')
+NODE_ID_VAL=$(printf '%s\n' "$OUT" | sed -n '/^```json$/,/^```$/p' | sed '1d;$d' | jq -r '.node_id')
+assert_eq "node-id only: issue is null" "null" "$ISSUE_VAL"
+assert_eq "node-id only: node_id serialized" "tactic-foo" "$NODE_ID_VAL"
+
+echo "--- (b) --issue 42, no --node-id ---"
+run_sut_no_issue --issue 42
+assert_eq "issue only: exit 0" "0" "$RC"
+ISSUE_VAL=$(printf '%s\n' "$OUT" | sed -n '/^```json$/,/^```$/p' | sed '1d;$d' | jq -r '.issue')
+NODE_ID_VAL=$(printf '%s\n' "$OUT" | sed -n '/^```json$/,/^```$/p' | sed '1d;$d' | jq -r '.node_id')
+assert_eq "issue only: issue serialized" "42" "$ISSUE_VAL"
+assert_eq "issue only: node_id is null" "null" "$NODE_ID_VAL"
+
+echo "--- (c) neither --issue nor --node-id ---"
+run_sut_no_issue
+assert_eq "neither given: exit 2" "2" "$RC"
+assert_contains "neither given: message mentions exactly one" "exactly one of" "$OUT"
+
+echo "--- (d) both --issue and --node-id ---"
+run_sut_no_issue --issue 42 --node-id tactic-foo
+assert_eq "both given: exit 2" "2" "$RC"
+assert_contains "both given: message mentions exactly one" "exactly one of" "$OUT"
+
+echo "--- (e) numeric --node-id rejected (slug reject) ---"
+run_sut_no_issue --node-id 42
+assert_eq "numeric node-id: exit 2" "2" "$RC"
+assert_contains "numeric node-id: message mentions node-id slug" "node-id slug" "$OUT"
+
 report_results

--- a/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
@@ -408,10 +408,12 @@ def cmd_prefix(c):
 # NODE_ID PASSTHROUGH (tactic-outcome-envelope-node-lane-parity): $outcome is
 # bound to the WHOLE parsed envelope object above, not a hand-picked field
 # subset, so a node-lane envelope's `node_id` key rides through unstripped on
-# `.outcome.node_id` in the per-session summary and into `by_phase_outcome`
-# below. No reduce change is needed for this — the pooled phase metric keys
-# only on `.phase` — but the field is there for a future by-node-outcome join
-# analogous to `by_node` (see below).
+# `.sessions[].outcome.node_id` in the per-session summary — and only there.
+# It does NOT reach `by_phase_outcome` below: that reduce builds a fresh object
+# from an explicit key list and keys only on `.phase`. A future pooled
+# by-node-outcome join analogous to `by_node` (see below) would therefore need
+# a new reduce, and should key on the sidecar-derived `artifact.node_id` rather
+# than on this envelope field.
 
 # Ordered per-session token list of tool calls, in document order. Bash calls
 # become "Bash:<cmd_prefix>"; other tools become their name.

--- a/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh
@@ -405,6 +405,14 @@ def cmd_prefix(c):
       and ($parsed.fixes_applied       | type) == "number"
     then $parsed else null end ) as $outcome
 
+# NODE_ID PASSTHROUGH (tactic-outcome-envelope-node-lane-parity): $outcome is
+# bound to the WHOLE parsed envelope object above, not a hand-picked field
+# subset, so a node-lane envelope's `node_id` key rides through unstripped on
+# `.outcome.node_id` in the per-session summary and into `by_phase_outcome`
+# below. No reduce change is needed for this — the pooled phase metric keys
+# only on `.phase` — but the field is there for a future by-node-outcome join
+# analogous to `by_node` (see below).
+
 # Ordered per-session token list of tool calls, in document order. Bash calls
 # become "Bash:<cmd_prefix>"; other tools become their name.
 | ( [ $msgs[] | select(.type=="assistant")

--- a/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
+++ b/.claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh
@@ -823,6 +823,54 @@ assert_eq "partial-envelope by_phase_outcome is empty {} (no fabricated entry)" 
 rm -rf "$PARTIAL_ROOT"
 
 # ---------------------------------------------------------------------------
+# node_id passthrough (tactic-outcome-envelope-node-lane-parity). A node-lane
+# envelope carries "issue": null, "node_id": "<slug>" instead of an issue
+# number. $outcome binds the WHOLE parsed envelope object (no hand-picked
+# field subset), so node_id should ride through unstripped onto the
+# per-session outcome — this is a regression guard that the passthrough is
+# never lost, not a new reduce.
+#
+# Built in its own mktemp root (mirrors the partial-envelope fixture above).
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "--- node_id passthrough (tactic-outcome-envelope-node-lane-parity) ---"
+
+NODE_ENV_JSON='{"schema":"dispatch.outcome.v1","phase":"review","repo":"natb1/commons.systems","issue":null,"node_id":"tactic-example-node","pr":2100,"base_sha":"nnn222","findings_surfaced":4,"findings_actionable":3,"fixes_applied":2,"followups_filed":1,"subagents_launched":6,"disposition":"completed_with_fixes","terminated_reason":null}'
+NODE_BLOCK="$(envelope_block "$NODE_ENV_JSON")"
+
+NODE_ROOT=$(mktemp -d)
+trap 'rm -rf "$NODE_ROOT" "$FAKE_WRITER_DIR"; teardown' EXIT INT TERM
+node_worktree="$NODE_ROOT/-home-x-worktrees-tactic-example-node"
+mkdir -p "$node_worktree"
+node_jsonl="$node_worktree/sess-node.jsonl"
+
+# line 1: first user line — classifies as worker (mirror line 68)
+printf '%s\n' '{"type":"user","message":{"content":"<command-name>/implement</command-name>"}}' \
+  >> "$node_jsonl"
+# line 2: assistant — opus, minimal usage (mirror the worker assistant shape)
+printf '%s\n' '{"type":"assistant","attributionSkill":"implement","isSidechain":false,"gitBranch":"tactic-example-node","message":{"model":"claude-opus-4-8","content":[{"type":"tool_use","id":"toolu_n01","name":"Bash","input":{"command":"echo hi"}}],"usage":{"input_tokens":1,"cache_creation_input_tokens":2,"cache_read_input_tokens":4,"output_tokens":1}}}' \
+  >> "$node_jsonl"
+# line 3: node-lane outcome-envelope tool_result (mirror lines 799-801)
+jq -nc --arg c "$NODE_BLOCK" \
+  '{type:"user",message:{content:[{type:"tool_result",tool_use_id:"toolu_n01",content:$c}]}}' \
+  >> "$node_jsonl"
+jq . "$node_jsonl" >/dev/null
+touch "$node_jsonl"
+
+OUT_NODE=$(
+  export DISPATCH_AUDIT_PROJECTS_ROOT="$NODE_ROOT"
+  bash "$SCRIPT_DIR/aggregate-usage.sh" --days 7
+)
+
+assert_eq "node-envelope sessions[sess-node].outcome.node_id" '"tactic-example-node"' \
+  "$(jq '[.sessions[]|select(.id=="sess-node")][0].outcome.node_id' <<<"$OUT_NODE")"
+assert_eq "node-envelope sessions[sess-node].outcome.issue is null" "null" \
+  "$(jq '[.sessions[]|select(.id=="sess-node")][0].outcome.issue' <<<"$OUT_NODE")"
+
+rm -rf "$NODE_ROOT"
+
+# ---------------------------------------------------------------------------
 # Unpriceable-model cost guard (#2027). ISOLATED fixture: a fresh projects root
 # with ONE worker session whose assistant message carries a model in NO known
 # family (not opus/sonnet/haiku) and NONZERO usage. cost()'s family==null branch

--- a/.claude/skills/qa-fix/SKILL.md
+++ b/.claude/skills/qa-fix/SKILL.md
@@ -184,6 +184,9 @@ each fork site.
 
    - **Context / PR.** Skip the `--issue` slices; reuse the `PR_NUM` the
      Idempotency preamble resolved (via `gh pr list --head`), do not re-derive.
+   - **Outcome envelope.** Every `dispatch-emit-outcome` call site
+     (`references/terminal-disposition.md`, `references/auto-fix-lane.md`) passes
+     `--node-id "$N"` in place of `--issue "$N"` on this lane.
    - **Completion.** On a clean pass do **not** apply `dispatch:qa-done` or call
      `dispatch-mark-complete` / `dispatch-finalize-phase`. Instead invoke the
      graph-native transition writer, which records the `qa-done` marker and

--- a/.claude/skills/qa-fix/references/auto-fix-lane.md
+++ b/.claude/skills/qa-fix/references/auto-fix-lane.md
@@ -164,11 +164,19 @@ Otherwise (opus-fixable items present), choose exactly one path:
 
    qa-fix keeps **no** merge base (Step 1 runs only a name-only
    `git diff origin/main...HEAD`), so **omit** `--base-sha` (it serializes as
-   null). Derive `repo` from the local remote (read-only git, sandbox-safe):
+   null). Derive `repo` from the local remote (read-only git, sandbox-safe). On
+   the node lane (`TARGET_KIND=node`) pass `--node-id "$N"` and omit `--issue`;
+   on the legacy issue lane (`TARGET_KIND=issue`) keep `--issue "$N"` and omit
+   `--node-id`:
    ```bash
    REPO=$(git remote get-url origin | sed -E 's#.*github.com[:/]##; s#\.git$##')
+   if [[ "$TARGET_KIND" == node ]]; then
+     id_arg=(--node-id "$N")
+   else
+     id_arg=(--issue "$N")
+   fi
    .claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome \
-     --phase qa --repo "$REPO" --issue "$N" --pr "$PR_NUM" \
+     --phase qa --repo "$REPO" "${id_arg[@]}" --pr "$PR_NUM" \
      --findings-surfaced <result.findings_surfaced> \
      --findings-actionable <result.findings_actionable> \
      --fixes-applied <fixes_applied_count> \

--- a/.claude/skills/qa-fix/references/terminal-disposition.md
+++ b/.claude/skills/qa-fix/references/terminal-disposition.md
@@ -90,12 +90,21 @@ Source the counts by whether Step 3.5 ran this pass:
   fan-out is added).
 
 qa-fix keeps **no** merge base, so **omit** `--base-sha`. Derive `repo` from the
-local remote (read-only git, sandbox-safe):
+local remote (read-only git, sandbox-safe). On the node lane (`TARGET_KIND=node`)
+pass `--node-id "$N"` and omit `--issue`; on the legacy issue lane
+(`TARGET_KIND=issue`) keep `--issue "$N"` and omit `--node-id` — see the
+idempotency preamble's "never pass `--issue`" node-lane rule, which extends here
+to naming the `--node-id "$N"` substitution:
 
 ```bash
 REPO=$(git remote get-url origin | sed -E 's#.*github.com[:/]##; s#\.git$##')
+if [[ "$TARGET_KIND" == node ]]; then
+  id_arg=(--node-id "$N")
+else
+  id_arg=(--issue "$N")
+fi
 .claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome \
-  --phase qa --repo "$REPO" --issue "$N" --pr "$PR_NUM" \
+  --phase qa --repo "$REPO" "${id_arg[@]}" --pr "$PR_NUM" \
   --findings-surfaced <result.findings_surfaced, or 0 if Step 3.5 was skipped> \
   --findings-actionable <result.findings_actionable, or 0 if Step 3.5 was skipped> \
   --fixes-applied 0 \
@@ -206,12 +215,19 @@ differ in whether the Step-3.5 Workflow ran — source the counts accordingly:
   reported `0`.
 
 qa-fix keeps **no** merge base, so **omit** `--base-sha`. Derive `repo` from the
-local remote (read-only git, sandbox-safe):
+local remote (read-only git, sandbox-safe). On the node lane (`TARGET_KIND=node`)
+pass `--node-id "$N"` and omit `--issue`; on the legacy issue lane
+(`TARGET_KIND=issue`) keep `--issue "$N"` and omit `--node-id`:
 
 ```bash
 REPO=$(git remote get-url origin | sed -E 's#.*github.com[:/]##; s#\.git$##')
+if [[ "$TARGET_KIND" == node ]]; then
+  id_arg=(--node-id "$N")
+else
+  id_arg=(--issue "$N")
+fi
 .claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome \
-  --phase qa --repo "$REPO" --issue "$N" --pr "$PR_NUM" \
+  --phase qa --repo "$REPO" "${id_arg[@]}" --pr "$PR_NUM" \
   --findings-surfaced <result.findings_surfaced, or 0 if Step 3.5 did not run> \
   --findings-actionable <result.findings_actionable, or 0 if Step 3.5 did not run> \
   --fixes-applied 0 \

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -107,7 +107,10 @@ esac
 ```
 
 On the node lane, `$N` is the node id (keys `tmp/` filenames); never pass
-`--issue`. **On the node lane no gh issue is ever read or written.**
+`--issue`. **On the node lane no gh issue is ever read or written.** This
+extends to every `dispatch-emit-outcome` call site (Step 7 /
+`references/terminal-actions.md`): on the node lane pass `--node-id "$N"` in
+place of `--issue "$N"`.
 
 ```bash
 case "$TARGET_KIND" in

--- a/.claude/skills/review-fix/references/terminal-actions.md
+++ b/.claude/skills/review-fix/references/terminal-actions.md
@@ -141,12 +141,21 @@ order relative to `dispatch-mark-deviation` does not matter. The deviation path
 only runs when the Workflow ran this session, so `result` is in scope. Pass
 `--disposition escalated` and `--terminated-reason` set to the **same string**
 passed to `dispatch-mark-deviation` above. Derive `repo` from the local remote
-(read-only git, sandbox-safe — no network):
+(read-only git, sandbox-safe — no network). On the node lane
+(`TARGET_KIND=node`) pass `--node-id "$N"` and omit `--issue` — the idempotency
+preamble's "never pass `--issue`" node-lane rule extends here to naming this
+substitution; on the legacy issue lane (`TARGET_KIND=issue`) keep `--issue "$N"`
+and omit `--node-id`:
 
 ```bash
 REPO=$(git remote get-url origin | sed -E 's#.*github.com[:/]##; s#\.git$##')
+if [[ "$TARGET_KIND" == node ]]; then
+  id_arg=(--node-id "$N")
+else
+  id_arg=(--issue "$N")
+fi
 .claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome \
-  --phase review --repo "$REPO" --issue <N> --pr "$PR_NUM" --base-sha "$MERGE_BASE" \
+  --phase review --repo "$REPO" "${id_arg[@]}" --pr "$PR_NUM" --base-sha "$MERGE_BASE" \
   --findings-surfaced <result.findings_surfaced> \
   --findings-actionable <result.findings_actionable> \
   --fixes-applied <result.fixes_applied> \
@@ -179,12 +188,19 @@ inject a phantom run into the aggregate. This call runs **sandboxed** —
 Use `result.disposition` directly (the Workflow already computes `completed` vs
 `completed_with_fixes` from `fixed.length`); **omit** `--terminated-reason` (it
 must be absent on a non-escalated disposition). Derive `repo` from the local
-remote (read-only git, sandbox-safe):
+remote (read-only git, sandbox-safe). On the node lane (`TARGET_KIND=node`)
+pass `--node-id "$N"` and omit `--issue`; on the legacy issue lane
+(`TARGET_KIND=issue`) keep `--issue "$N"` and omit `--node-id`:
 
 ```bash
 REPO=$(git remote get-url origin | sed -E 's#.*github.com[:/]##; s#\.git$##')
+if [[ "$TARGET_KIND" == node ]]; then
+  id_arg=(--node-id "$N")
+else
+  id_arg=(--issue "$N")
+fi
 .claude/skills/dispatch-propagate/scripts/dispatch-emit-outcome \
-  --phase review --repo "$REPO" --issue <N> --pr "$PR_NUM" --base-sha "$MERGE_BASE" \
+  --phase review --repo "$REPO" "${id_arg[@]}" --pr "$PR_NUM" --base-sha "$MERGE_BASE" \
   --findings-surfaced <result.findings_surfaced> \
   --findings-actionable <result.findings_actionable> \
   --fixes-applied <result.fixes_applied> \


### PR DESCRIPTION
Implements the intention node `tactic-outcome-envelope-node-lane-parity`
(graph-native tactic; no GitHub issue). Gives the dispatch outcome envelope
(`dispatch-emit-outcome` / `dispatch:outcome:v1`) node-lane parity, mirroring
the session sidecar's dual `issue`/`node_id` shape — it previously
hard-required a positive-integer `--issue` and carried no `node_id` field.

## Unit 1 — `dispatch-emit-outcome`: accept `--node-id`, emit `node_id`
Added a `--node-id` flag as an alternative to `--issue` (exactly one required),
validated against the same node-id slug regex used by
`provision-node-worktree`. The envelope now serializes both `issue` and
`node_id` fields, exactly one non-null. Added a new test suite in
`test-emit-outcome.sh` covering node-id-only, issue-only, neither, both, and
numeric-node-id-reject.

## Unit 2 — `outcome-envelope.md`: document `node_id`
Updated the field table (`issue` now nullable, new `node_id` row), added the
exactly-one-of prose, and updated the worked example plus a node-lane variant
note.

## Unit 3 — `aggregate-usage.sh`: carry `node_id` through, test it
No reduce change was needed — the reader already binds the whole parsed
envelope object, so `node_id` rides through unstripped. Added a documenting
comment and a regression-guard fixture/test in `test-aggregate-usage.sh`
asserting the passthrough.

## Unit 4 — qa-fix + review-fix SKILLs: branch emit calls on the lane
Every `dispatch-emit-outcome` call site in `qa-fix/references/*.md` and
`review-fix/references/terminal-actions.md` now branches on `TARGET_KIND`:
`--node-id "$N"` on the node lane, `--issue "$N"` on the legacy issue lane.
Extended each SKILL's node-lane preamble to state the substitution rule.

## Verification
- `bash .claude/skills/dispatch-propagate/scripts/test-emit-outcome.sh` — 39/39 passing.
- `bash .claude/skills/dispatch-token-audit/scripts/test-aggregate-usage.sh` — 184/184 passing.
- `.claude/skills/dispatch-propagate/scripts/run-lint.sh` — all lint checks passed.
