### PR TITLE
tactic-unclaimed-hold-alerting: surface unclaimed manual-policy holds blocking top-ranked work

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-fleet-alarm
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-fleet-alarm
@@ -177,7 +177,7 @@ if ! source "$SCRIPT_DIR/lib.sh"; then
 fi
 
 # The closed enum of alarm kinds. Extending it is a deliberate edit here.
-KINDS=(tick-stale daemon-degraded busy-stall automerge-suppressed watch-unknown heal-fired heal-unknown)
+KINDS=(tick-stale daemon-degraded busy-stall automerge-suppressed unclaimed-hold watch-unknown heal-fired heal-unknown)
 
 usage() {
   cat <<'USAGE'
@@ -186,7 +186,7 @@ usage: dispatch-fleet-alarm --kind <kind> --statement <text> --body-file <path>
        dispatch-fleet-alarm -h|--help
 
 kinds: tick-stale daemon-degraded busy-stall automerge-suppressed
-       watch-unknown heal-fired heal-unknown
+       unclaimed-hold watch-unknown heal-fired heal-unknown
 
 Records an out-of-band fleet-health reading as the graph node
 tactic-fleet-alarm-<kind> (find-or-create; body refreshed on re-detection).

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-fleet-watch
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-fleet-watch
@@ -31,26 +31,35 @@
 #   5. unclaimed-hold        a tracked hold blocking top-ranked work that no
 #                            session and no reservation claims
 #
-# WHY ONE SNAPSHOT, CAPTURED AT THE INPUT BOUNDARY:
+# WHY TWO SNAPSHOTS, BOTH CAPTURED AT THE INPUT BOUNDARY:
 #   Predicate 3 reads the live session array through
 #   claude_agents_count_busy_workers, which already applies the worker keyspace
 #   filter (`^[0-9]+-|^tactic-|^strategy-`, lib-claude-agents.sh:1043), and
 #   predicate 5 reads it through worktree_has_live_session, one probe per
-#   candidate hold/source worktree. This script captures ONE machine-wide
-#   snapshot per pass via claude_agents_snapshot_capture and exports it as
-#   DISPATCH_AGENTS_SNAPSHOT.
+#   candidate hold/source worktree.
+#   THE TWO PREDICATES DO NOT READ THE SAME VIEW. Predicate 3 reads the ACTIVE
+#   view (`claude agents --json`, DISPATCH_AGENTS_SNAPSHOT, backing
+#   `_claude_agents_raw`); worktree_has_live_session reads the REGISTERED view
+#   (`claude agents --json --all`, DISPATCH_AGENTS_SNAPSHOT_ALL, backing
+#   `_claude_agents_raw_registered`) — the two are documented as INDEPENDENT at
+#   lib-claude-agents.sh:451-461. So this script captures BOTH machine-wide
+#   snapshots per pass, via claude_agents_snapshot_capture and
+#   claude_agents_snapshot_capture_registered, and exports both variables.
+#   Without the registered capture, predicate 5 would still issue up to two live
+#   `--all` round-trips PER CANDIDATE ROW.
 #   History: the session-keyspace exclusion used to be bolted onto individual
 #   predicates one at a time, and the bug recurred every single time a new
 #   predicate was added — the new test read the raw array, forgot the filter,
 #   and counted routers/human sessions as workers. The filter must be a PROPERTY
 #   OF THE INPUT, captured once at the boundary, not a rule each test restates.
-#   Predicate 5 inherited both the single daemon query and the filter for free,
-#   without knowing either exists — exactly as this note predicted a fifth
-#   predicate would.
+#   Predicate 5 inherited the filter for free, without knowing it exists —
+#   exactly as this note predicted a fifth predicate would.
 #   It does NOT inherit the fail direction, though, and that is the one thing a
 #   later predicate must reason about for itself: see "FAIL DIRECTION" on
-#   predicate 5 below. The snapshot's READABILITY is therefore recorded at the
-#   capture site (SNAPSHOT_OK) and consumed by predicate 5.
+#   predicate 5 below. Each snapshot's READABILITY is therefore recorded at its
+#   capture site (SNAPSHOT_OK for the active view, SNAPSHOT_ALL_OK for the
+#   registered one), and predicate 5 gates on SNAPSHOT_ALL_OK — the bit for the
+#   view its claim ladder actually reads.
 #
 # TWO DETAIL STRINGS PER PREDICATE, ON PURPOSE:
 #   D_<P>  the READING — carries the live numbers (elapsed spans, ages, counts,
@@ -276,16 +285,17 @@ state_set() { # <key> <epoch|null>
   return 0
 }
 
-# --- one snapshot at the input boundary --------------------------------------
-# See the header ("WHY ONE SNAPSHOT"). Capture failure is NOT fatal: the library
+# --- both snapshots at the input boundary ------------------------------------
+# See the header ("WHY TWO SNAPSHOTS"). Capture failure is NOT fatal: the library
 # falls back to a live per-call query, which carries its own UNKNOWN contract.
 # shellcheck source=/dev/null
 if ! source "$SCRIPT_DIR/lib-claude-agents.sh" 2>/dev/null; then
   log "cannot source lib-claude-agents.sh"
   exit 69
 fi
-# Predicate 5 additionally needs to know whether the snapshot READ succeeded —
-# see "FAIL DIRECTION" on that predicate. SNAPSHOT_OK is that one bit.
+# Predicate 5 additionally needs to know whether the REGISTERED-view read
+# succeeded — see "FAIL DIRECTION" on that predicate. SNAPSHOT_ALL_OK is that
+# bit; SNAPSHOT_OK is the ACTIVE-view sibling, which predicate 5 never reads.
 # shellcheck source=/dev/null
 if ! source "$SCRIPT_DIR/lib-graph-worktree.sh" 2>/dev/null; then
   log "cannot source lib-graph-worktree.sh"
@@ -301,6 +311,15 @@ SNAPSHOT_OK=0
 if claude_agents_snapshot_capture "$SNAPSHOT_PATH" 2>/dev/null; then
   export DISPATCH_AGENTS_SNAPSHOT="$SNAPSHOT_PATH"
   SNAPSHOT_OK=1
+fi
+# The REGISTERED view is a SEPARATE daemon query (`--all`) over a SEPARATE
+# variable. Predicate 5's claim ladder reads only this one, so its readability
+# is a separate bit — SNAPSHOT_OK says nothing about it.
+SNAPSHOT_ALL_PATH="$WORK_DIR/agents-snapshot-all.json"
+SNAPSHOT_ALL_OK=0
+if claude_agents_snapshot_capture_registered "$SNAPSHOT_ALL_PATH" 2>/dev/null; then
+  export DISPATCH_AGENTS_SNAPSHOT_ALL="$SNAPSHOT_ALL_PATH"
+  SNAPSHOT_ALL_OK=1
 fi
 
 # --- pause state, read ONCE --------------------------------------------------
@@ -582,9 +601,18 @@ fi
 #   backwards: an unreadable daemon would read as "someone is on it" and
 #   SUPPRESS the alarm — a false all-clear, the one failure this whole script
 #   exists to prevent. worktree_has_live_session cannot report unknown
-#   separately (occupied IS its unknown), so the readability of the pass's one
-#   daemon snapshot is captured at the input boundary instead and consumed here:
+#   separately (occupied IS its unknown), so the readability of the daemon view
+#   it reads is captured at the input boundary instead and consumed here:
 #   no snapshot, no verdict. `unknown` raises watch-unknown and resolves nothing.
+#   WHICH VIEW: the ladder below calls worktree_has_live_session, which reads the
+#   REGISTERED view (`claude agents --json --all`), NOT the active view predicate
+#   3 uses. The gate is therefore SNAPSHOT_ALL_OK. Gating on SNAPSHOT_OK (the
+#   active view) would certify an input this predicate never reads: a registered
+#   query that fails at probe time folds every candidate to "claimed", HOLD_COUNT
+#   stays 0, and the pass reports `clear` — which does not merely suppress the
+#   alarm, it sends `--resolve --kind unclaimed-hold` and closes an already-open
+#   alarm node. Exporting DISPATCH_AGENTS_SNAPSHOT_ALL also pins the ladder to
+#   the same bytes the gate certified, instead of re-querying per candidate row.
 #
 # Not quiet under pause — see the PAUSE block in the header.
 V_HOLD="unknown"; D_HOLD=""; B_HOLD=""
@@ -594,10 +622,12 @@ HOLD_READINGS=""   # reading: the same pairs with ages and resolved attention
 HOLD_ROOT="$(resolve_main_worktree 2>/dev/null)" || HOLD_ROOT=""
 if [[ -z "$HOLD_ROOT" ]]; then
   D_HOLD="repo root unresolvable (no worktree has main checked out and DISPATCH_GRAPH_MAIN_WORKTREE is unset) — unclaimed holds could not be enumerated"
-elif [[ "$SNAPSHOT_OK" -ne 1 ]]; then
-  # See FAIL DIRECTION above: without a readable snapshot every candidate would
-  # read as claimed and this predicate would report a silent all-clear.
-  D_HOLD="the machine-wide claude agents daemon snapshot could not be captured — whether a session claims a hold is unreadable, and an unreadable claim must NOT be folded into 'claimed' here (that would suppress this alarm)"
+elif [[ "$SNAPSHOT_ALL_OK" -ne 1 || ! -r "$SNAPSHOT_ALL_PATH" ]]; then
+  # See FAIL DIRECTION above: without a readable REGISTERED snapshot every
+  # candidate would read as claimed and this predicate would report a silent
+  # all-clear that ALSO resolves the alarm node. SNAPSHOT_OK is deliberately not
+  # consulted — it certifies the active view, which this ladder never reads.
+  D_HOLD="the machine-wide claude agents daemon snapshot (registered view, 'claude agents --json --all') could not be captured or is no longer readable — whether a session claims a hold is unreadable, and an unreadable claim must NOT be folded into 'claimed' here (that would suppress this alarm)"
 else
   HOLD_OUT=""; HOLD_RC=0
   if [[ -n "${DISPATCH_FLEET_WATCH_HOLDALERT_CMD:-}" ]]; then
@@ -693,7 +723,7 @@ note_verdict "$V_AUTOMERGE" "automerge-suppressed: $B_AUTOMERGE"
 note_verdict "$V_HOLD"      "unclaimed-hold: $B_HOLD"
 
 # An unreadable PAUSE state is itself an unreadable input — it must raise
-# watch-unknown even when all four predicates happened to read cleanly.
+# watch-unknown even when all five predicates happened to read cleanly.
 if [[ "$PAUSE_UNKNOWN" -eq 1 ]]; then
   UNKNOWN_COUNT=$((UNKNOWN_COUNT + 1))
   UNKNOWN_REASONS+="- pause-state: dispatch_pause_state returned unknown — the sentinel's parent directory exists but is not searchable, so pause state could not be determined. Every predicate was evaluated anyway (pause silences nothing when pause itself is unreadable)."$'\n'

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-fleet-watch
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-fleet-watch
@@ -2,7 +2,7 @@
 #
 # dispatch-fleet-watch — ONE-SHOT fleet-health watcher pass.
 #
-# Reads four independent fleet-health predicates, reports each one, and turns
+# Reads five independent fleet-health predicates, reports each one, and turns
 # every finding (and every unreadable input) into a graph node through
 # dispatch-fleet-alarm. Then it exits. It does NOT loop and it takes no deadline
 # argument: cadence belongs to the systemd timer that invokes it, not to the
@@ -14,7 +14,7 @@
 # (fleet-health-watch.sh) evaluated predicates in sequence and returned at the
 # first finding — so one spurious finding silently stopped every LATER predicate
 # from being read at all, and the fleet went unwatched while a watcher appeared
-# to be running. Four verdicts are collected first; reporting happens once, at
+# to be running. Every verdict is collected first; reporting happens once, at
 # the end, over the complete set.
 #
 # THE SECOND MOST IMPORTANT PROPERTY: an unreadable input is `unknown`, never
@@ -28,20 +28,29 @@
 #   2. daemon-degraded       delegated to dispatch-daemon-liveness
 #   3. busy-stall            sustained BUSY=0 across passes (state-file spanned)
 #   4. automerge-suppressed  open tactic-main-red-* latch held too long
+#   5. unclaimed-hold        a tracked hold blocking top-ranked work that no
+#                            session and no reservation claims
 #
 # WHY ONE SNAPSHOT, CAPTURED AT THE INPUT BOUNDARY:
-#   Only predicate 3 currently reads the live session array, and it reads it
-#   through claude_agents_count_busy_workers, which already applies the worker
-#   keyspace filter (`^[0-9]+-|^tactic-|^strategy-`, lib-claude-agents.sh:1043).
-#   Nonetheless this script captures ONE machine-wide snapshot per pass via
-#   claude_agents_snapshot_capture and exports it as DISPATCH_AGENTS_SNAPSHOT.
+#   Predicate 3 reads the live session array through
+#   claude_agents_count_busy_workers, which already applies the worker keyspace
+#   filter (`^[0-9]+-|^tactic-|^strategy-`, lib-claude-agents.sh:1043), and
+#   predicate 5 reads it through worktree_has_live_session, one probe per
+#   candidate hold/source worktree. This script captures ONE machine-wide
+#   snapshot per pass via claude_agents_snapshot_capture and exports it as
+#   DISPATCH_AGENTS_SNAPSHOT.
 #   History: the session-keyspace exclusion used to be bolted onto individual
 #   predicates one at a time, and the bug recurred every single time a new
 #   predicate was added — the new test read the raw array, forgot the filter,
 #   and counted routers/human sessions as workers. The filter must be a PROPERTY
 #   OF THE INPUT, captured once at the boundary, not a rule each test restates.
-#   A fifth predicate added later inherits both the single daemon query and the
-#   filter for free, without knowing either exists.
+#   Predicate 5 inherited both the single daemon query and the filter for free,
+#   without knowing either exists — exactly as this note predicted a fifth
+#   predicate would.
+#   It does NOT inherit the fail direction, though, and that is the one thing a
+#   later predicate must reason about for itself: see "FAIL DIRECTION" on
+#   predicate 5 below. The snapshot's READABILITY is therefore recorded at the
+#   capture site (SNAPSHOT_OK) and consumed by predicate 5.
 #
 # TWO DETAIL STRINGS PER PREDICATE, ON PURPOSE:
 #   D_<P>  the READING — carries the live numbers (elapsed spans, ages, counts,
@@ -90,10 +99,14 @@
 #   paused   — predicates 1 and 3 are `quiet` (not evaluated, not reported as
 #              clear/finding/unknown, and 3 additionally CLEARS its
 #              busy_zero_since stamp so the pause window does not accumulate
-#              toward the stall span). Predicates 2 and 4 evaluate normally: a
-#              paused fleet still has a live daemon, and a suppressed auto-merge
-#              latch is still suppressed.
-#   unknown  — ALL FOUR predicates evaluate and emit as normal, each tagged
+#              toward the stall span). Predicates 2, 4 and 5 evaluate normally:
+#              a paused fleet still has a live daemon, a suppressed auto-merge
+#              latch is still suppressed, and an unclaimed hold blocking
+#              top-ranked work is still blocking it. Paused scheduling with
+#              manual-only dispatch is a supported STANDING operating mode, and
+#              a top-ranked node blocked by a hold nobody is holding is exactly
+#              what the human driving that paused fleet needs told.
+#   unknown  — ALL FIVE predicates evaluate and emit as normal, each tagged
 #              `pause=unknown`, AND the pass emits a watch-unknown finding
 #              naming the unreadable pause state. Silencing on an unreadable
 #              input is exactly the failure class this rewrite exists to close.
@@ -115,6 +128,11 @@
 #   DISPATCH_FLEET_WATCH_TICK_MAX_AGE      default 1500   (25m)
 #   DISPATCH_FLEET_WATCH_IDLE_LIMIT        default 2700   (45m)
 #   DISPATCH_FLEET_WATCH_SUPPRESSION_LIMIT default 21600  (6h)
+#   DISPATCH_FLEET_WATCH_HOLD_MIN_AGE      default 86400  (24h) — how long a
+#       hold must have sat unclaimed in the human review queue before it alerts.
+#   DISPATCH_FLEET_WATCH_HOLD_TOP_K        default 10 (a COUNT, not seconds) —
+#       how many top-ranked live nodes count as "important" for predicate 5's
+#       blocked-source gate. Both are passed straight through to the enumerator.
 #
 # Paths:
 #   DISPATCH_DECISION_LOG_FILE / DISPATCH_DECISION_LOG_DIR
@@ -144,7 +162,18 @@
 #                                      "NEVER FLEET-RESUME EITHER" above); a
 #                                      substitute must honour that flag.
 #   DISPATCH_FLEET_WATCH_ALARM_CMD     default: $SCRIPT_DIR/dispatch-fleet-alarm
+#   DISPATCH_FLEET_WATCH_HOLDALERT_CMD Executable run INSTEAD of the whole
+#                                      predicate-5 enumerator invocation, with
+#                                      NO arguments appended (mirrors
+#                                      DISPATCH_HOLD_RECHECK_ENUM in
+#                                      lib-stale-hold-recheck.sh). Its stdout
+#                                      must carry the same 6-column TSV.
 #   CLAUDE_AGENTS_CMD                  lib-claude-agents.sh's own `claude` seam
+#   DISPATCH_GRAPH_MAIN_WORKTREE       lib-graph-worktree.sh's root override,
+#                                      honoured by resolve_main_worktree (the
+#                                      anchor for predicate 5's enumerator and
+#                                      worktree probes)
+#   DISPATCH_RESERVATION_DIR           lib-reservation-ledger.sh's ledger dir
 #
 # NOT set -e: every risky step is guarded explicitly so the pass always reaches
 # its reporting block (same convention as sibling dispatch-graph-main-red-sync).
@@ -159,9 +188,10 @@ usage() {
 usage: dispatch-fleet-watch [--json]
        dispatch-fleet-watch -h|--help
 
-One-shot fleet-health watcher pass. Evaluates four predicates (tick-stale,
-daemon-degraded, busy-stall, automerge-suppressed), ALWAYS all four, and
-records findings / unreadable inputs as graph nodes via dispatch-fleet-alarm.
+One-shot fleet-health watcher pass. Evaluates five predicates (tick-stale,
+daemon-degraded, busy-stall, automerge-suppressed, unclaimed-hold), ALWAYS all
+five, and records findings / unreadable inputs as graph nodes via
+dispatch-fleet-alarm.
 
 exit: 0 all clear, 1 finding, 2 unknown, 64 usage, 69 environment.
 USAGE
@@ -189,7 +219,9 @@ ALARM_CMD="${DISPATCH_FLEET_WATCH_ALARM_CMD:-$SCRIPT_DIR/dispatch-fleet-alarm}"
 TICK_MAX_AGE="${DISPATCH_FLEET_WATCH_TICK_MAX_AGE:-1500}"
 IDLE_LIMIT="${DISPATCH_FLEET_WATCH_IDLE_LIMIT:-2700}"
 SUPPRESSION_LIMIT="${DISPATCH_FLEET_WATCH_SUPPRESSION_LIMIT:-21600}"
-for t in "$TICK_MAX_AGE" "$IDLE_LIMIT" "$SUPPRESSION_LIMIT"; do
+HOLD_MIN_AGE="${DISPATCH_FLEET_WATCH_HOLD_MIN_AGE:-86400}"
+HOLD_TOP_K="${DISPATCH_FLEET_WATCH_HOLD_TOP_K:-10}"
+for t in "$TICK_MAX_AGE" "$IDLE_LIMIT" "$SUPPRESSION_LIMIT" "$HOLD_MIN_AGE" "$HOLD_TOP_K"; do
   [[ "$t" =~ ^[0-9]+$ ]] || { log "threshold must be a non-negative integer, got '$t'"; exit 64; }
 done
 
@@ -252,9 +284,23 @@ if ! source "$SCRIPT_DIR/lib-claude-agents.sh" 2>/dev/null; then
   log "cannot source lib-claude-agents.sh"
   exit 69
 fi
+# Predicate 5 additionally needs to know whether the snapshot READ succeeded —
+# see "FAIL DIRECTION" on that predicate. SNAPSHOT_OK is that one bit.
+# shellcheck source=/dev/null
+if ! source "$SCRIPT_DIR/lib-graph-worktree.sh" 2>/dev/null; then
+  log "cannot source lib-graph-worktree.sh"
+  exit 69
+fi
+# shellcheck source=/dev/null
+if ! source "$SCRIPT_DIR/lib-reservation-ledger.sh" 2>/dev/null; then
+  log "cannot source lib-reservation-ledger.sh"
+  exit 69
+fi
 SNAPSHOT_PATH="$WORK_DIR/agents-snapshot.json"
+SNAPSHOT_OK=0
 if claude_agents_snapshot_capture "$SNAPSHOT_PATH" 2>/dev/null; then
   export DISPATCH_AGENTS_SNAPSHOT="$SNAPSHOT_PATH"
+  SNAPSHOT_OK=1
 fi
 
 # --- pause state, read ONCE --------------------------------------------------
@@ -519,6 +565,99 @@ else
   fi
 fi
 
+# --- 5. an unclaimed hold blocking top-ranked work ---------------------------
+# The condition: a tracked hold whose review nobody has picked up has sat in the
+# human queue past HOLD_MIN_AGE while blocking a node among the graph's top
+# HOLD_TOP_K live, unparked, eligible sources. Nothing else notices — the source
+# is simply unselectable, forever, and the fleet looks busy on other work.
+#
+# Shape copied from lib-stale-hold-recheck.sh steps 1-3c: resolve the main
+# checkout, enumerate through a tsx CLI anchored there, then run the SAME
+# claimed ladder per candidate. The difference is what the ladder is FOR — there
+# it gates a resolve, here it decides whether to alert.
+#
+# FAIL DIRECTION, and why it needs a guard the resolve sweep does not:
+#   For the resolve sweep, fail-safe means KEEP, so an unknown session state
+#   folding to "occupied" is exactly right. For an ALERT the same fold is
+#   backwards: an unreadable daemon would read as "someone is on it" and
+#   SUPPRESS the alarm — a false all-clear, the one failure this whole script
+#   exists to prevent. worktree_has_live_session cannot report unknown
+#   separately (occupied IS its unknown), so the readability of the pass's one
+#   daemon snapshot is captured at the input boundary instead and consumed here:
+#   no snapshot, no verdict. `unknown` raises watch-unknown and resolves nothing.
+#
+# Not quiet under pause — see the PAUSE block in the header.
+V_HOLD="unknown"; D_HOLD=""; B_HOLD=""
+HOLD_COUNT=0
+HOLD_PAIRS=""      # identity: one `<hold-id> -> <source-id>` per line
+HOLD_READINGS=""   # reading: the same pairs with ages and resolved attention
+HOLD_ROOT="$(resolve_main_worktree 2>/dev/null)" || HOLD_ROOT=""
+if [[ -z "$HOLD_ROOT" ]]; then
+  D_HOLD="repo root unresolvable (no worktree has main checked out and DISPATCH_GRAPH_MAIN_WORKTREE is unset) — unclaimed holds could not be enumerated"
+elif [[ "$SNAPSHOT_OK" -ne 1 ]]; then
+  # See FAIL DIRECTION above: without a readable snapshot every candidate would
+  # read as claimed and this predicate would report a silent all-clear.
+  D_HOLD="the machine-wide claude agents daemon snapshot could not be captured — whether a session claims a hold is unreadable, and an unreadable claim must NOT be folded into 'claimed' here (that would suppress this alarm)"
+else
+  HOLD_OUT=""; HOLD_RC=0
+  if [[ -n "${DISPATCH_FLEET_WATCH_HOLDALERT_CMD:-}" ]]; then
+    HOLD_OUT=$( (cd "$HOLD_ROOT" && "$DISPATCH_FLEET_WATCH_HOLDALERT_CMD") 2>/dev/null ) || HOLD_RC=$?
+  else
+    HOLD_OUT=$( (cd "$HOLD_ROOT" && node --import tsx/esm \
+      "$HOLD_ROOT/packages/intentionsutil/scripts/list-unclaimed-hold-alerts.ts" \
+      --dir "$HOLD_ROOT/intentions" \
+      --now "$(date -u -d "@$NOW" +%FT%TZ)" \
+      --min-age-seconds "$HOLD_MIN_AGE" \
+      --top-k "$HOLD_TOP_K") 2>/dev/null ) || HOLD_RC=$?
+  fi
+  if (( HOLD_RC != 0 )); then
+    # An enumeration that could not run is NEVER "no unclaimed holds".
+    D_HOLD="the unclaimed-hold enumerator exited $HOLD_RC — no hold was inspected this pass, which is NOT the same as no hold alerting"
+    B_HOLD="the unclaimed-hold enumerator (list-unclaimed-hold-alerts.ts) could not be run"
+  else
+    HOLD_PARSE_OK=1
+    while IFS=$'\t' read -r H_ID H_SRC H_KIND H_AGE H_TIER H_VALUE; do
+      [[ -n "${H_ID}${H_SRC}" ]] || continue
+      # Unparseable is unknown, not clear: a row we cannot read may be the very
+      # alert that matters. Both ids also become path components below.
+      if [[ -z "$H_ID" || -z "$H_SRC" || ! "$H_AGE" =~ ^[0-9]+$ ]]; then
+        HOLD_PARSE_OK=0; break
+      fi
+      case "$H_ID$H_SRC" in
+        *..*|*/*|*[[:cntrl:]]*) HOLD_PARSE_OK=0; break ;;
+      esac
+      # CLAIMED — the "unclaimed" half, checked for the SOURCE and the HOLD
+      # alike, exactly as lib-stale-hold-recheck.sh step 3c does. The full
+      # worktree PATH goes to worktree_has_live_session, never a bare id.
+      if reservation_exists "$H_SRC" 2>/dev/null \
+        || worktree_has_live_session "$HOLD_ROOT/.claude/worktrees/$H_SRC" 2>/dev/null \
+        || reservation_exists "$H_ID" 2>/dev/null \
+        || worktree_has_live_session "$HOLD_ROOT/.claude/worktrees/$H_ID" 2>/dev/null; then
+        continue
+      fi
+      HOLD_COUNT=$(( HOLD_COUNT + 1 ))
+      HOLD_PAIRS+="$H_ID -> $H_SRC"$'\n'
+      HOLD_READINGS+="$H_ID -> $H_SRC (${H_KIND:-<kind?>}, unclaimed ${H_AGE}s, source ${H_TIER:-<tier?>}/${H_VALUE:-<value?>}); "
+    done <<<"$HOLD_OUT"
+    if [[ "$HOLD_PARSE_OK" -ne 1 ]]; then
+      V_HOLD="unknown"
+      D_HOLD="the unclaimed-hold enumerator emitted a row this pass could not parse (expected <hold-id>TAB<source-id>TAB<kind>TAB<age>TAB<tier>TAB<value>) — no verdict is possible"
+      B_HOLD="the unclaimed-hold enumerator emitted an unparseable row"
+    elif (( HOLD_COUNT > 0 )); then
+      V_HOLD="finding"
+      D_HOLD="$HOLD_COUNT unclaimed hold(s) blocking top-${HOLD_TOP_K} work: ${HOLD_READINGS%; }"
+      # IDENTITY ONLY. The ages and the resolved tier/value are readings — they
+      # move on essentially every graph commit, and a body carrying them would
+      # push to origin/main once per 5-minute pass. Sorted so the same set of
+      # pairs always renders the same bytes regardless of enumerator ordering.
+      B_HOLD="tracked hold(s) have blocked top-ranked work while unclaimed by any session or reservation: $(printf '%s' "$HOLD_PAIRS" | sort | tr '\n' ';' | sed 's/;$//' | sed 's/;/; /g')"
+    else
+      V_HOLD="clear"
+      D_HOLD="no unclaimed hold is blocking top-${HOLD_TOP_K} work (minimum unclaimed age ${HOLD_MIN_AGE}s)"
+    fi
+  fi
+fi
+
 # =============================================================================
 # Reporting — runs ONCE, over the complete verdict set.
 # =============================================================================
@@ -533,6 +672,7 @@ B_TICK="${B_TICK:-$D_TICK}"
 B_DAEMON="${B_DAEMON:-$D_DAEMON}"
 B_BUSY="${B_BUSY:-$D_BUSY}"
 B_AUTOMERGE="${B_AUTOMERGE:-$D_AUTOMERGE}"
+B_HOLD="${B_HOLD:-$D_HOLD}"
 
 FINDING_COUNT=0
 UNKNOWN_COUNT=0
@@ -550,6 +690,7 @@ note_verdict "$V_TICK"      "tick-stale: $B_TICK"
 note_verdict "$V_DAEMON"    "daemon-degraded: $B_DAEMON"
 note_verdict "$V_BUSY"      "busy-stall: $B_BUSY"
 note_verdict "$V_AUTOMERGE" "automerge-suppressed: $B_AUTOMERGE"
+note_verdict "$V_HOLD"      "unclaimed-hold: $B_HOLD"
 
 # An unreadable PAUSE state is itself an unreadable input — it must raise
 # watch-unknown even when all four predicates happened to read cleanly.
@@ -649,6 +790,19 @@ State file: $STATE_FILE (suppression_since — the live value is in this pass's
 journald output and in --json)
 Pause state: $PAUSE_STATE (auto-merge suppression is evaluated regardless of pause)"
 
+# Identity only: the offending `<hold-id> -> <source-id>` pairs and the two
+# threshold names. NOT the unclaimed ages and NOT the resolved source
+# tier/value — those move on essentially every graph commit, so a body carrying
+# them would push to origin/main once per 5-minute pass. They are on stdout and
+# in --json for this pass instead.
+dispatch_predicate "$V_HOLD" unclaimed-hold \
+  "A tracked hold has blocked top-ranked work with no session claiming it" \
+  "$B_HOLD
+
+Thresholds: DISPATCH_FLEET_WATCH_HOLD_MIN_AGE=${HOLD_MIN_AGE}s,
+DISPATCH_FLEET_WATCH_HOLD_TOP_K=${HOLD_TOP_K}
+Pause state: $PAUSE_STATE (unclaimed holds are evaluated regardless of pause)"
+
 # THE most important single behavior in this script: any unknown, for any
 # reason, is announced. A watcher that cannot read its inputs must say so
 # loudly rather than emit a false all-clear.
@@ -678,6 +832,8 @@ if [[ "$JSON" -eq 1 ]]; then
     --arg v_daemon "$V_DAEMON" --arg d_daemon "$D_DAEMON" \
     --arg v_busy "$V_BUSY" --arg d_busy "$D_BUSY" \
     --arg v_automerge "$V_AUTOMERGE" --arg d_automerge "$D_AUTOMERGE" \
+    --arg v_hold "$V_HOLD" --arg d_hold "$D_HOLD" \
+    --argjson hold_count "$HOLD_COUNT" \
     --arg busy_count "${BUSY_COUNT:-}" \
     --arg busy_zero_since "${BUSY_SINCE_AFTER:-}" \
     --arg suppression_since "${SUPPRESSION_SINCE_AFTER:-}" \
@@ -700,7 +856,9 @@ if [[ "$JSON" -eq 1 ]]; then
                                    busy_zero_since: ($busy_zero_since | blank_null | if . == null then null else tonumber end) },
         "automerge-suppressed":  { verdict: $v_automerge, detail: $d_automerge,
                                    suppression_since: ($suppression_since | blank_null | if . == null then null else tonumber end),
-                                   open_main_red_nodes: ($red_nodes | blank_null | if . == null then [] else split("\n") end) }
+                                   open_main_red_nodes: ($red_nodes | blank_null | if . == null then [] else split("\n") end) },
+        "unclaimed-hold":        { verdict: $v_hold,      detail: $d_hold,
+                                   candidate_count: $hold_count }
       },
       unknown_reasons: ($unknown_reasons | blank_null)
     }'
@@ -712,6 +870,7 @@ printf '  tick-stale:           %-8s %s%s\n' "$V_TICK"      "$D_TICK"      "$PAU
 printf '  daemon-degraded:      %-8s %s%s\n' "$V_DAEMON"    "$D_DAEMON"    "$PAUSE_TAG"
 printf '  busy-stall:           %-8s %s%s\n' "$V_BUSY"      "$D_BUSY"      "$PAUSE_TAG"
 printf '  automerge-suppressed: %-8s %s%s\n' "$V_AUTOMERGE" "$D_AUTOMERGE" "$PAUSE_TAG"
+printf '  unclaimed-hold:       %-8s %s%s\n' "$V_HOLD"      "$D_HOLD"      "$PAUSE_TAG"
 
 # Never print a bare `ok` when anything is unknown — that is the false
 # all-clear this watcher exists to prevent.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-fleet-watch.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-fleet-watch.sh
@@ -117,12 +117,23 @@ STUB
 chmod +x "$BIN/holdalert"
 
 # `claude` stub — lib-claude-agents.sh's own CLAUDE_AGENTS_CMD seam. Handles
-# both `agents --json` (the snapshot capture) and the busy count that reads it.
+# both `agents --json` (the ACTIVE view: the snapshot capture and the busy count
+# that reads it) and `agents --json --all` (the REGISTERED view, which is what
+# worktree_has_live_session — predicate 5's claim ladder — actually reads).
 # STUB_AGENTS_FAIL=1 makes the daemon query fail, which is exactly how the real
 # library produces its UNKNOWN busy count.
+# THE TWO VIEWS MUST BE INDEPENDENTLY FAILABLE. They are separate daemon queries
+# over separate snapshot variables, and a stub that answers both from one fixture
+# cannot see a predicate gating on the wrong one: STUB_AGENTS_ALL_FAIL=1 fails
+# ONLY the `--all` query, leaving the active view healthy.
 cat > "$BIN/claude" <<'STUB'
 #!/usr/bin/env bash
 [[ "${STUB_AGENTS_FAIL:-0}" == "1" ]] && exit 1
+for a in "$@"; do
+  if [[ "$a" == "--all" ]]; then
+    [[ "${STUB_AGENTS_ALL_FAIL:-0}" == "1" ]] && exit 1
+  fi
+done
 printf '%s\n' "${STUB_AGENTS_JSON:-[]}"
 STUB
 chmod +x "$BIN/claude"
@@ -171,6 +182,7 @@ run_case() {
     STUB_REDSYNC_OUT="${STUB_REDSYNC_OUT:-}" \
     STUB_AGENTS_JSON="${STUB_AGENTS_JSON:-[]}" \
     STUB_AGENTS_FAIL="${STUB_AGENTS_FAIL:-0}" \
+    STUB_AGENTS_ALL_FAIL="${STUB_AGENTS_ALL_FAIL:-0}" \
     STUB_ALARM_RC="${STUB_ALARM_RC:-0}" \
     bash "$SCRIPT" "$@" 2>/dev/null
   )"
@@ -182,7 +194,7 @@ run_case() {
 
 reset_stubs() {
   unset STUB_LIVENESS_RC STUB_LIVENESS_VERDICT STUB_LIVENESS_REASON STUB_LIVENESS_NOJSON
-  unset STUB_REDSYNC_OUT STUB_AGENTS_JSON STUB_AGENTS_FAIL STUB_ALARM_RC
+  unset STUB_REDSYNC_OUT STUB_AGENTS_JSON STUB_AGENTS_FAIL STUB_AGENTS_ALL_FAIL STUB_ALARM_RC
   unset STUB_HOLDALERT_OUT STUB_HOLDALERT_RC
 }
 
@@ -612,6 +624,29 @@ assert_contains "case23 verdict tagged with the pause state" "Pause state: pause
   "$(cat "$CASEDIR/bodies/unclaimed-hold.body")"
 # Predicate 1 is still quiet under pause — pause did not stop meaning anything.
 assert_contains "case23 tick-stale still quiet under pause" "tick-stale:           quiet" "$RUN_OUT"
+
+# ===========================================================================
+# Case 24 (WRONG-INPUT GUARD, the false-all-clear this predicate exists to
+# prevent): the ACTIVE view reads fine but the REGISTERED view (`--all`) — the
+# only view predicate 5's claim ladder reads — is unreadable, with a genuine
+# unclaimed candidate present. Gating on the active view's readability would let
+# every `--all` probe return UNKNOWN, fold every candidate to "claimed", and
+# report `clear` — which does not merely suppress the alarm, it RESOLVES an
+# already-open unclaimed-hold node. The verdict must be unknown: no finding, no
+# resolve, watch-unknown raised.
+reset_stubs; new_env case24
+fresh_log
+STUB_LIVENESS_RC=0 STUB_AGENTS_JSON="$(agents_json 1)" STUB_AGENTS_ALL_FAIL=1 STUB_REDSYNC_OUT="" \
+  STUB_HOLDALERT_OUT="$(hold_row tactic-hold-review-alpha tactic-alpha review 90000 A 12.5)" run_case
+assert_contains "case24 verdict unknown (registered view unreadable)" "unclaimed-hold:       unknown" "$RUN_OUT"
+assert_not_contains "case24 verdict is NOT a false clear" "unclaimed-hold:       clear" "$RUN_OUT"
+assert_not_contains "case24 no unclaimed-hold resolve" "--resolve --kind unclaimed-hold" "$ALARMS"
+assert_not_contains "case24 no unclaimed-hold finding" "--kind unclaimed-hold --statement" "$ALARMS"
+assert_eq "case24 watch-unknown alarm fired" 1 "$(grep -c -- '--kind watch-unknown --statement' <<<"$ALARMS")"
+assert_eq "case24 exit code (unknown)" 2 "$RUN_RC"
+# The ACTIVE view really was healthy, or the case proves nothing about WHICH
+# view the gate consults: predicate 3 read it and produced a definite verdict.
+assert_not_contains "case24 busy-stall still read the active view" "busy-stall:           unknown" "$RUN_OUT"
 
 # ===========================================================================
 # Case 17 (DOCTRINE RATCHET): the watcher must never fleet-halt. Grep the

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-fleet-watch.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-fleet-watch.sh
@@ -18,6 +18,14 @@
 #                                       exercised live — it is small and its
 #                                       tri-state is load-bearing here)
 #   DISPATCH_FLEET_WATCH_STATE_FILE     cross-pass span state
+#   DISPATCH_FLEET_WATCH_HOLDALERT_CMD  stub for predicate 5's enumerator
+#                                       (list-unclaimed-hold-alerts.ts) — the
+#                                       whole invocation, no args appended
+#   DISPATCH_GRAPH_MAIN_WORKTREE        lib-graph-worktree.sh's root override,
+#                                       so resolve_main_worktree never reaches
+#                                       the real repo (and predicate 5's
+#                                       worktree probes stay inside $WORK)
+#   DISPATCH_RESERVATION_DIR            lib-reservation-ledger.sh's ledger dir
 #
 # No systemd, no real `claude` daemon, no git remote, no graph write — only bash
 # + jq. Run under bash, never zsh.
@@ -98,6 +106,16 @@ exit "${STUB_ALARM_RC:-0}"
 STUB
 chmod +x "$BIN/alarm"
 
+# predicate 5's enumerator stub (list-unclaimed-hold-alerts.ts). The watcher
+# runs it with NO arguments appended, so the stub takes none. STUB_HOLDALERT_OUT
+# is the raw 6-column TSV; STUB_HOLDALERT_RC fakes an enumeration failure.
+cat > "$BIN/holdalert" <<'STUB'
+#!/usr/bin/env bash
+[[ -n "${STUB_HOLDALERT_OUT:-}" ]] && printf '%s\n' "$STUB_HOLDALERT_OUT"
+exit "${STUB_HOLDALERT_RC:-0}"
+STUB
+chmod +x "$BIN/holdalert"
+
 # `claude` stub — lib-claude-agents.sh's own CLAUDE_AGENTS_CMD seam. Handles
 # both `agents --json` (the snapshot capture) and the busy count that reads it.
 # STUB_AGENTS_FAIL=1 makes the daemon query fail, which is exactly how the real
@@ -141,6 +159,11 @@ run_case() {
     DISPATCH_DECISION_LOG_FILE="$LOGFILE" \
     DISPATCH_PAUSE_FLAG="$PAUSEFLAG" \
     DISPATCH_FLEET_WATCH_STATE_FILE="$STATEFILE" \
+    DISPATCH_FLEET_WATCH_HOLDALERT_CMD="$BIN/holdalert" \
+    DISPATCH_GRAPH_MAIN_WORKTREE="$CASEDIR" \
+    DISPATCH_RESERVATION_DIR="$RESVDIR" \
+    STUB_HOLDALERT_OUT="${STUB_HOLDALERT_OUT:-}" \
+    STUB_HOLDALERT_RC="${STUB_HOLDALERT_RC:-0}" \
     STUB_LIVENESS_RC="${STUB_LIVENESS_RC:-0}" \
     STUB_LIVENESS_VERDICT="${STUB_LIVENESS_VERDICT:-}" \
     STUB_LIVENESS_REASON="${STUB_LIVENESS_REASON:-}" \
@@ -160,6 +183,7 @@ run_case() {
 reset_stubs() {
   unset STUB_LIVENESS_RC STUB_LIVENESS_VERDICT STUB_LIVENESS_REASON STUB_LIVENESS_NOJSON
   unset STUB_REDSYNC_OUT STUB_AGENTS_JSON STUB_AGENTS_FAIL STUB_ALARM_RC
+  unset STUB_HOLDALERT_OUT STUB_HOLDALERT_RC
 }
 
 # new_env <case-name> — fresh log/pause/state paths for an isolated case.
@@ -170,18 +194,22 @@ new_env() {
   PAUSEDIR="$CASEDIR/state"; mkdir -p "$PAUSEDIR"
   PAUSEFLAG="$PAUSEDIR/paused"
   STATEFILE="$CASEDIR/fleet-watch-state.json"
+  # Predicate 5's two other inputs: the reservation ledger (empty = nothing
+  # claimed) and the worktrees root under the faked main worktree ($CASEDIR).
+  RESVDIR="$CASEDIR/reservations"; mkdir -p "$RESVDIR"
+  mkdir -p "$CASEDIR/.claude/worktrees"
 }
 
 fresh_log() { printf '{"ts":"%s","site":"select-tick"}\n' "$(iso $((NOW - 60)))" > "$LOGFILE"; }
 stale_log() { printf '{"ts":"%s","site":"select-tick"}\n' "$(iso $((NOW - 99999)))" > "$LOGFILE"; }
 
 # ===========================================================================
-# Case 1: all four clear -> exit 0, four --resolve calls, zero finding calls.
+# Case 1: all five clear -> exit 0, five --resolve calls, zero finding calls.
 reset_stubs; new_env case1
 fresh_log
 STUB_LIVENESS_RC=0 STUB_AGENTS_JSON="$(agents_json 2)" STUB_REDSYNC_OUT="" run_case
 assert_eq "case1 exit code" 0 "$RUN_RC"
-assert_eq "case1 resolve count" 4 "$(grep -c -- '--resolve' <<<"$ALARMS")"
+assert_eq "case1 resolve count" 5 "$(grep -c -- '--resolve' <<<"$ALARMS")"
 assert_eq "case1 finding-alarm count" 0 "$(grep -c -- '--statement' <<<"$ALARMS")"
 assert_contains "case1 reports ok" "result: ok" "$RUN_OUT"
 # The latch is READ, never completed: completing it re-arms the auto-merge gate
@@ -214,7 +242,13 @@ assert_not_contains "case2 daemon-degraded not resolved" "--resolve --kind daemo
 reset_stubs; new_env case3
 stale_log
 touch "$PAUSEFLAG"
-STUB_LIVENESS_RC=0 STUB_AGENTS_JSON="[]" STUB_REDSYNC_OUT="" run_case
+# `agents_json 0` (an array with no BUSY WORKERS, but non-empty) rather than a
+# literal `[]`: an exactly-`[]` payload is only a definite empty read when
+# lib-claude-agents.sh's daemon-process probe corroborates it, so a bare `[]`
+# would make the snapshot capture UNKNOWN on some hosts and not others. The
+# predicate under test here (busy-stall, quiet under pause) reads the same
+# either way.
+STUB_LIVENESS_RC=0 STUB_AGENTS_JSON="$(agents_json 0)" STUB_REDSYNC_OUT="" run_case
 assert_eq "case3 exit code (paused, quiet)" 0 "$RUN_RC"
 assert_not_contains "case3 no tick-stale finding alarm" "--kind tick-stale --statement" "$ALARMS"
 assert_not_contains "case3 no tick-stale resolve either" "--resolve --kind tick-stale" "$ALARMS"
@@ -236,8 +270,8 @@ assert_contains "case4 pause reported unknown" "pause=unknown" "$RUN_OUT"
 assert_eq "case4 watch-unknown alarm fired" 1 "$(grep -c -- '--kind watch-unknown --statement' <<<"$ALARMS")"
 assert_not_contains "case4 does NOT report bare ok" "result: ok" "$RUN_OUT"
 if [[ "$RUN_RC" -ne 0 ]]; then ok "case4 exit is not 0"; else no "case4 exited 0 despite pause-unknown"; fi
-# All four still evaluated (each read cleanly, so each resolved).
-assert_eq "case4 all four predicates still evaluated" 4 "$(grep -c -- '--resolve' <<<"$ALARMS")"
+# All five still evaluated (each read cleanly, so each resolved).
+assert_eq "case4 all five predicates still evaluated" 5 "$(grep -c -- '--resolve' <<<"$ALARMS")"
 
 # ===========================================================================
 # Case 5: busy-worker count UNKNOWN (the daemon query fails) with a pre-set
@@ -457,6 +491,127 @@ assert_not_contains "case16 busy body has no first-seen epoch stamp" "$((NOW - 8
 # ...but the offending node id IS identity and must survive.
 assert_contains "case16 automerge body still names the offending node" "tactic-main-red-abcd1234" \
   "$(cat "$CASEDIR/bodies-2/automerge-suppressed.body")"
+
+# ===========================================================================
+# Predicate 5 (unclaimed-hold). The enumerator is stubbed through
+# DISPATCH_FLEET_WATCH_HOLDALERT_CMD, the claim ladder through the `claude`
+# stub (live sessions) and an empty $RESVDIR (reservations).
+#
+# hold_row <hold-id> <source-id> <kind> <age> <tier> <value> — one enumerator
+# TSV line, built with real TABs so the watcher's `IFS=$'\t' read` sees the
+# same six columns list-unclaimed-hold-alerts.ts emits.
+hold_row() { printf '%s\t%s\t%s\t%s\t%s\t%s' "$1" "$2" "$3" "$4" "$5" "$6"; }
+
+# Case 18: one unclaimed candidate, no live session, empty reservation ledger
+# -> exactly one unclaimed-hold finding alarm, exit 1.
+reset_stubs; new_env case18
+fresh_log
+STUB_LIVENESS_RC=0 STUB_AGENTS_JSON="$(agents_json 1)" STUB_REDSYNC_OUT="" \
+  STUB_HOLDALERT_OUT="$(hold_row tactic-hold-review-alpha tactic-alpha review 90000 A 12.5)" run_case
+assert_eq "case18 exactly one unclaimed-hold finding" 1 \
+  "$(grep -c -- '--kind unclaimed-hold --statement' <<<"$ALARMS")"
+assert_not_contains "case18 no unclaimed-hold resolve" "--resolve --kind unclaimed-hold" "$ALARMS"
+assert_contains "case18 verdict is finding" "unclaimed-hold:       finding" "$RUN_OUT"
+assert_eq "case18 exit code (finding)" 1 "$RUN_RC"
+
+# ===========================================================================
+# Case 19: the enumerator emits nothing -> clear, exactly one resolve, exit 0.
+reset_stubs; new_env case19
+fresh_log
+STUB_LIVENESS_RC=0 STUB_AGENTS_JSON="$(agents_json 1)" STUB_REDSYNC_OUT="" run_case
+assert_eq "case19 exactly one unclaimed-hold resolve" 1 \
+  "$(grep -c -- '--resolve --kind unclaimed-hold' <<<"$ALARMS")"
+assert_not_contains "case19 no unclaimed-hold finding" "--kind unclaimed-hold --statement" "$ALARMS"
+assert_contains "case19 verdict is clear" "unclaimed-hold:       clear" "$RUN_OUT"
+assert_eq "case19 exit code (clear)" 0 "$RUN_RC"
+
+# ===========================================================================
+# Case 20 (THE "UNCLAIMED" HALF): the same candidate, but a live session is
+# registered under the SOURCE's worktree basename. Somebody is on it, so this is
+# not an unclaimed hold — verdict clear, resolve issued, no finding.
+reset_stubs; new_env case20
+fresh_log
+CLAIMED_AGENTS="$(jq -c '. + [{sessionId:"sid-1", name:"tactic-alpha", status:"busy", state:"running"}]' <<<"$(agents_json 1)")"
+STUB_LIVENESS_RC=0 STUB_AGENTS_JSON="$CLAIMED_AGENTS" STUB_REDSYNC_OUT="" \
+  STUB_HOLDALERT_OUT="$(hold_row tactic-hold-review-alpha tactic-alpha review 90000 A 12.5)" run_case
+assert_contains "case20 verdict clear (source is claimed)" "unclaimed-hold:       clear" "$RUN_OUT"
+assert_eq "case20 unclaimed-hold resolved" 1 "$(grep -c -- '--resolve --kind unclaimed-hold' <<<"$ALARMS")"
+assert_not_contains "case20 no unclaimed-hold finding" "--kind unclaimed-hold --statement" "$ALARMS"
+
+# ===========================================================================
+# Case 21: the enumerator FAILS (exit 2). An enumeration that could not run is
+# unknown, never clear: no unclaimed-hold alarm, no resolve, watch-unknown
+# raised, exit 2. A failed read must never launder into "no unclaimed holds".
+reset_stubs; new_env case21
+fresh_log
+STUB_LIVENESS_RC=0 STUB_AGENTS_JSON="$(agents_json 1)" STUB_REDSYNC_OUT="" \
+  STUB_HOLDALERT_RC=2 run_case
+assert_contains "case21 verdict unknown" "unclaimed-hold:       unknown" "$RUN_OUT"
+assert_not_contains "case21 no unclaimed-hold finding" "--kind unclaimed-hold --statement" "$ALARMS"
+assert_not_contains "case21 no unclaimed-hold resolve" "--resolve --kind unclaimed-hold" "$ALARMS"
+assert_eq "case21 watch-unknown alarm fired" 1 "$(grep -c -- '--kind watch-unknown --statement' <<<"$ALARMS")"
+assert_not_contains "case21 does NOT report bare ok" "result: ok" "$RUN_OUT"
+assert_eq "case21 exit code (unknown)" 2 "$RUN_RC"
+
+# ===========================================================================
+# Case 22 (BODY-STABILITY RATCHET for predicate 5): two passes over the SAME
+# hold/source pair whose readings differ — a different unclaimed age and a
+# different resolved source tier/value — must emit a byte-identical body. The
+# resolved attention values move on essentially every graph commit, so a body
+# carrying them would fetch/rebase/push to origin/main once per 5-minute pass.
+reset_stubs; new_env case22
+fresh_log
+ALARM_BODY_DIR="$CASEDIR/bodies-1"
+STUB_LIVENESS_RC=0 STUB_AGENTS_JSON="$(agents_json 1)" STUB_REDSYNC_OUT="" \
+  STUB_HOLDALERT_OUT="$(hold_row tactic-hold-review-alpha tactic-alpha review 90000 A 12.5)" run_case
+assert_eq "case22 pass 1 raised the unclaimed-hold finding" 1 \
+  "$(grep -c -- '--kind unclaimed-hold --statement' <<<"$ALARMS")"
+CASE22_OUT_1="$RUN_OUT"
+ALARM_BODY_DIR="$CASEDIR/bodies-2"
+reset_stubs
+STUB_LIVENESS_RC=0 STUB_AGENTS_JSON="$(agents_json 1)" STUB_REDSYNC_OUT="" \
+  STUB_HOLDALERT_OUT="$(hold_row tactic-hold-review-alpha tactic-alpha review 178000 B 41.25)" run_case
+ALARM_BODY_DIR=""
+if [[ ! -s "$CASEDIR/bodies-1/unclaimed-hold.body" || ! -s "$CASEDIR/bodies-2/unclaimed-hold.body" ]]; then
+  no "case22 unclaimed-hold body missing from one of the passes (the ratchet would be vacuous)"
+elif cmp -s "$CASEDIR/bodies-1/unclaimed-hold.body" "$CASEDIR/bodies-2/unclaimed-hold.body"; then
+  ok "case22 unclaimed-hold body is identical across passes"
+else
+  no "case22 unclaimed-hold body CHURNS across passes: $(diff "$CASEDIR/bodies-1/unclaimed-hold.body" "$CASEDIR/bodies-2/unclaimed-hold.body" | tr '\n' ' ')"
+fi
+# The readings really did differ, or the byte-comparison above proves nothing.
+if [[ "$(grep -F 'unclaimed-hold:' <<<"$CASE22_OUT_1")" != "$(grep -F 'unclaimed-hold:' <<<"$RUN_OUT")" ]]; then
+  ok "case22 unclaimed-hold reading DID change between passes (stdout keeps the live numbers)"
+else
+  no "case22 unclaimed-hold reading did not change between passes — the body comparison above is vacuous"
+fi
+CASE22_BODY="$(cat "$CASEDIR/bodies-2/unclaimed-hold.body")"
+assert_not_contains "case22 body carries no unclaimed age" "178000" "$CASE22_BODY"
+assert_not_contains "case22 body carries no resolved attention value" "41.25" "$CASE22_BODY"
+# ...but the offending pair IS the condition's identity and must survive.
+assert_contains "case22 body names the offending hold" "tactic-hold-review-alpha" "$CASE22_BODY"
+assert_contains "case22 body names the blocked source" "tactic-alpha" "$CASE22_BODY"
+
+# ===========================================================================
+# Case 23: PAUSED. Predicate 5 still evaluates (paused scheduling with
+# manual-only dispatch is a standing operating mode, and a top-ranked node
+# blocked by an unclaimed hold is exactly what the human driving it needs), and
+# its verdict carries the pause state rather than going quiet.
+reset_stubs; new_env case23
+fresh_log
+touch "$PAUSEFLAG"
+ALARM_BODY_DIR="$CASEDIR/bodies"
+STUB_LIVENESS_RC=0 STUB_AGENTS_JSON="$(agents_json 1)" STUB_REDSYNC_OUT="" \
+  STUB_HOLDALERT_OUT="$(hold_row tactic-hold-review-alpha tactic-alpha review 90000 A 12.5)" run_case
+ALARM_BODY_DIR=""
+assert_contains "case23 predicate 5 evaluated under pause" "unclaimed-hold:       finding" "$RUN_OUT"
+assert_not_contains "case23 predicate 5 is NOT quiet under pause" "unclaimed-hold:       quiet" "$RUN_OUT"
+assert_eq "case23 unclaimed-hold finding raised under pause" 1 \
+  "$(grep -c -- '--kind unclaimed-hold --statement' <<<"$ALARMS")"
+assert_contains "case23 verdict tagged with the pause state" "Pause state: paused" \
+  "$(cat "$CASEDIR/bodies/unclaimed-hold.body")"
+# Predicate 1 is still quiet under pause — pause did not stop meaning anything.
+assert_contains "case23 tick-stale still quiet under pause" "tick-stale:           quiet" "$RUN_OUT"
 
 # ===========================================================================
 # Case 17 (DOCTRINE RATCHET): the watcher must never fleet-halt. Grep the

--- a/packages/intentionsutil/scripts/list-unclaimed-hold-alerts.ts
+++ b/packages/intentionsutil/scripts/list-unclaimed-hold-alerts.ts
@@ -1,0 +1,120 @@
+// list-unclaimed-hold-alerts — thin CLI over the pure unclaimed-hold alert
+// enumerator (tactic-unclaimed-hold-alerting Unit 3).
+//
+// Prints every manual-policy hold that has sat unclaimed in the office-hours
+// queue for at least `--min-age-seconds` while blocking a source among the
+// graph's top `--top-k` live, unparked, eligible nodes.
+//
+// It is a pure read-only enumeration + printing wrapper over
+// `listUnclaimedHoldAlerts` (src/hold-alerts.ts). No graph writes, no git, no
+// gh, no daemon.
+//
+// Usage:
+//   node --import tsx/esm list-unclaimed-hold-alerts.ts \
+//     --dir <intentions-dir> --min-age-seconds <n> --top-k <n> [--now <iso8601>]
+//
+//   --dir              (required) the intentions store directory nodes load from.
+//   --min-age-seconds  (required) minimum unclaimed age, inclusive.
+//   --top-k            (required) how many top-ranked live nodes count as
+//                      "important" for the blocked-source gate.
+//   --now              (optional) the clock to measure age against; defaults to
+//                      the current time.
+//
+// Stdout: one TSV line per alert,
+//   `<hold-id>\t<source-id>\t<kind>\t<age-seconds>\t<source-tier>\t<source-value>`
+// (nothing when there are no alerts).
+// Exit 0 on success; exit 2 on a usage error or a malformed store.
+//
+// NOTE: this is a SEPARATE CLI from list-recheckable-holds.ts on purpose. That
+// script's four-column TSV is read by lib-stale-hold-recheck.sh with a
+// four-variable `read`, so an appended column there would land inside `cls`.
+
+import { pathToFileURL } from "node:url";
+import { listNodesStrict } from "../src/store.js";
+import { listUnclaimedHoldAlerts } from "../src/hold-alerts.js";
+
+export interface HoldAlertCliOpts {
+  dir: string;
+  now: Date;
+  minAgeSeconds: number;
+  topK: number;
+}
+
+/** Parse a required non-negative integer flag value; throws on anything else. */
+function parseCount(raw: string, flag: string): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) {
+    throw new Error(
+      `list-unclaimed-hold-alerts: ${flag} requires a non-negative integer, got '${raw}'`,
+    );
+  }
+  return n;
+}
+
+function parseArgs(argv: string[]): HoldAlertCliOpts {
+  let dir: string | null = null;
+  let now: Date | null = null;
+  let minAgeSeconds: number | null = null;
+  let topK: number | null = null;
+
+  const requireValue = (v: string | undefined, flag: string): string => {
+    if (v === undefined || v === "")
+      throw new Error(`list-unclaimed-hold-alerts: ${flag} requires an argument`);
+    return v;
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--dir") {
+      dir = requireValue(argv[++i], "--dir");
+    } else if (arg === "--now") {
+      const raw = requireValue(argv[++i], "--now");
+      const parsed = new Date(raw);
+      if (Number.isNaN(parsed.getTime())) {
+        throw new Error(`list-unclaimed-hold-alerts: --now is not a valid ISO-8601 date: '${raw}'`);
+      }
+      now = parsed;
+    } else if (arg === "--min-age-seconds") {
+      minAgeSeconds = parseCount(requireValue(argv[++i], "--min-age-seconds"), "--min-age-seconds");
+    } else if (arg === "--top-k") {
+      topK = parseCount(requireValue(argv[++i], "--top-k"), "--top-k");
+    } else {
+      throw new Error(`list-unclaimed-hold-alerts: unknown argument '${arg}'`);
+    }
+  }
+
+  // Every gate is explicit: a missing threshold is a usage error, never a
+  // silent default that would quietly change which holds alert.
+  if (dir === null || minAgeSeconds === null || topK === null) {
+    throw new Error(
+      "usage: list-unclaimed-hold-alerts.ts --dir <intentions-dir> " +
+        "--min-age-seconds <n> --top-k <n> [--now <iso8601>]",
+    );
+  }
+  return { dir, now: now ?? new Date(), minAgeSeconds, topK };
+}
+
+function main(argv: string[]): void {
+  const { dir, now, minAgeSeconds, topK } = parseArgs(argv);
+  // STRICT by contract, for the same reason list-recheckable-holds.ts:52-58
+  // gives: the tolerant `listNodes` would drop an unreadable `<id>.md` with only
+  // a stderr warning while still exiting 0, so the alerting pass would silently
+  // under-report — both the holds themselves and the top-K pool they are gated
+  // against. `listNodesStrict` throws instead, which becomes exit 2.
+  const nodes = listNodesStrict(dir);
+  for (const a of listUnclaimedHoldAlerts(nodes, { now, minAgeSeconds, topK })) {
+    process.stdout.write(
+      `${a.holdId}\t${a.sourceId}\t${a.kind}\t${a.ageSeconds}\t${a.sourceTier}\t${a.sourceValue}\n`,
+    );
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main(process.argv.slice(2));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`${message}\n`);
+    process.exit(2);
+  }
+}

--- a/packages/intentionsutil/scripts/office-hours-select.ts
+++ b/packages/intentionsutil/scripts/office-hours-select.ts
@@ -43,7 +43,10 @@
 // `office-hours-graph` read loop cites this block): `<rank>\t<sessionType>\t
 // <nodeId>\t<since>` per line, rendered by the exported `formatQueueRow` below
 // and pinned by its unit test. `rank` is the soft-penalty-adjusted rank, not
-// raw attention.
+// raw attention. These four columns are UNCHANGED by lift advisories: when a
+// member's key was lifted from a blocked source (`liftedFrom !== null`), the
+// "why" goes to stderr as a `NOTE —` line (`formatLiftNote`), never as a fifth
+// stdout column — see the stderr contract above.
 
 import { existsSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -129,6 +132,19 @@ export function formatDisposition(
  */
 export function formatQueueRow(m: QueueMember): string {
   return `${m.rank}\t${m.sessionType}\t${m.nodeId}\t${m.since}`;
+}
+
+/**
+ * The stderr advisory for a queue member whose ordering key was lifted from a
+ * blocked source (`liftedFrom !== null`) — surfaces WHY the hold jumped the
+ * queue. Follows the `formatBlockerNote` `NOTE —` convention. Never called for
+ * a member with `liftedFrom === null`.
+ */
+export function formatLiftNote(m: QueueMember): string {
+  return (
+    `NOTE — ${m.nodeId} ranks at tier ${m.tier}/${m.rank} inherited from blocked source ` +
+    `${m.liftedFrom} (own: tier ${m.ownTier}/${m.ownRank})`
+  );
 }
 
 // --- Argv parsing (pure, exported for tests) --------------------------------
@@ -246,6 +262,9 @@ function main(): void {
   if (wantList) {
     for (const m of officeHoursQueue(nodes, sessionType)) {
       process.stdout.write(`${formatQueueRow(m)}\n`);
+      if (m.liftedFrom !== null) {
+        process.stderr.write(`${formatLiftNote(m)}\n`);
+      }
     }
     return;
   }

--- a/packages/intentionsutil/src/hold-alerts.ts
+++ b/packages/intentionsutil/src/hold-alerts.ts
@@ -105,6 +105,12 @@ export function listUnclaimedHoldAlerts(
   nodes: IntentionNode[],
   opts: HoldAlertOpts,
 ): UnclaimedHoldAlert[] {
+  // top-K of zero means zero sources are "important" — nothing can qualify.
+  // (Not the same as "no cutoff": an absent cutoff below means "fewer than K
+  // eligible nodes exist, so every one of them qualifies" — a positive K that
+  // the pool falls short of, not a K of zero.)
+  if (opts.topK <= 0) return [];
+
   const byId = new Map(nodes.map((n) => [n.id, n]));
   const attention = resolveAttention(nodes);
 
@@ -119,7 +125,7 @@ export function listUnclaimedHoldAlerts(
   }
   pool.sort(compareRankDesc);
   // Fewer than K entries ⇒ no cutoff ⇒ every source qualifies.
-  const cutoff = pool.length >= opts.topK && opts.topK > 0 ? pool[opts.topK - 1] : null;
+  const cutoff = pool.length >= opts.topK ? pool[opts.topK - 1] : null;
 
   const alerts: UnclaimedHoldAlert[] = [];
   for (const candidate of listHoldCandidates(nodes)) {

--- a/packages/intentionsutil/src/hold-alerts.ts
+++ b/packages/intentionsutil/src/hold-alerts.ts
@@ -1,0 +1,162 @@
+// hold-alerts — "which manual holds have been sitting unclaimed in the
+// office-hours queue, while blocking something the graph says is important?"
+//
+// Pure: no filesystem, git, network, or daemon access. The whole decision is
+// made from the `nodes` array handed in, so it is offline-testable with
+// in-memory fixtures — and, because it composes existing primitives rather than
+// re-deriving them, it inherits their invariants for free.
+//
+// Composition:
+//   1. `listHoldCandidates` (./hold-sweep.ts) enumerates and classifies holds.
+//      Alerting keeps only `cls === "manual"` — the holds with no
+//      machine-checkable re-check predicate (`KIND_RECHECK[kind].policy ===
+//      "manual"`, today `provision-conflict` and `fix-attempt-cap`), i.e. the
+//      ones that stay parked until a human or a dedicated session picks them up.
+//      Reusing it as-is is what binds alerting to the canonical hold id, drops
+//      holds whose source is gone, and drops holds whose `blocked_by` edge has
+//      already cleared.
+//   2. `resolveAttention` (./attention.ts), called exactly once, supplies the
+//      `(tier, value)` of the blocked source.
+//   3. Age comes from the hold's own `office_hours.since`.
+
+import { resolveAttention } from "./attention.js";
+import { listHoldCandidates } from "./hold-sweep.js";
+import type { HoldKind } from "./holds.js";
+import type { IntentionNode } from "./schema.js";
+
+/** One manual hold that has gone unclaimed long enough to be worth surfacing. */
+export interface UnclaimedHoldAlert {
+  holdId: string;
+  sourceId: string;
+  kind: HoldKind;
+  ageSeconds: number;
+  sourceTier: number;
+  sourceValue: number;
+}
+
+export interface HoldAlertOpts {
+  /** The clock the age is measured against. */
+  now: Date;
+  /** Minimum age (inclusive) before a hold is alertable. */
+  minAgeSeconds: number;
+  /** How many top-ranked live nodes count as "important" for the source gate. */
+  topK: number;
+}
+
+/** The two-axis rank consumers order by: tier dominates, value breaks ties. */
+interface Rank {
+  tier: number;
+  value: number;
+}
+
+/** Lexicographic descending compare on `(tier, value)` — tier dominates. */
+function compareRankDesc(a: Rank, b: Rank): number {
+  if (a.tier !== b.tier) return b.tier - a.tier;
+  return b.value - a.value;
+}
+
+/** Whether `(tier, value)` is at or above `cutoff`, lexicographically. */
+function atOrAbove(rank: Rank, cutoff: Rank): boolean {
+  if (rank.tier !== cutoff.tier) return rank.tier > cutoff.tier;
+  return rank.value >= cutoff.value;
+}
+
+/**
+ * List the manual-policy holds that have been unclaimed for at least
+ * `opts.minAgeSeconds` while blocking a source in the graph's top `opts.topK`.
+ *
+ * Pure — see the module header.
+ *
+ * **Age.** Measured from the hold node's `office_hours.since` (a `YYYY-MM-DD`
+ * `requireDateString`, `schema.ts:505-511`), as
+ * `floor((opts.now - since) / 1000)`. That field is the right clock precisely
+ * because `decideHold` (`scripts/hold-node-decide.ts:166-170`) deliberately does
+ * NOT refresh `since` on a repeat occurrence — "its age is the signal". And
+ * because `since` is durable graph state, this predicate needs no cross-pass
+ * state file: two passes over the same graph agree without remembering anything.
+ *
+ * A manual-class hold with `office_hours === null` is NEVER emitted, and its
+ * missing `since` is never coerced to age 0. Such a hold is structurally
+ * possible — the terminal test at `hold-sweep.ts:127` requires `phase === "done"`
+ * AND `office_hours === null`, so an unparked, not-yet-done hold classifies
+ * `manual` — but it is not sitting in the office-hours queue at all, and
+ * "unclaimed in the queue" is not a statement about it.
+ *
+ * **Top-K gate.** The pool is every node that is eligible (present in
+ * `resolveAttention`'s map — that map holds exactly the goal-layer-eligible
+ * nodes, per the `kind-<k>.attributes.goal_layer` test), live (`phase !==
+ * "done"`), and unparked (`office_hours === null`). Their `(tier, value)` pairs
+ * are sorted lexicographically descending and the Kth entry is the cutoff; a
+ * candidate is emitted only when its source's `(tier, value)` is at or above it.
+ * With fewer than K such nodes there is no cutoff and every source qualifies.
+ *
+ * Top-K rather than an absolute value floor on purpose: resolved values drift as
+ * the graph changes, so an absolute floor needs periodic retuning, while "is
+ * this blocking one of the top K things in the graph" does not.
+ *
+ * A candidate whose source has no resolved attention (an ineligible source) is
+ * skipped — it has no `(tier, value)` to gate or report on, and by construction
+ * it is not in the top-K pool either.
+ *
+ * @returns Alerts sorted by source `(tier, value)` descending, then `holdId`
+ *   ascending.
+ */
+export function listUnclaimedHoldAlerts(
+  nodes: IntentionNode[],
+  opts: HoldAlertOpts,
+): UnclaimedHoldAlert[] {
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const attention = resolveAttention(nodes);
+
+  // The top-K pool: eligible (in the resolved map), live, unparked.
+  const pool: Rank[] = [];
+  for (const node of nodes) {
+    const resolved = attention.get(node.id);
+    if (resolved === undefined) continue; // not goal-layer eligible
+    if (node.phase === "done") continue;
+    if (node.office_hours !== null) continue;
+    pool.push({ tier: resolved.tier, value: resolved.value });
+  }
+  pool.sort(compareRankDesc);
+  // Fewer than K entries ⇒ no cutoff ⇒ every source qualifies.
+  const cutoff = pool.length >= opts.topK && opts.topK > 0 ? pool[opts.topK - 1] : null;
+
+  const alerts: UnclaimedHoldAlert[] = [];
+  for (const candidate of listHoldCandidates(nodes)) {
+    if (candidate.cls !== "manual") continue;
+
+    const holdNode = byId.get(candidate.holdId);
+    if (holdNode === undefined) continue; // unreachable: candidates come from `nodes`
+    // Not in the office-hours queue at all — see the doc comment. Never coerced
+    // to age 0.
+    if (holdNode.office_hours === null) continue;
+
+    const since = Date.parse(holdNode.office_hours.since);
+    if (Number.isNaN(since)) continue;
+    const ageSeconds = Math.floor((opts.now.getTime() - since) / 1000);
+    if (ageSeconds < opts.minAgeSeconds) continue;
+
+    const sourceRank = attention.get(candidate.sourceId);
+    if (sourceRank === undefined) continue; // ineligible source: nothing to rank
+    if (cutoff !== null && !atOrAbove(sourceRank, cutoff)) continue;
+
+    alerts.push({
+      holdId: candidate.holdId,
+      sourceId: candidate.sourceId,
+      kind: candidate.kind,
+      ageSeconds,
+      sourceTier: sourceRank.tier,
+      sourceValue: sourceRank.value,
+    });
+  }
+
+  alerts.sort((a, b) => {
+    const byRank = compareRankDesc(
+      { tier: a.sourceTier, value: a.sourceValue },
+      { tier: b.sourceTier, value: b.sourceValue },
+    );
+    if (byRank !== 0) return byRank;
+    return a.holdId < b.holdId ? -1 : a.holdId > b.holdId ? 1 : 0;
+  });
+  return alerts;
+}

--- a/packages/intentionsutil/src/officeHours.ts
+++ b/packages/intentionsutil/src/officeHours.ts
@@ -14,14 +14,29 @@ export const SESSION_TYPE_PENALTY = 0.5;
 /** One parked node as it appears in the ordered queue. */
 export interface QueueMember {
   nodeId: string;
-  /** Resolved attention rank; a node absent from the attention map ranks 0. */
+  /**
+   * The queue's ordering rank: the session-type-penalized value of the
+   * surfacing key — the lexicographic max of the node's own resolved
+   * `(tier, value)` and that of every non-`done` node it blocks. A node absent
+   * from the attention map ranks 0.
+   */
   rank: number;
   /**
-   * Resolved attention tier; a node absent from the attention map defaults to
-   * tier 1, matching `resolveAttention`'s default tier. The hard outer sort
-   * key — see `officeHoursQueue`.
+   * The queue's ordering tier: the tier of the surfacing key (see `rank`). A
+   * node absent from the attention map defaults to tier 1, matching
+   * `resolveAttention`'s default tier. The hard outer sort key — see
+   * `officeHoursQueue`.
    */
   tier: number;
+  /** The node's OWN resolved tier, before any blocked-source lift. */
+  ownTier: number;
+  /** The node's OWN penalized rank, before any blocked-source lift. */
+  ownRank: number;
+  /**
+   * The id of the blocking source whose `(tier, value)` lifted this member's
+   * key, or `null` when nothing it blocks outranks it.
+   */
+  liftedFrom: string | null;
   sessionType: SessionType;
   since: string;
 }
@@ -42,11 +57,33 @@ export interface QueueMember {
  * sufficiently boosted penalized node can still overtake an `other` node
  * within the same tier, but it can never cross a tier boundary.
  *
+ * A parked node's key is not its own attention alone: it is the lexicographic
+ * max of its own resolved `(tier, value)` and the resolved `(tier, value)` of
+ * every node it BLOCKS (every node whose `blocked_by` lists it), restricted to
+ * sources not yet at `phase: "done"` — the same "a done blocker is cleared"
+ * convention `openBlockers` uses. A park that is holding up high-attention live
+ * work surfaces with that work's urgency rather than its own, and
+ * `liftedFrom` names the source that supplied the key. The lift is monotone-up:
+ * a member's key can only rise, never fall, so a park that blocks nothing keeps
+ * exactly the key it had before. `ownTier`/`ownRank` always report the
+ * un-lifted values.
+ *
  * When `sessionType` is provided, only parked nodes whose
  * `office_hours.session_type` matches are included.
  */
 export function officeHoursQueue(nodes: IntentionNode[], sessionType?: SessionType): QueueMember[] {
   const attention = resolveAttention(nodes);
+  // reverse.get(id) = the nodes that list `id` in their own blocked_by — i.e.
+  // the nodes `id` blocks. Same shape as `reverseBlockers` in
+  // `computeSignalPath` (attention.ts), which is private to that module.
+  const reverse = new Map<string, IntentionNode[]>();
+  for (const n of nodes) {
+    for (const b of n.blocked_by) {
+      const list = reverse.get(b);
+      if (list) list.push(n);
+      else reverse.set(b, [n]);
+    }
+  }
   const members: QueueMember[] = [];
   for (const n of nodes) {
     // A `continue` guard narrows office_hours to non-null for the body below —
@@ -57,11 +94,38 @@ export function officeHoursQueue(nodes: IntentionNode[], sessionType?: SessionTy
     const penalty =
       st === "requirement-discovery" || st === "curriculum-review" ? SESSION_TYPE_PENALTY : 1;
     const rawRank = attention.get(n.id)?.value ?? 0;
-    const tier = attention.get(n.id)?.tier ?? 1;
+    const ownTier = attention.get(n.id)?.tier ?? 1;
+    // Lexicographic (tier, value) max over {own} ∪ blocked sources. The penalty
+    // is applied AFTER the key is chosen: it is a property of this park's
+    // session type, not of where the value came from, and it must never affect
+    // the tier comparison.
+    let keyTier = ownTier;
+    let keyValue = rawRank;
+    let liftedFrom: string | null = null;
+    for (const src of reverse.get(n.id) ?? []) {
+      if (src.phase === "done") continue;
+      const srcValue = attention.get(src.id)?.value ?? 0;
+      const srcTier = attention.get(src.id)?.tier ?? 1;
+      const better =
+        srcTier > keyTier ||
+        (srcTier === keyTier &&
+          (srcValue > keyValue ||
+            // Ties among sources break by id ascending; a source can never tie
+            // its way past the member's own key (liftedFrom stays null).
+            (srcValue === keyValue && liftedFrom !== null && src.id < liftedFrom)));
+      if (better) {
+        keyTier = srcTier;
+        keyValue = srcValue;
+        liftedFrom = src.id;
+      }
+    }
     members.push({
       nodeId: n.id,
-      rank: rawRank * penalty,
-      tier,
+      rank: keyValue * penalty,
+      tier: keyTier,
+      ownTier,
+      ownRank: rawRank * penalty,
+      liftedFrom,
       sessionType: st,
       since: n.office_hours.since,
     });

--- a/packages/intentionsutil/src/officeHours.ts
+++ b/packages/intentionsutil/src/officeHours.ts
@@ -6,6 +6,7 @@
 // so this module needs nothing beyond the nodes to decide what to launch.
 
 import type { IntentionNode, SessionType } from "./schema.js";
+import type { ResolvedAttention } from "./attention.js";
 import { resolveAttention } from "./attention.js";
 
 /** Soft rank multiplier for penalized session types; author-tunable. */
@@ -73,9 +74,60 @@ export interface QueueMember {
  */
 export function officeHoursQueue(nodes: IntentionNode[], sessionType?: SessionType): QueueMember[] {
   const attention = resolveAttention(nodes);
-  // reverse.get(id) = the nodes that list `id` in their own blocked_by — i.e.
-  // the nodes `id` blocks. Same shape as `reverseBlockers` in
-  // `computeSignalPath` (attention.ts), which is private to that module.
+  const reverse = reverseBlockers(nodes);
+  const members: QueueMember[] = [];
+  for (const n of nodes) {
+    // A `continue` guard narrows office_hours to non-null for the body below —
+    // no cast, and `.since` type-checks.
+    if (n.office_hours === null) continue;
+    const st = n.office_hours.session_type;
+    if (sessionType !== undefined && st !== sessionType) continue;
+    const penalty = sessionTypePenalty(st);
+    const own = attentionKeyOf(attention, n.id);
+    // The penalty is applied AFTER the surfacing key is chosen: it is a
+    // property of this park's session type, not of where the value came from,
+    // and it must never affect the tier comparison.
+    const key = surfacingKey(n, own, reverse, attention);
+    members.push({
+      nodeId: n.id,
+      rank: key.value * penalty,
+      tier: key.tier,
+      ownTier: own.tier,
+      ownRank: own.value * penalty,
+      liftedFrom: key.liftedFrom,
+      sessionType: st,
+      since: n.office_hours.since,
+    });
+  }
+  return members.sort(compareQueueMembers);
+}
+
+/** A resolved `(tier, value)` attention pair, with map-absent defaults applied. */
+interface AttentionKey {
+  tier: number;
+  value: number;
+}
+
+/**
+ * `id`'s resolved attention key. A node absent from the map defaults to
+ * `(tier 1, value 0)` — tier 1 matching `resolveAttention`'s default tier.
+ */
+function attentionKeyOf(attention: Map<string, ResolvedAttention>, id: string): AttentionKey {
+  const resolved = attention.get(id);
+  return { tier: resolved?.tier ?? 1, value: resolved?.value ?? 0 };
+}
+
+/** The soft rank multiplier a parked node earns from its session type. */
+function sessionTypePenalty(st: SessionType): number {
+  return st === "requirement-discovery" || st === "curriculum-review" ? SESSION_TYPE_PENALTY : 1;
+}
+
+/**
+ * `result.get(id)` = the nodes that list `id` in their own `blocked_by` — i.e.
+ * the nodes `id` blocks. Same shape as `reverseBlockers` in `computeSignalPath`
+ * (attention.ts), which is private to that module.
+ */
+function reverseBlockers(nodes: IntentionNode[]): Map<string, IntentionNode[]> {
   const reverse = new Map<string, IntentionNode[]>();
   for (const n of nodes) {
     for (const b of n.blocked_by) {
@@ -84,58 +136,55 @@ export function officeHoursQueue(nodes: IntentionNode[], sessionType?: SessionTy
       else reverse.set(b, [n]);
     }
   }
-  const members: QueueMember[] = [];
-  for (const n of nodes) {
-    // A `continue` guard narrows office_hours to non-null for the body below —
-    // no cast, and `.since` type-checks.
-    if (n.office_hours === null) continue;
-    const st = n.office_hours.session_type;
-    if (sessionType !== undefined && st !== sessionType) continue;
-    const penalty =
-      st === "requirement-discovery" || st === "curriculum-review" ? SESSION_TYPE_PENALTY : 1;
-    const rawRank = attention.get(n.id)?.value ?? 0;
-    const ownTier = attention.get(n.id)?.tier ?? 1;
-    // Lexicographic (tier, value) max over {own} ∪ blocked sources. The penalty
-    // is applied AFTER the key is chosen: it is a property of this park's
-    // session type, not of where the value came from, and it must never affect
-    // the tier comparison.
-    let keyTier = ownTier;
-    let keyValue = rawRank;
-    let liftedFrom: string | null = null;
-    for (const src of reverse.get(n.id) ?? []) {
-      if (src.phase === "done") continue;
-      const srcValue = attention.get(src.id)?.value ?? 0;
-      const srcTier = attention.get(src.id)?.tier ?? 1;
-      const better =
-        srcTier > keyTier ||
-        (srcTier === keyTier &&
-          (srcValue > keyValue ||
-            // Ties among sources break by id ascending; a source can never tie
-            // its way past the member's own key (liftedFrom stays null).
-            (srcValue === keyValue && liftedFrom !== null && src.id < liftedFrom)));
-      if (better) {
-        keyTier = srcTier;
-        keyValue = srcValue;
-        liftedFrom = src.id;
-      }
+  return reverse;
+}
+
+/** A surfacing key: the lifted `(tier, value)` plus the source that supplied it. */
+interface SurfacingKey extends AttentionKey {
+  liftedFrom: string | null;
+}
+
+/**
+ * True when a blocked source's key should replace the key held so far:
+ * lexicographically greater on `(tier, value)`, or — among sources already tied
+ * with an earlier lift — ordered ahead by id. A source can never tie its way
+ * past the member's OWN key, since `liftedFrom` is still null in that case.
+ */
+function liftsKey(src: AttentionKey, srcId: string, key: SurfacingKey): boolean {
+  if (src.tier !== key.tier) return src.tier > key.tier;
+  if (src.value !== key.value) return src.value > key.value;
+  return key.liftedFrom !== null && srcId < key.liftedFrom;
+}
+
+/**
+ * The lexicographic `(tier, value)` max over `{own}` ∪ the not-yet-`done` nodes
+ * that `node` blocks, and the id of the source that supplied it (`null` when
+ * `own` won). Monotone-up: the returned key is never below `own`.
+ */
+function surfacingKey(
+  node: IntentionNode,
+  own: AttentionKey,
+  reverse: Map<string, IntentionNode[]>,
+  attention: Map<string, ResolvedAttention>,
+): SurfacingKey {
+  const key: SurfacingKey = { tier: own.tier, value: own.value, liftedFrom: null };
+  for (const src of reverse.get(node.id) ?? []) {
+    if (src.phase === "done") continue;
+    const srcKey = attentionKeyOf(attention, src.id);
+    if (liftsKey(srcKey, src.id, key)) {
+      key.tier = srcKey.tier;
+      key.value = srcKey.value;
+      key.liftedFrom = src.id;
     }
-    members.push({
-      nodeId: n.id,
-      rank: keyValue * penalty,
-      tier: keyTier,
-      ownTier,
-      ownRank: rawRank * penalty,
-      liftedFrom,
-      sessionType: st,
-      since: n.office_hours.since,
-    });
   }
-  return members.sort(
-    (a, b) =>
-      b.tier - a.tier ||
-      b.rank - a.rank ||
-      (a.nodeId < b.nodeId ? -1 : a.nodeId > b.nodeId ? 1 : 0),
-  );
+  return key;
+}
+
+/** Queue order: tier descending, then penalized rank descending, then id ascending. */
+function compareQueueMembers(a: QueueMember, b: QueueMember): number {
+  if (a.tier !== b.tier) return b.tier - a.tier;
+  if (a.rank !== b.rank) return b.rank - a.rank;
+  return a.nodeId < b.nodeId ? -1 : a.nodeId > b.nodeId ? 1 : 0;
 }
 
 /** An unresolved `blocked_by` edge of a parked node. */

--- a/packages/intentionsutil/test/hold-alerts.test.ts
+++ b/packages/intentionsutil/test/hold-alerts.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+import { listUnclaimedHoldAlerts } from "../src/hold-alerts.js";
+import { holdIdFor, type HoldKind } from "../src/holds.js";
+import type { IntentionNode, OfficeHours } from "../src/schema.js";
+
+/** Minimal full IntentionNode fixture (mirrors hold-sweep.test.ts's `anode`). */
+function anode(partial: Partial<IntentionNode> & { id: string; kind: string }): IntentionNode {
+  return {
+    id: partial.id,
+    kind: partial.kind,
+    statement: partial.statement ?? `Statement for ${partial.id}`,
+    owner: partial.owner ?? "ai",
+    status: partial.status ?? "codified",
+    parent: partial.parent ?? null,
+    serves: partial.serves ?? [],
+    recovers: partial.recovers ?? [],
+    rationale: partial.rationale ?? null,
+    reading: partial.reading ?? null,
+    gap: partial.gap ?? null,
+    clarifications: partial.clarifications ?? [],
+    tooling_goals: partial.tooling_goals ?? [],
+    success_signal: partial.success_signal ?? null,
+    attention: partial.attention ?? null,
+    phase: partial.phase ?? null,
+    execution: partial.execution ?? null,
+    validates: partial.validates ?? [],
+    blocked_by: partial.blocked_by ?? [],
+    office_hours: partial.office_hours ?? null,
+    pace_exempt: partial.pace_exempt ?? false,
+    rounds: partial.rounds ?? null,
+    attributes: partial.attributes ?? {},
+  };
+}
+
+/** A parking record dated `since` (the age clock this module reads). */
+function parked(since: string): OfficeHours {
+  return {
+    reason: "merge conflict against a moving main",
+    since,
+    recommendation: null,
+    session_type: "other",
+  };
+}
+
+const PARKED: OfficeHours = parked("2026-07-30");
+
+/**
+ * The kind nodes eligibility is data on: kind-tactic carries `goal_layer: true`,
+ * so tactics get a resolved-attention entry (mirrors attention.test.ts).
+ */
+function kinds(): IntentionNode[] {
+  return [
+    anode({ id: "kind-kind", kind: "kind" }),
+    anode({ id: "kind-tactic", kind: "kind", attributes: { goal_layer: true } }),
+  ];
+}
+
+/**
+ * A hold node of `kind` holding `sourceId`, at its CANONICAL derived id — the
+ * binding `listHoldCandidates` enforces.
+ */
+function hold(
+  sourceId: string,
+  kind: HoldKind,
+  partial: Partial<IntentionNode> = {},
+): IntentionNode {
+  return anode({
+    id: holdIdFor(kind, sourceId),
+    kind: "tactic",
+    phase: "implement",
+    office_hours: PARKED,
+    attributes: { hold_kind: kind, hold_for: sourceId },
+    ...partial,
+  });
+}
+
+/** The source node a hold blocks, boosted to `boost` and optionally tiered. */
+function source(
+  id: string,
+  blockedBy: string[],
+  boost: number,
+  tier?: 2 | 3,
+): IntentionNode {
+  return anode({
+    id,
+    kind: "tactic",
+    phase: "implement",
+    blocked_by: blockedBy,
+    attention: { boost, override: null, rationale: "because", tier: 1 },
+    attributes: tier === undefined ? {} : { tier },
+  });
+}
+
+/** 2026-08-04T00:00:00Z; a hold parked 2026-07-30 is 5 days (432000s) old. */
+const NOW = new Date("2026-08-04T00:00:00Z");
+const FIVE_DAYS = 5 * 24 * 3600;
+
+describe("listUnclaimedHoldAlerts", () => {
+  it("emits a manual hold over the age bound blocking a top-K source", () => {
+    const h = hold("tactic-a", "provision-conflict");
+    const nodes = [...kinds(), h, source("tactic-a", [h.id], 5)];
+    expect(listUnclaimedHoldAlerts(nodes, { now: NOW, minAgeSeconds: 3600, topK: 5 })).toEqual([
+      {
+        holdId: "tactic-hold-conflict-a",
+        sourceId: "tactic-a",
+        kind: "provision-conflict",
+        ageSeconds: FIVE_DAYS,
+        sourceTier: 1,
+        sourceValue: 5,
+      },
+    ]);
+  });
+
+  it("does not emit the same hold under the age bound", () => {
+    const h = hold("tactic-a", "provision-conflict");
+    const nodes = [...kinds(), h, source("tactic-a", [h.id], 5)];
+    expect(
+      listUnclaimedHoldAlerts(nodes, { now: NOW, minAgeSeconds: FIVE_DAYS + 1, topK: 5 }),
+    ).toEqual([]);
+  });
+
+  it("emits at exactly the age bound (inclusive)", () => {
+    const h = hold("tactic-a", "provision-conflict");
+    const nodes = [...kinds(), h, source("tactic-a", [h.id], 5)];
+    const result = listUnclaimedHoldAlerts(nodes, {
+      now: NOW,
+      minAgeSeconds: FIVE_DAYS,
+      topK: 5,
+    });
+    expect(result.map((a) => a.holdId)).toEqual(["tactic-hold-conflict-a"]);
+  });
+
+  it("does not emit a hold blocking a source outside the top K", () => {
+    const low = hold("tactic-low", "provision-conflict");
+    const nodes = [
+      ...kinds(),
+      low,
+      source("tactic-low", [low.id], 1),
+      source("tactic-hot", [], 9),
+    ];
+    // topK: 1 ⇒ cutoff is tactic-hot's rank; tactic-low is below it.
+    expect(listUnclaimedHoldAlerts(nodes, { now: NOW, minAgeSeconds: 0, topK: 1 })).toEqual([]);
+    // Widening K to 2 admits it.
+    const wider = listUnclaimedHoldAlerts(nodes, { now: NOW, minAgeSeconds: 0, topK: 2 });
+    expect(wider.map((a) => a.holdId)).toEqual(["tactic-hold-conflict-low"]);
+  });
+
+  it("never emits an auto-policy (worktree-residue) hold", () => {
+    const h = hold("tactic-a", "worktree-residue");
+    const nodes = [...kinds(), h, source("tactic-a", [h.id], 5)];
+    expect(listUnclaimedHoldAlerts(nodes, { now: NOW, minAgeSeconds: 0, topK: 5 })).toEqual([]);
+  });
+
+  it("emits a fix-attempt-cap hold — the other manual-policy kind", () => {
+    const h = hold("tactic-a", "fix-attempt-cap");
+    const nodes = [...kinds(), h, source("tactic-a", [h.id], 5)];
+    const result = listUnclaimedHoldAlerts(nodes, { now: NOW, minAgeSeconds: 0, topK: 5 });
+    expect(result.map((a) => [a.holdId, a.kind])).toEqual([
+      ["tactic-hold-fix-cap-a", "fix-attempt-cap"],
+    ]);
+  });
+
+  it("does not emit a hold whose source's blocked_by edge already cleared", () => {
+    // Inherited from listHoldCandidates: no edge, nothing is being held.
+    const h = hold("tactic-a", "provision-conflict");
+    const nodes = [...kinds(), h, source("tactic-a", [], 5)];
+    expect(listUnclaimedHoldAlerts(nodes, { now: NOW, minAgeSeconds: 0, topK: 5 })).toEqual([]);
+  });
+
+  it("does not emit a manual hold with office_hours === null", () => {
+    // Structurally possible (terminal requires phase done AND office_hours
+    // null), but it is not sitting in the queue — and its missing `since` is
+    // never coerced to age 0.
+    const h = hold("tactic-a", "provision-conflict", { office_hours: null });
+    const nodes = [...kinds(), h, source("tactic-a", [h.id], 5)];
+    expect(listUnclaimedHoldAlerts(nodes, { now: NOW, minAgeSeconds: 0, topK: 5 })).toEqual([]);
+  });
+
+  it("orders by source (tier, value) descending", () => {
+    const a = hold("tactic-a", "provision-conflict");
+    const b = hold("tactic-b", "provision-conflict");
+    const nodes = [
+      ...kinds(),
+      a,
+      source("tactic-a", [a.id], 2),
+      b,
+      source("tactic-b", [b.id], 8),
+    ];
+    const result = listUnclaimedHoldAlerts(nodes, { now: NOW, minAgeSeconds: 0, topK: 5 });
+    expect(result.map((r) => r.sourceId)).toEqual(["tactic-b", "tactic-a"]);
+  });
+
+  it("breaks (tier, value) ties by holdId ascending", () => {
+    const a = hold("tactic-a", "provision-conflict");
+    const b = hold("tactic-b", "provision-conflict");
+    const nodes = [
+      ...kinds(),
+      b,
+      source("tactic-b", [b.id], 5),
+      a,
+      source("tactic-a", [a.id], 5),
+    ];
+    const result = listUnclaimedHoldAlerts(nodes, { now: NOW, minAgeSeconds: 0, topK: 5 });
+    expect(result.map((r) => r.holdId)).toEqual([
+      "tactic-hold-conflict-a",
+      "tactic-hold-conflict-b",
+    ]);
+  });
+
+  it("lets tier dominate value in both ordering and the top-K cutoff", () => {
+    const lowTierHot = hold("tactic-a", "provision-conflict");
+    const highTierCold = hold("tactic-b", "provision-conflict");
+    const nodes = [
+      ...kinds(),
+      lowTierHot,
+      source("tactic-a", [lowTierHot.id], 9), // tier 1, value 9
+      highTierCold,
+      source("tactic-b", [highTierCold.id], 0, 3), // tier 3, value 0
+    ];
+    const result = listUnclaimedHoldAlerts(nodes, { now: NOW, minAgeSeconds: 0, topK: 5 });
+    expect(result.map((r) => [r.sourceId, r.sourceTier, r.sourceValue])).toEqual([
+      ["tactic-b", 3, 0],
+      ["tactic-a", 1, 9],
+    ]);
+    // And with K narrowed to 1, the tier-3 source is the only one at/above cutoff.
+    const narrow = listUnclaimedHoldAlerts(nodes, { now: NOW, minAgeSeconds: 0, topK: 1 });
+    expect(narrow.map((r) => r.sourceId)).toEqual(["tactic-b"]);
+  });
+
+  it("applies no cutoff when fewer than K live unparked eligible nodes exist", () => {
+    const h = hold("tactic-a", "provision-conflict");
+    const nodes = [...kinds(), h, source("tactic-a", [h.id], 0)];
+    const result = listUnclaimedHoldAlerts(nodes, { now: NOW, minAgeSeconds: 0, topK: 100 });
+    expect(result.map((r) => r.holdId)).toEqual(["tactic-hold-conflict-a"]);
+  });
+
+  it("measures age from office_hours.since, not from any repeat occurrence", () => {
+    const older = hold("tactic-a", "provision-conflict", { office_hours: parked("2026-07-04") });
+    const nodes = [...kinds(), older, source("tactic-a", [older.id], 5)];
+    const result = listUnclaimedHoldAlerts(nodes, { now: NOW, minAgeSeconds: 0, topK: 5 });
+    expect(result[0].ageSeconds).toBe(31 * 24 * 3600);
+  });
+});

--- a/packages/intentionsutil/test/office-hours.test.ts
+++ b/packages/intentionsutil/test/office-hours.test.ts
@@ -13,6 +13,7 @@ import {
 import type { SessionType } from "../src/schema.js";
 import {
   formatDisposition,
+  formatLiftNote,
   formatQueueRow,
   parseSelectorArgs,
   resolveSessionCwd,
@@ -674,6 +675,39 @@ describe("formatQueueRow", () => {
     });
     expect(row).toBe("12.5\tcurriculum-review\ttactic-a\t2026-07-01");
     expect(row.split("\t")).toEqual(["12.5", "curriculum-review", "tactic-a", "2026-07-01"]);
+  });
+
+  it("emits exactly four tab-separated fields, even for a lifted member", () => {
+    const row = formatQueueRow({
+      nodeId: "tactic-b",
+      rank: 30,
+      tier: 3,
+      ownTier: 1,
+      ownRank: 5,
+      liftedFrom: "tactic-blocked",
+      sessionType: "other",
+      since: "2026-08-01",
+    });
+    expect(row.split("\t")).toHaveLength(4);
+    expect(row).toBe("30\tother\ttactic-b\t2026-08-01");
+  });
+});
+
+describe("formatLiftNote", () => {
+  it("renders the advisory naming the lifted-from source and own values", () => {
+    const note = formatLiftNote({
+      nodeId: "tactic-b",
+      rank: 30,
+      tier: 3,
+      ownTier: 1,
+      ownRank: 5,
+      liftedFrom: "tactic-blocked",
+      sessionType: "other",
+      since: "2026-08-01",
+    });
+    expect(note).toBe(
+      "NOTE — tactic-b ranks at tier 3/30 inherited from blocked source tactic-blocked (own: tier 1/5)",
+    );
   });
 });
 

--- a/packages/intentionsutil/test/office-hours.test.ts
+++ b/packages/intentionsutil/test/office-hours.test.ts
@@ -230,6 +230,198 @@ describe("officeHoursQueue", () => {
     expect(filtered.map((m) => m.nodeId)).toEqual(["tactic-reqdisc"]);
     expect(filtered.every((m) => m.sessionType === "requirement-discovery")).toBe(true);
   });
+
+  it("lifts a parked hold to the rank of the live work it blocks", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "tactic-hold", kind: "tactic", office_hours: parked() }),
+      anode({
+        id: "tactic-source",
+        kind: "tactic",
+        attention: boost(60),
+        phase: "implement",
+        blocked_by: ["tactic-hold"],
+      }),
+      anode({
+        id: "tactic-unrelated",
+        kind: "tactic",
+        attention: boost(40),
+        office_hours: parked(),
+      }),
+    ];
+
+    const queue = officeHoursQueue(nodes);
+
+    expect(queue.map((m) => m.nodeId)).toEqual(["tactic-hold", "tactic-unrelated"]);
+    const hold = queue.find((m) => m.nodeId === "tactic-hold");
+    expect(hold?.rank).toBe(60);
+    expect(hold?.ownRank).toBe(0);
+    expect(hold?.liftedFrom).toBe("tactic-source");
+  });
+
+  it("lifts the tier when a blocking source is at a higher tier (tier dominates value)", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "tactic-hold", kind: "tactic", attention: boost(100), office_hours: parked() }),
+      anode({
+        id: "tactic-source",
+        kind: "tactic",
+        attention: boost(1),
+        attributes: { tier: 2 },
+        phase: "implement",
+        blocked_by: ["tactic-hold"],
+      }),
+    ];
+
+    const hold = officeHoursQueue(nodes).find((m) => m.nodeId === "tactic-hold");
+
+    expect(hold?.tier).toBe(2);
+    expect(hold?.rank).toBe(1);
+    expect(hold?.ownTier).toBe(1);
+    expect(hold?.ownRank).toBe(100);
+    expect(hold?.liftedFrom).toBe("tactic-source");
+  });
+
+  it("takes the max over several blocking sources", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "tactic-hold", kind: "tactic", office_hours: parked() }),
+      anode({
+        id: "tactic-src-low",
+        kind: "tactic",
+        attention: boost(5),
+        phase: "implement",
+        blocked_by: ["tactic-hold"],
+      }),
+      anode({
+        id: "tactic-src-high",
+        kind: "tactic",
+        attention: boost(30),
+        phase: "implement",
+        blocked_by: ["tactic-hold"],
+      }),
+    ];
+
+    const hold = officeHoursQueue(nodes).find((m) => m.nodeId === "tactic-hold");
+
+    expect(hold?.rank).toBe(30);
+    expect(hold?.liftedFrom).toBe("tactic-src-high");
+  });
+
+  it("breaks a tie between equal blocking sources by id ascending", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "tactic-hold", kind: "tactic", office_hours: parked() }),
+      anode({
+        id: "tactic-src-z",
+        kind: "tactic",
+        attention: boost(9),
+        phase: "implement",
+        blocked_by: ["tactic-hold"],
+      }),
+      anode({
+        id: "tactic-src-a",
+        kind: "tactic",
+        attention: boost(9),
+        phase: "implement",
+        blocked_by: ["tactic-hold"],
+      }),
+    ];
+
+    const hold = officeHoursQueue(nodes).find((m) => m.nodeId === "tactic-hold");
+
+    expect(hold?.rank).toBe(9);
+    expect(hold?.liftedFrom).toBe("tactic-src-a");
+  });
+
+  it("does not lift from a blocking source already at phase done (cleared blocker)", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "tactic-hold", kind: "tactic", attention: boost(2), office_hours: parked() }),
+      anode({
+        id: "tactic-src-done",
+        kind: "tactic",
+        attention: boost(50),
+        phase: "done",
+        blocked_by: ["tactic-hold"],
+      }),
+    ];
+
+    const hold = officeHoursQueue(nodes).find((m) => m.nodeId === "tactic-hold");
+
+    expect(hold?.rank).toBe(2);
+    expect(hold?.tier).toBe(1);
+    expect(hold?.liftedFrom).toBeNull();
+  });
+
+  it("keeps its own key when it outranks every blocking source", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "tactic-hold", kind: "tactic", attention: boost(20), office_hours: parked() }),
+      anode({
+        id: "tactic-source",
+        kind: "tactic",
+        attention: boost(3),
+        phase: "implement",
+        blocked_by: ["tactic-hold"],
+      }),
+    ];
+
+    const hold = officeHoursQueue(nodes).find((m) => m.nodeId === "tactic-hold");
+
+    expect(hold?.rank).toBe(20);
+    expect(hold?.ownRank).toBe(20);
+    expect(hold?.liftedFrom).toBeNull();
+  });
+
+  it("applies the session-type penalty to a lifted value without crossing a tier", () => {
+    const nodes = [
+      ...kinds(),
+      anode({
+        id: "tactic-hold",
+        kind: "tactic",
+        office_hours: parkedTyped("requirement-discovery"),
+      }),
+      anode({
+        id: "tactic-source",
+        kind: "tactic",
+        attention: boost(40),
+        phase: "implement",
+        blocked_by: ["tactic-hold"],
+      }),
+      anode({
+        id: "tactic-tier2",
+        kind: "tactic",
+        attention: boost(1),
+        attributes: { tier: 2 },
+        office_hours: parked(),
+      }),
+    ];
+
+    const queue = officeHoursQueue(nodes);
+    const hold = queue.find((m) => m.nodeId === "tactic-hold");
+
+    expect(hold?.rank).toBe(40 * SESSION_TYPE_PENALTY);
+    expect(hold?.ownRank).toBe(0);
+    expect(hold?.tier).toBe(1);
+    // The penalized lift is huge, but tier is still the hard outer axis.
+    expect(queue.map((m) => m.nodeId)).toEqual(["tactic-tier2", "tactic-hold"]);
+  });
+
+  it("leaves a parked node with no inbound blocked_by edges unchanged", () => {
+    const nodes = [
+      ...kinds(),
+      anode({ id: "tactic-alone", kind: "tactic", attention: boost(7), office_hours: parked() }),
+      anode({ id: "tactic-elsewhere", kind: "tactic", attention: boost(90), phase: "implement" }),
+    ];
+
+    const alone = officeHoursQueue(nodes).find((m) => m.nodeId === "tactic-alone");
+
+    expect(alone?.liftedFrom).toBeNull();
+    expect(alone?.rank).toBe(alone?.ownRank);
+    expect(alone?.tier).toBe(alone?.ownTier);
+    expect(alone?.rank).toBe(7);
+  });
 });
 
 describe("openBlockers", () => {
@@ -474,6 +666,9 @@ describe("formatQueueRow", () => {
       nodeId: "tactic-a",
       rank: 12.5,
       tier: 1,
+      ownTier: 1,
+      ownRank: 12.5,
+      liftedFrom: null,
       sessionType: "curriculum-review",
       since: "2026-07-01",
     });


### PR DESCRIPTION
Graph node: tactic-unclaimed-hold-alerting

## Summary

A manual-policy hold (`provision-conflict`, `fix-attempt-cap`) blocking a
top-ranked source node had no active alerting surface — it sat in the generic
office-hours pull queue ranked by its OWN near-zero attention, so the
highest-attention work in the graph could stay silently blocked indefinitely.
Two halves, both landed here.

- **Priority** — `officeHoursQueue` now lifts a parked node's surfacing key
  to the lexicographic max of its own resolved `(tier, value)` and the
  `(tier, value)` of every live node it blocks, so a hold blocking top-ranked
  work no longer sits behind unrelated low-attention parks. `resolveAttention`
  / `attention.ts` are untouched — this is a surfacing-layer change only.
- **Active alerting** — a new read-only enumerator and fleet-watch predicate
  raise a `tactic-fleet-alarm-unclaimed-hold` node when a manual-policy hold
  has blocked top-K live work past an age bound with no session claiming
  either the source or the hold. Never a fleet halt, never an `office_hours`
  park, never a `blocked_by` write — its only side effect is its own alarm
  node via `dispatch-fleet-alarm`.

## Units delivered

**Unit 1 — `packages/intentionsutil/src/officeHours.ts`.** `QueueMember`
gains `ownTier`/`ownRank` (pre-lift, penalty applied) and `liftedFrom`. A
reverse-blocker index is built once per call; a parked member's key is lifted
from the max `(tier, value)` over itself and every non-`done` inbound
blocker. The session-type penalty still applies post-lift and never crosses a
tier boundary. Byte-identical for nodes with no inbound `blocked_by` edges.

**Unit 2 — `packages/intentionsutil/scripts/office-hours-select.ts`.** A new
`formatLiftNote` writes one `NOTE — …` stderr advisory per lifted queue
member in `--list`, naming the blocked source. `formatQueueRow`'s
four-column stdout contract (consumed positionally by `office-hours-graph`)
is untouched.

**Unit 3 — `packages/intentionsutil/src/hold-alerts.ts` +
`scripts/list-unclaimed-hold-alerts.ts`.** A pure `listUnclaimedHoldAlerts`
composes `listHoldCandidates` (manual-policy holds only) with one
`resolveAttention` call: age from the hold's `office_hours.since` (never
refreshed, so it's a sound age clock), a top-K cutoff over eligible live
unparked nodes rather than an absolute value floor (resolved values drift as
the graph changes). New read-only TSV CLI copies the `list-recheckable-holds`
shape; that file's own TSV contract is untouched.

**Unit 4 — `dispatch-fleet-alarm` / `dispatch-fleet-watch` /
`test-dispatch-fleet-watch.sh`.** New `unclaimed-hold` alarm kind (2-line
addition to the closed enum). New fleet-watch predicate 5: resolves the main
worktree, runs Unit 3's CLI as its enumerator (test-seam overridable), and
drops any candidate whose source or hold id is claimed (`reservation_exists`
OR `worktree_has_live_session` against the full worktree path). An unreadable
agents-daemon snapshot forces `unknown` rather than folding to "occupied" —
an unknown-as-occupied would be a false all-clear for an alert, unlike the
resolve-sweep's fail-safe-keep direction. Detail body carries only sorted
`<hold-id> → <source-id>` pairs and thresholds — never ages or resolved
values, which churn on every graph commit. Evaluated under pause, like
predicates 2 and 4.

## Verification

- `npx vitest run --project packages/intentionsutil --root .` — 41 files,
  806 tests, all passing.
- `.claude/skills/dispatch-propagate/scripts/test-dispatch-fleet-watch.sh` —
  124 passed, 0 failed.
- `.claude/skills/dispatch-propagate/scripts/test-dispatch-fleet-alarm.sh` —
  86 passed, 0 failed.
- `run-typecheck.sh --app packages/intentionsutil` — clean.
- `run-lint.sh --app packages/intentionsutil` — clean.
- CLI smoke-tested against the live `intentions/` store.
