### PR TITLE
graph: lazy clarification ids + citation resolution (tactic-clarification-citation-ids)

### DIFF
--- a/intentions/strategy-graph-native-dispatch.md
+++ b/intentions/strategy-graph-native-dispatch.md
@@ -825,13 +825,14 @@ clarifications:
       if its re-entry routing re-runs check-node-selection — the draft tactic's
       first unit verifies that overlap before implementing. Recorded 2026-07-19
       /align-strategy interview."
-  - question: The 2026-07-16 reaping clarification reaps a node-worker session on
-      EVERY terminal exit, and its edge case (c) reaps a mid-phase-dead
-      (crashed) worker's orphaned job via the tick/sweep pass. But a session
-      that terminated WITHOUT a clean phase-transition and WITHOUT an
-      escalation-park has no durable record anywhere — it was not parked to the
-      office-hours queue, so nothing carries its failure context except the live
-      session itself. Should auto-close really fire on those exits?
+  - question: Clarification `strategy-graph-native-dispatch#reaping`
+      (2026-07-16) reaps a node-worker session on EVERY terminal exit, and its
+      edge case (c) reaps a mid-phase-dead (crashed) worker's orphaned job via
+      the tick/sweep pass. But a session that terminated WITHOUT a clean
+      phase-transition and WITHOUT an escalation-park has no durable record
+      anywhere — it was not parked to the office-hours queue, so nothing carries
+      its failure context except the live session itself. Should auto-close
+      really fire on those exits?
     answer: "No — auto-close (reap) is narrowed to fire ONLY on a clean
       phase-transition or an escalation-park; every OTHER terminal exit — a hard
       crash, an error exit, or a clean-but-no-transition/no-progress exit —
@@ -844,15 +845,15 @@ clarifications:
       parked to office-hours (so it never reaches the PARKED panel, the
       office-hours-debuggable channel) and it did not advance the phase, so the
       live session is the only artifact of the failure. Reaping it would
-      silently erase the one thing a debugger has. This DIVERGES from the
-      2026-07-16 clarification's edge case (c) (which reaped the crashed job via
-      the sweep) and narrows 'reaped on every terminal exit' (its main body, and
-      edge case (b)'s
+      silently erase the one thing a debugger has. This DIVERGES from
+      `strategy-graph-native-dispatch#reaping`'s edge case (c) (which reaped the
+      crashed job via the sweep) and narrows 'reaped on every terminal exit'
+      (its main body, and edge case (b)'s
       reap-then-fuse-re-selects-after-a-silent-no-transition-exit) to 'reaped
       iff the exit transitioned or parked the node'. It does NOT re-open the
-      session-as-observability coupling the 2026-07-16 clarification rejected: a
-      kept failed session is a DEBUGGING ARTIFACT a human inspects, not a
-      recovery substrate (session attach/resume is still not a supported
+      session-as-observability coupling `strategy-graph-native-dispatch#reaping`
+      rejected: a kept failed session is a DEBUGGING ARTIFACT a human inspects,
+      not a recovery substrate (session attach/resume is still not a supported
       recovery path — the router never resumes from a kept session; the human
       reaps it and the node re-selects fresh or is fixed forward) and not the
       escalation channel (real escalations still park to office-hours).
@@ -873,10 +874,11 @@ clarifications:
       minimal count' over 'no new surface', this round]. Retained as draft
       tactic-frozen-session-debug-count. (d) COMPOSITION with the 2026-07-19
       keep-all toggle — the DEFAULT itself narrows to 'reap iff
-      transitioned-or-parked' (this amends all three recorded sites: the
-      2026-07-16 reaping clarification, the 2026-07-19 configurable-auto-close
-      clarification, and the reap condition); the keep-all toggle
-      (tactic-worker-self-close-configurable) layers ON TOP — when ON it
+      transitioned-or-parked' (this amends all three recorded sites:
+      `strategy-graph-native-dispatch#reaping`, the 2026-07-19
+      configurable-auto-close clarification, and the reap condition); the
+      keep-all toggle (tactic-worker-self-close-configurable) layers ON TOP —
+      when ON it
       additionally keeps the transitioned/parked sessions the narrowed default
       would otherwise reap; both the transition-or-park check and the toggle
       live in the shared self-close primitive [author chose 'narrow default;

--- a/intentions/strategy-graph-native-dispatch.md
+++ b/intentions/strategy-graph-native-dispatch.md
@@ -279,7 +279,8 @@ clarifications:
     answer: A selected node’s scope or state changes after selection — before its
       worker starts, or while it runs. What closes the window? — See body
       §Fingerprint & Freeze. Recorded 2026-07-06 interview.
-  - question: Does long-horizon graph work keep a workflow or session alive?
+  - id: disposable-session
+    question: Does long-horizon graph work keep a workflow or session alive?
     answer: Does long-horizon graph work keep a workflow or session alive? — See
       body §Execution Substrate for the full mechanism. Recorded 2026-07-06
       interview.
@@ -495,7 +496,8 @@ clarifications:
       Does the cost of the fix versus the cost of deferring it also bear on the
       disposition? — See body §Review & QA Disposition for the full mechanism.
       Recorded 2026-07-13 interview.
-  - question: After a node worker terminates, is its session removed from the agents
+  - id: reaping
+    question: After a node worker terminates, is its session removed from the agents
       list — and does an escalation-parked session stay for the author to
       engage?
     answer: After a node worker terminates, is its session removed from the agents
@@ -602,8 +604,9 @@ clarifications:
       off-path demotion covers the recorded requirement’s own rank; the freeze
       tax of the recording edit itself — every stamped child paying a
       re-evaluation session even for an orthogonal edit — is addressed
-      separately by the materiality-scoped-freeze clarification.)"
-  - question: A strategy edit soft-freezes every stamped open child regardless of
+      separately by `strategy-graph-native-dispatch#materiality-scoped-freeze`.)"
+  - id: materiality-scoped-freeze
+    question: A strategy edit soft-freezes every stamped open child regardless of
       relevance or rank (a low-rank edit such as the 2026-07-18 skill-rename
       round stales every stamped in-flight child) — should the freeze decision
       incorporate a rank comparison, and how does a stale child recover WHAT
@@ -703,16 +706,17 @@ clarifications:
       owns which ladder layer? — See body §Serialization & Commit for the full
       mechanism. Recorded 2026-07-19 /align-strategy round.
   - question: Should auto-close of a completed worker session be configurable, given
-      the 2026-07-16 reaping clarification reaps on every terminal exit and
-      diverged from the session-as-observability rival?
+      `strategy-graph-native-dispatch#reaping` (2026-07-16) reaps on every
+      terminal exit and diverged from the session-as-observability rival?
     answer: "Yes — auto-close is made configurable via a default-off operator escape
       hatch, and this does NOT weaken the reaping doctrine. Auto-close (reap on
       every terminal exit) remains the DEFAULT and the doctrinal expression of
       disposable sessions; the toggle, off by default, lets an operator KEEP a
       completed or escalation-parked worker session for local
       inspection/debugging. The doctrine holds because its actual concern —
-      established by the disposable-session clarification and the 2026-07-16
-      reaping clarification's divergence from the session-as-observability rival
+      established by `strategy-graph-native-dispatch#disposable-session` and by
+      the divergence of `strategy-graph-native-dispatch#reaping` (2026-07-16)
+      from the session-as-observability rival
       — is that session persistence must never become router SUBSTRATE or the
       observability CHANNEL, not the bare existence of a lingering session; the
       author affirmed this reading of the divergence's intent this round. A
@@ -1277,9 +1281,10 @@ clarifications:
       ceiling (boost 100), which the 2026-07-13 guard keeps dominant — the
       ledger fix is important but is not a red-main emergency. (Amended
       2026-07-26: the \"$XDG_DATA_HOME/commons-dispatch/paused\" sentinel named
-      here is superseded by a dispatch.config/*.json boolean field — see the
-      pause-field clarification of that date. The mechanism this clarification
-      protects is unchanged: pause gates worker SPAWNING only and never ledger
+      here is superseded by a dispatch.config/*.json boolean field — see
+      `strategy-graph-native-dispatch#pause-field`. The mechanism this
+      clarification protects is unchanged: pause gates worker SPAWNING only and
+      never ledger
       BOOKKEEPING, and the pre-short-circuit ledger sweep still runs on a paused
       tick.)"
   - question: Does the greenfield design enforce serialization of work on the
@@ -1621,11 +1626,13 @@ clarifications:
       accepted deliberately: this round LOWERS the repo's literal XDG usage
       rather than raising it, because the one dispatch parameter that was
       XDG-compliant (the pause flag at $XDG_DATA_HOME/commons-dispatch/paused)
-      moves into the non-XDG dispatch.config/ — see the pause-field
-      clarification of the same date. Unrelated XDG uses elsewhere (topic-usage
+      moves into the non-XDG dispatch.config/ — see
+      `strategy-graph-native-dispatch#pause-field` (same date). Unrelated XDG
+      uses elsewhere (topic-usage
       state under $XDG_STATE_HOME, systemd user units under $XDG_CONFIG_HOME,
       the budget skill's own config) are untouched and out of scope."
-  - question: Should "dispatch scheduling paused" (default false) stay a filesystem
+  - id: pause-field
+    question: Should "dispatch scheduling paused" (default false) stay a filesystem
       sentinel at $XDG_DATA_HOME/commons-dispatch/paused, or become a
       dispatch.config/*.json field like the other operator-facing dispatch
       parameters?
@@ -2727,7 +2734,8 @@ clarifications:
       tactic-terminal-declaration-verified-against-node. Distinct from
       tactic-qa-fix-node-terminal-declaration, which covers the opposite (safe)
       direction of a missing declaration and its mechanical guard."
-  - question: The 2026-07-26 pause-field clarification's rationale lists the worker
+  - question: The rationale of `strategy-graph-native-dispatch#pause-field`
+      (2026-07-26) lists the worker
       auto-close toggle among operator parameters that "already resolve through
       dispatch-config-load". Is that true of the toggle today, and does it
       change where the toggle belongs?
@@ -3633,8 +3641,9 @@ clarifications:
       event carries no already-readable signal the release predicate is CALENDAR
       TIME (attributes.wait_until), and the attempt counter's survival across a
       re-wait — which this entry left open — is settled by re-arming one node in
-      place rather than re-minting. See the calendar-release clarification of
-      this date for both, including the router.ts:343-355 exclusion this entry
+      place rather than re-minting. See
+      `strategy-graph-native-dispatch#calendar-release` (this date) for both,
+      including the router.ts:343-355 exclusion this entry
       already requires, which now must cover a RE-ARMED node too (a re-arm
       returns the node to phase-less, so it re-enters the draft-candidate loop
       this exclusion guards).
@@ -3789,7 +3798,8 @@ clarifications:
       marked set that grows without bound is that condition failing — which
       parks this strategy for an author decision — rather than a silently
       absorbed cost.
-  - question: The ratified WAIT releases "when the observation lands" — but for
+  - id: calendar-release
+    question: The ratified WAIT releases "when the observation lands" — but for
       deploy lag, detecting the observation IS running the test. What releases a
       WAIT whose event has no readable signal, and what survives a re-wait?
     answer: >
@@ -4337,7 +4347,7 @@ attributes:
       count) must hold in it without relying on the autonomous heartbeat's
       reaper (Amended 2026-07-26: the pause SENTINEL named in this condition is
       replaced by a dispatch.config/*.json boolean field as the sole mechanism —
-      see the pause-field clarification of that date. Every clause of this
+      see `strategy-graph-native-dispatch#pause-field`. Every clause of this
       condition carries over to the field unchanged, and pause evaluation
       additionally fails CLOSED: any config resolve/read/parse failure is
       treated as paused, never as not-paused.)"

--- a/packages/intentionsutil/src/router.ts
+++ b/packages/intentionsutil/src/router.ts
@@ -106,12 +106,20 @@ export interface GraphSelection {
  *
  * `serves` is order-normalized (sorted) so an edge reorder is not substance;
  * clarifications keep author order (their sequence is meaningful dialectic
- * history).
+ * history). Each clarification's `id` is included in the hashed shape only
+ * when non-null: `id: null` is the overwhelming common case (no citation slug
+ * assigned yet) and predates the `id` field entirely, so it must hash exactly
+ * as `{question, answer}` did before `id` existed — otherwise this
+ * schema-widening alone would falsely invalidate every already-stamped
+ * fingerprint graph-wide. Assigning a real (non-null) id IS a substantive
+ * edit — a citable slug being added/changed/removed — so it stays hashed.
  */
 export function strategyFingerprint(strategy: IntentionNode): string {
   const substance = {
     statement: strategy.statement,
-    clarifications: strategy.clarifications,
+    clarifications: strategy.clarifications.map((c) =>
+      c.id === null ? { question: c.question, answer: c.answer } : c,
+    ),
     conditions: strategy.attributes.conditions ?? null,
     serves: [...strategy.serves].sort(),
     success_signal: strategy.success_signal,

--- a/packages/intentionsutil/src/schema.ts
+++ b/packages/intentionsutil/src/schema.ts
@@ -1101,6 +1101,79 @@ function checkAttentionTierNamespace(node: IntentionNode, problems: string[]): v
 }
 
 /**
+ * A `<node-id>#<slug>` clarification citation. The prefix group is deliberately
+ * a LOOSE id-shaped token (not a kind-prefix alternation like `id-refs.ts`'s
+ * `idShape`): membership in the real id set is what decides whether a match is
+ * a citation at all, so the regex only has to be permissive enough to capture
+ * every possible id and precise enough not to swallow surrounding punctuation.
+ *
+ * The `(?<![\w-])` / `(?![\w-])` boundaries are borrowed from `id-refs.ts` so a
+ * citation embedded in a longer identifier never matches. A bare `#123` GitHub
+ * issue ref has no id-shaped token immediately before the `#`, so it cannot
+ * match at all; a `#fragment` in a URL matches only if the token before it
+ * happens to be a real node id.
+ */
+const CLARIFICATION_CITATION_RE =
+  /(?<![\w-])([a-z0-9]+(?:-[a-z0-9]+)*)#([a-z0-9]+(?:-[a-z0-9]+)*)(?![\w-])/g;
+
+/** Every string a node's clarification citations may appear in, labeled for reporting. */
+function citationScanFields(node: IntentionNode): Array<{ field: string; text: string }> {
+  const fields: Array<{ field: string; text: string }> = [
+    { field: "statement", text: node.statement },
+  ];
+  if (node.rationale !== null) fields.push({ field: "rationale", text: node.rationale });
+  node.clarifications.forEach((c, i) => {
+    fields.push({ field: `clarifications[${i}].question`, text: c.question });
+    fields.push({ field: `clarifications[${i}].answer`, text: c.answer });
+  });
+  // `attributes` is Record<string, unknown>, so `conditions` (a kind-specific
+  // strategy attribute) is untyped here — scan it only when it really is an
+  // array, and skip non-string entries rather than coercing them.
+  const conditions = node.attributes.conditions;
+  if (Array.isArray(conditions)) {
+    conditions.forEach((entry, i) => {
+      if (typeof entry === "string") {
+        fields.push({ field: `attributes.conditions[${i}]`, text: entry });
+      }
+    });
+  }
+  return fields;
+}
+
+/**
+ * Rule 21: every `<node-id>#<slug>` clarification citation resolves — the cited
+ * node exists AND carries a clarification whose `id` is `<slug>`. This is the
+ * durable replacement for free-text ordinal references ("clarification 26"),
+ * which silently shifted whenever an entry was inserted above them.
+ *
+ * The grammar is deliberately conservative: a match is only a CITATION when the
+ * token before the `#` is an id that actually exists in the node set being
+ * validated. Anything else — a markdown heading, a `#123` issue reference, a URL
+ * fragment — is skipped silently, so this rule can never false-positive on
+ * ordinary prose. The consequence is that a typo'd node id degrades to "not a
+ * citation" rather than to an error; `validateGraphProseRefs` owns dangling
+ * plain-id references, and this rule owns dangling SLUGS on resolvable ids.
+ */
+function checkClarificationCitations(
+  node: IntentionNode,
+  byId: Map<string, IntentionNode>,
+  problems: string[],
+): void {
+  for (const { field, text } of citationScanFields(node)) {
+    for (const m of text.matchAll(CLARIFICATION_CITATION_RE)) {
+      const [citation, targetId, slug] = m;
+      const target = byId.get(targetId);
+      if (target === undefined) continue; // not a citation — some other use of `#`
+      if (!target.clarifications.some((c) => c.id === slug)) {
+        problems.push(
+          `${node.id}: ${field} cites "${citation}" but ${targetId} has no clarification with id "${slug}"`,
+        );
+      }
+    }
+  }
+}
+
+/**
  * Rule 15: reject cycles in the blocked_by graph. A DFS over resolved edges
  * flags every node that participates in a cycle (a tactic transitively blocked
  * by itself). Dangling edges are reported by rule 13, not traversed.
@@ -1214,6 +1287,15 @@ function checkBlockedByCycles(
  *      check deliberately uses the own tier, not the effective one: an
  *      effective-tier check would cascade, invalidating every boosted
  *      descendant the moment any ancestor gained a mark.
+ *  21. Every `<node-id>#<slug>` clarification citation resolves: the cited node
+ *      exists and carries a clarification whose `id` is `<slug>`. Citations are
+ *      scanned in `statement`, `rationale`, every `clarifications[].question`
+ *      and `.answer`, and every string entry of `attributes.conditions`. A `#`
+ *      whose preceding token is NOT a real node id is not a citation at all and
+ *      is skipped silently, so markdown headings, `#123` issue references, and
+ *      URL fragments never false-positive. This replaces free-text ordinal
+ *      references ("clarification 26"), which shifted on insertion above them
+ *      with nothing validating them.
  *
  * Rules 6-9 only judge edges whose target already resolves (rules 2-4 above
  * report the dangling case); this avoids double-reporting the same broken
@@ -1264,6 +1346,8 @@ export function validateGraph(nodes: IntentionNode[]): void {
     checkTierMarkShape(node, problems);
     // Rule 20: attention.tier tags the node's own tier namespace.
     checkAttentionTierNamespace(node, problems);
+    // Rule 21: <node-id>#<slug> clarification citations resolve.
+    checkClarificationCitations(node, byId, problems);
   }
   // Rule 15: reject cycles in the blocked_by graph.
   checkBlockedByCycles(nodes, byId, problems);

--- a/packages/intentionsutil/src/schema.ts
+++ b/packages/intentionsutil/src/schema.ts
@@ -108,6 +108,11 @@ export interface SuccessSignal {
 export interface Clarification {
   question: string;
   answer: string;
+  // Optional kebab-case slug naming this clarification for citation as
+  // `<node-id>#<slug>`. Unique within a single node's own clarifications
+  // array (NOT enforced across nodes — see validateGraph for cross-node
+  // citation resolution). Defaults to null when absent.
+  id: string | null;
 }
 
 /** A tooling goal a node aims to produce or change. */
@@ -298,17 +303,43 @@ function validateAttributes(value: unknown, field: string): Record<string, unkno
   return { ...value };
 }
 
+// Kebab-case slug: lowercase alphanumeric segments joined by single hyphens,
+// no leading/trailing/doubled hyphens, non-empty.
+const CLARIFICATION_ID_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+function validateClarificationId(value: unknown, field: string): string | null {
+  if (value == null) return null;
+  if (typeof value !== "string" || !CLARIFICATION_ID_RE.test(value)) {
+    throw new IntentionSchemaError(
+      `Expected a kebab-case slug (or absent/null) for ${field}, got ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
+}
+
 function validateClarifications(value: unknown, field: string): Clarification[] {
   if (!Array.isArray(value)) {
     throw new IntentionSchemaError(`Expected array for ${field}, got ${typeof value}`);
   }
+  const seenIds = new Map<string, number>();
   return value.map((item, i) => {
     if (!isPlainObject(item)) {
       throw new IntentionSchemaError(`Expected object at ${field}[${i}], got ${typeof item}`);
     }
+    const id = validateClarificationId(item.id, `${field}[${i}].id`);
+    if (id !== null) {
+      const priorIndex = seenIds.get(id);
+      if (priorIndex !== undefined) {
+        throw new IntentionSchemaError(
+          `Duplicate clarification id "${id}" at ${field}[${i}].id (already used at ${field}[${priorIndex}].id)`,
+        );
+      }
+      seenIds.set(id, i);
+    }
     return {
       question: requireString(item.question, `${field}[${i}].question`),
       answer: requireString(item.answer, `${field}[${i}].answer`),
+      id,
     };
   });
 }

--- a/packages/intentionsutil/test/coverage.test.ts
+++ b/packages/intentionsutil/test/coverage.test.ts
@@ -228,8 +228,8 @@ describe("computeReviewCoverage — last_reviewed (rule 4)", () => {
           id: "s",
           kind: "strategy",
           clarifications: [
-            { question: "q1", answer: "Recorded 2026-05-01." },
-            { question: "q2", answer: "Amended 2026-06-15." },
+            { question: "q1", answer: "Recorded 2026-05-01.", id: null },
+            { question: "q2", answer: "Amended 2026-06-15.", id: null },
           ],
         }),
       ],
@@ -262,7 +262,7 @@ describe("computeReviewCoverage — last_reviewed (rule 4)", () => {
         node({
           id: "d",
           kind: "delegation",
-          clarifications: [{ question: "q", answer: "Reviewed 2026-08-01." }],
+          clarifications: [{ question: "q", answer: "Reviewed 2026-08-01.", id: null }],
           attributes: { review_trigger: "x", last_assessed: "2026-07-02" },
         }),
       ],

--- a/packages/intentionsutil/test/digest.test.ts
+++ b/packages/intentionsutil/test/digest.test.ts
@@ -131,8 +131,8 @@ describe("renderPerNode (Section 1)", () => {
         id: "tactic-c",
         kind: "tactic",
         clarifications: [
-          { question: "q1", answer: "decided on 2026-01-05 initially" },
-          { question: "q2", answer: "revised 2026-07-09 per round" },
+          { question: "q1", answer: "decided on 2026-01-05 initially", id: null },
+          { question: "q2", answer: "revised 2026-07-09 per round", id: null },
         ],
         attributes: { conditions: ["one", "two", "three"] },
       }),

--- a/packages/intentionsutil/test/router.test.ts
+++ b/packages/intentionsutil/test/router.test.ts
@@ -1097,6 +1097,42 @@ describe("strategyFingerprint", () => {
     const reordered = strategy({ id: "strategy-s", serves: ["virtue-b", "virtue-a"] });
     expect(strategyFingerprint(base)).toBe(strategyFingerprint(reordered));
   });
+
+  it("a null clarification id hashes identically to no id key at all (schema-widening stability)", () => {
+    // Simulates the pre-`id`-field shape: clarification objects that never
+    // carried an `id` key. `id: string | null` was added to the Clarification
+    // interface after this shape existed everywhere in the store, and
+    // `validateNode` now always fills `id: null` when absent — so a real node
+    // read via readNode/validateNode always has the key present. The
+    // fingerprint must not change just because the key started appearing.
+    const withoutIdKey = strategy({
+      id: "strategy-s",
+      clarifications: [
+        { question: "q1", answer: "a1 (2026-07-01)" },
+        { question: "q2", answer: "a2 (2026-07-01)" },
+      ] as unknown as IntentionNode["clarifications"],
+    });
+    const withNullId = strategy({
+      id: "strategy-s",
+      clarifications: [
+        { question: "q1", answer: "a1 (2026-07-01)", id: null },
+        { question: "q2", answer: "a2 (2026-07-01)", id: null },
+      ],
+    });
+    expect(strategyFingerprint(withNullId)).toBe(strategyFingerprint(withoutIdKey));
+  });
+
+  it("assigning a non-null clarification id changes the fingerprint", () => {
+    const withNullId = strategy({
+      id: "strategy-s",
+      clarifications: [{ question: "q1", answer: "a1 (2026-07-01)", id: null }],
+    });
+    const withRealId = strategy({
+      id: "strategy-s",
+      clarifications: [{ question: "q1", answer: "a1 (2026-07-01)", id: "q1-slug" }],
+    });
+    expect(strategyFingerprint(withRealId)).not.toBe(strategyFingerprint(withNullId));
+  });
 });
 
 describe("strategyAlignSelectable", () => {

--- a/packages/intentionsutil/test/router.test.ts
+++ b/packages/intentionsutil/test/router.test.ts
@@ -1081,7 +1081,7 @@ describe("strategyFingerprint", () => {
     expect(
       strategyFingerprint({
         ...base,
-        clarifications: [{ question: "q", answer: "a" }],
+        clarifications: [{ question: "q", answer: "a", id: null }],
       }),
     ).not.toBe(fp);
     expect(

--- a/packages/intentionsutil/test/router.test.ts
+++ b/packages/intentionsutil/test/router.test.ts
@@ -1110,7 +1110,7 @@ describe("strategyFingerprint", () => {
       clarifications: [
         { question: "q1", answer: "a1 (2026-07-01)" },
         { question: "q2", answer: "a2 (2026-07-01)" },
-      ] as unknown as IntentionNode["clarifications"],
+      ] as unknown as IntentionNode["clarifications"], // type-safety-ok: simulates pre-widening on-disk shape with no `id` key at all
     });
     const withNullId = strategy({
       id: "strategy-s",

--- a/packages/intentionsutil/test/schema.test.ts
+++ b/packages/intentionsutil/test/schema.test.ts
@@ -1577,9 +1577,9 @@ describe("validateGraph", () => {
         id: "tactic-1",
         kind: "tactic",
         clarifications: [
-          { question: "front-loaded?", answer: "(Recorded 2026-07-05 by author) settled." },
-          { question: "trailing?", answer: "Settled the scope. Recorded 2026-07-05." },
-          { question: "mid-sentence?", answer: "On 2026-07-05 the author ratified this." },
+          { question: "front-loaded?", answer: "(Recorded 2026-07-05 by author) settled.", id: null },
+          { question: "trailing?", answer: "Settled the scope. Recorded 2026-07-05.", id: null },
+          { question: "mid-sentence?", answer: "On 2026-07-05 the author ratified this.", id: null },
         ],
       }),
     ];
@@ -1594,8 +1594,8 @@ describe("validateGraph", () => {
         id: "tactic-1",
         kind: "tactic",
         clarifications: [
-          { question: "dated?", answer: "Recorded 2026-07-05." },
-          { question: "dateless?", answer: "No date anywhere in this answer." },
+          { question: "dated?", answer: "Recorded 2026-07-05.", id: null },
+          { question: "dateless?", answer: "No date anywhere in this answer.", id: null },
         ],
       }),
     ];
@@ -1621,12 +1621,12 @@ describe("validateGraph", () => {
       gnode({
         id: "tactic-1",
         kind: "tactic",
-        clarifications: [{ question: "q", answer: "No date here." }],
+        clarifications: [{ question: "q", answer: "No date here.", id: null }],
       }),
       gnode({
         id: "virtue-1",
         kind: "virtue",
-        clarifications: [{ question: "q", answer: "Also no date." }],
+        clarifications: [{ question: "q", answer: "Also no date.", id: null }],
       }),
     ];
     let caught: unknown;
@@ -1823,6 +1823,105 @@ describe("validateGraph", () => {
     const nodes = tierNodes({ attributes: { bug_fix: true, security: true }, attention: null });
     expect(() => validateGraph(nodes)).not.toThrow();
   });
+
+  // --- Rule 21: <node-id>#<slug> clarification citations ---------------------
+
+  /**
+   * A citing node (`strategy-citer`) plus a cited node (`strategy-cited`) that
+   * carries one clarification with id "why-lazy". Both kind nodes are present so
+   * only rule 21 is under test.
+   */
+  function citationNodes(citer: Partial<IntentionNode>): IntentionNode[] {
+    return [
+      gnode({ id: "kind-kind", kind: "kind", status: "codified" }),
+      gnode({
+        id: "kind-strategy",
+        kind: "kind",
+        status: "codified",
+        attributes: {
+          goal_layer: true,
+          status_vocabulary: { raw: "Not yet started.", codified: "Complete." },
+        },
+      }),
+      gnode({
+        id: "strategy-cited",
+        kind: "strategy",
+        clarifications: [
+          {
+            question: "Why are ids lazy?",
+            answer: "Because only cited entries need one. 2026-08-04",
+            id: "why-lazy",
+          },
+        ],
+      }),
+      gnode({ id: "strategy-citer", kind: "strategy", ...citer }),
+    ];
+  }
+
+  it("Rule 21: accepts a citation that resolves to a clarification id on the cited node", () => {
+    const nodes = citationNodes({
+      statement: "Follows from `strategy-cited#why-lazy`, which settled the question.",
+    });
+    expect(() => validateGraph(nodes)).not.toThrow();
+  });
+
+  it("Rule 21: rejects a citation whose slug names no clarification on the cited node", () => {
+    const nodes = citationNodes({
+      statement: "Follows from `strategy-cited#no-such-slug`.",
+    });
+    expect(() => validateGraph(nodes)).toThrow(
+      /strategy-citer: statement cites "strategy-cited#no-such-slug" but strategy-cited has no clarification with id "no-such-slug"/,
+    );
+  });
+
+  it("Rule 21: reports the field a dangling citation was found in (rationale, clarifications)", () => {
+    const nodes = citationNodes({
+      rationale: "See strategy-cited#gone.",
+      clarifications: [
+        {
+          question: "Does strategy-cited#absent still hold?",
+          answer: "Yes, per strategy-cited#why-lazy. 2026-08-04",
+          id: null,
+        },
+      ],
+    });
+    expect(() => validateGraph(nodes)).toThrow(
+      /strategy-citer: rationale cites "strategy-cited#gone"/,
+    );
+    expect(() => validateGraph(nodes)).toThrow(
+      /strategy-citer: clarifications\[0\]\.question cites "strategy-cited#absent"/,
+    );
+    // The resolving citation in the answer is NOT reported.
+    expect(() => validateGraph(nodes)).not.toThrow(/clarifications\[0\]\.answer/);
+  });
+
+  it("Rule 21: ignores a `#` whose preceding token is not a real node id", () => {
+    const nodes = citationNodes({
+      statement: "Recurred as #1170 and again in #123; see docs/page#some-anchor and #foo.",
+      rationale: "Also https://example.com/guide#install and a markdown heading marker.",
+    });
+    expect(() => validateGraph(nodes)).not.toThrow();
+  });
+
+  it("Rule 21: resolves and dangles citations inside attributes.conditions entries", () => {
+    const ok = citationNodes({
+      attributes: {
+        status_vocabulary: { raw: "Not yet started.", codified: "Complete." },
+        conditions: ["Holds while `strategy-cited#why-lazy` stands.", 42],
+      },
+    });
+    expect(() => validateGraph(ok)).not.toThrow();
+
+    const bad = citationNodes({
+      attributes: {
+        status_vocabulary: { raw: "Not yet started.", codified: "Complete." },
+        conditions: ["First condition.", "Breaks if `strategy-cited#dropped` is retired."],
+      },
+    });
+    expect(() => validateGraph(bad)).toThrow(
+      /strategy-citer: attributes\.conditions\[1\] cites "strategy-cited#dropped" but strategy-cited has no clarification with id "dropped"/,
+    );
+  });
 });
 
 describe("validateGraphProseRefs", () => {
@@ -1875,7 +1974,7 @@ describe("validateGraphProseRefs", () => {
       pnode({
         id: "tactic-a",
         kind: "tactic",
-        clarifications: [{ question: "q", answer: "Depends on `tactic-missing`." }],
+        clarifications: [{ question: "q", answer: "Depends on `tactic-missing`.", id: null }],
       }),
     ];
     expect(() => validateGraphProseRefs(nodes, new Map(), [], new Set())).toThrow(
@@ -1972,7 +2071,7 @@ describe("validateGraphProseRefs", () => {
       pnode({
         id: "tactic-b",
         kind: "tactic",
-        clarifications: [{ question: "q", answer: "Also `tactic-y`." }],
+        clarifications: [{ question: "q", answer: "Also `tactic-y`.", id: null }],
       }),
     ];
     let caught: unknown;

--- a/packages/intentionsutil/test/schema.test.ts
+++ b/packages/intentionsutil/test/schema.test.ts
@@ -17,7 +17,7 @@ describe("validateNode", () => {
       rationale: "r",
       reading: "rd",
       gap: "g",
-      clarifications: [{ question: "q", answer: "a" }],
+      clarifications: [{ question: "q", answer: "a", id: "q-a" }],
       tooling_goals: [{ kind: "actuator", statement: "t" }],
       success_signal: {
         observable: "o",
@@ -873,6 +873,115 @@ describe("validateNode", () => {
         attention: { boost: 1, rationale: "" },
       }),
     ).toThrow(/rationale must be a non-empty string/);
+  });
+
+  it("accepts a valid kebab-case clarification id", () => {
+    const result = validateNode({
+      id: "n10a",
+      kind: "tactic",
+      statement: "Has a slugged clarification.",
+      owner: "human",
+      status: "raw",
+      clarifications: [{ question: "q", answer: "a", id: "why-this-approach" }],
+    });
+    expect(result.clarifications).toEqual([{ question: "q", answer: "a", id: "why-this-approach" }]);
+  });
+
+  it("defaults clarification id to null when absent", () => {
+    const result = validateNode({
+      id: "n10b",
+      kind: "tactic",
+      statement: "No id on the clarification.",
+      owner: "human",
+      status: "raw",
+      clarifications: [{ question: "q", answer: "a" }],
+    });
+    expect(result.clarifications).toEqual([{ question: "q", answer: "a", id: null }]);
+  });
+
+  it("defaults clarification id to null when explicitly null", () => {
+    const result = validateNode({
+      id: "n10c",
+      kind: "tactic",
+      statement: "Explicit null id.",
+      owner: "human",
+      status: "raw",
+      clarifications: [{ question: "q", answer: "a", id: null }],
+    });
+    expect(result.clarifications).toEqual([{ question: "q", answer: "a", id: null }]);
+  });
+
+  it("rejects an uppercase clarification id", () => {
+    expect(() =>
+      validateNode({
+        id: "n10d",
+        kind: "tactic",
+        statement: "Bad slug.",
+        owner: "human",
+        status: "raw",
+        clarifications: [{ question: "q", answer: "a", id: "Why-This" }],
+      }),
+    ).toThrow(/clarifications\[0\]\.id/);
+  });
+
+  it("rejects a clarification id with underscores", () => {
+    expect(() =>
+      validateNode({
+        id: "n10e",
+        kind: "tactic",
+        statement: "Bad slug.",
+        owner: "human",
+        status: "raw",
+        clarifications: [{ question: "q", answer: "a", id: "why_this" }],
+      }),
+    ).toThrow(/clarifications\[0\]\.id/);
+  });
+
+  it("rejects an empty-string clarification id", () => {
+    expect(() =>
+      validateNode({
+        id: "n10f",
+        kind: "tactic",
+        statement: "Empty slug.",
+        owner: "human",
+        status: "raw",
+        clarifications: [{ question: "q", answer: "a", id: "" }],
+      }),
+    ).toThrow(/clarifications\[0\]\.id/);
+  });
+
+  it("rejects duplicate non-null clarification ids within one node", () => {
+    expect(() =>
+      validateNode({
+        id: "n10g",
+        kind: "tactic",
+        statement: "Duplicate slugs.",
+        owner: "human",
+        status: "raw",
+        clarifications: [
+          { question: "q1", answer: "a1", id: "dup" },
+          { question: "q2", answer: "a2", id: "dup" },
+        ],
+      }),
+    ).toThrow(/[Dd]uplicate clarification id "dup".*clarifications\[1\]\.id/);
+  });
+
+  it("allows multiple clarifications with null ids (no uniqueness constraint on absent ids)", () => {
+    const result = validateNode({
+      id: "n10h",
+      kind: "tactic",
+      statement: "Multiple unslugged clarifications.",
+      owner: "human",
+      status: "raw",
+      clarifications: [
+        { question: "q1", answer: "a1" },
+        { question: "q2", answer: "a2" },
+      ],
+    });
+    expect(result.clarifications).toEqual([
+      { question: "q1", answer: "a1", id: null },
+      { question: "q2", answer: "a2", id: null },
+    ]);
   });
 });
 

--- a/packages/intentionsutil/test/store.test.ts
+++ b/packages/intentionsutil/test/store.test.ts
@@ -51,8 +51,8 @@ describe("store round-trip", () => {
       reading: "See the alignment principles.",
       gap: "No automated alignment check exists yet.",
       clarifications: [
-        { question: "Who arbitrates conflicts?", answer: "The charter owner." },
-        { question: "How often is it reviewed?", answer: "Each digest cycle." },
+        { question: "Who arbitrates conflicts?", answer: "The charter owner.", id: "who-arbitrates" },
+        { question: "How often is it reviewed?", answer: "Each digest cycle.", id: null },
       ],
       tooling_goals: [{ kind: "actuator", statement: "align-cli" }, { kind: "sensor", statement: "intention-tree" }],
       success_signal: {
@@ -141,10 +141,12 @@ describe("store round-trip", () => {
         {
           question: "Does the yaml library clip trailing newlines?",
           answer: "Not when fields are read back via parse — this test confirms it.",
+          id: null,
         },
         {
           question: "Are internal blank lines preserved?",
           answer: "Yes — the rationale field above contains one.",
+          id: null,
         },
       ],
       tooling_goals: [{ kind: "actuator", statement: "yaml-round-trip" }, { kind: "sensor", statement: "intention-store" }],


### PR DESCRIPTION
Implements the intention node `tactic-clarification-citation-ids`
(graph-native tactic; no GitHub issue). Free-text ordinal clarification
references ("clarification 26") shift on insertion and nothing validates
them — this class of bug recurred twice (commit 7cb64dbc; entries 35/37 on
`strategy-graph-native-dispatch`, repaired 2026-07-09 with question-anchored
interim refs). This introduces lazy, insertion-stable clarification ids and a
validate-graph rule that checks citations against them.

## Unit 1 — Schema: optional `id` on Clarification
`Clarification` (`packages/intentionsutil/src/schema.ts`) gains an optional
`id: string | null` (default `null`). `validateClarifications` validates a
present `id` as a kebab-case slug and enforces uniqueness within one node's
own `clarifications` array (not across nodes). Round-trips through
`writeNode`/YAML with no store changes needed.

## Unit 2 — validate-graph citation resolution rule
New `validateGraph` Rule 21 (`checkClarificationCitations`): scans each
node's `statement`, `rationale`, every `clarifications[].question`/`.answer`,
and every `attributes.conditions` string for `<node-id>#<slug>` occurrences.
A `#` is only ever treated as a citation when the token before it resolves to
a real node id (so GitHub `#123` refs, URLs, and markdown headings never
false-positive); when it does resolve, the target node must carry a
clarification with `id === <slug>` or the citation is a graph-integrity
violation naming the citing node, field, and dangling citation text.

## Unit 3 — Upgrade existing interim references
Converted `strategy-graph-native-dispatch`'s descriptive self-referential
clarification mentions (`pause-field`, `calendar-release`,
`materiality-scoped-freeze`, `disposable-session`, `reaping`) to
`strategy-graph-native-dispatch#<slug>` citations — 8 occurrences across 5
newly-slugged entries. Scoped to this one file only, per the plan's
explicit no-big-bang-rewrite constraint; the file's many other numeric
`(entry N)` references and other files' similar prose are left for
opportunistic upgrade as those nodes are next amended.

## Fix — strategyFingerprint stability across the Unit 1 schema widening
Discovered mid-implementation: `strategyFingerprint` (`router.ts`) hashes
`strategy.clarifications` verbatim, so the new default `id: null` key added
by Unit 1 changed every strategy's computed fingerprint the moment the
schema landed — even with zero authored content change — which would have
falsely stale-frozen every open tactic serving any strategy graph-wide
(verified directly: `strategy-graph-self-description`'s computed fingerprint
differed from its pre-change stamp purely from the new key). Fixed by
normalizing `id: null` clarifications to serialize without the `id` key for
fingerprint purposes, while a non-null `id` still counts as substance
(assigning a citable id is a real content edit). Regression-tested.

## Verification
- `npx vitest run --project packages/intentionsutil --root .` — 835/835 passing.
- `npx tsx packages/intentionsutil/scripts/validate-graph.ts` — clean (497
  nodes; 0 unresolved prose refs beyond the pre-existing baseline).
- Negative control: temporarily mistyped a citation slug and confirmed Rule
  21 fails naming the citing node/field/dangling citation; reverted.
