### PR TITLE
lib-frozen-session-park: pin diagnosis-time --base so a race refuses instead of clobbering a park

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/lib-frozen-session-park.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-frozen-session-park.sh
@@ -43,7 +43,14 @@
 #   evidence of staleness. An UNKNOWN daemon, an unreadable transcript, an
 #   unmeasurable mtime, or a missing node file all mean "keep", never "park".
 #   The only path that parks is: blocked + measured idle >= grace + NO other
-#   live session holding the node + a real, unparked node file on origin/main.
+#   live session holding the node + a real node file on origin/main that is
+#   unparked AT WRITE TIME. That last term is stronger than the read alone can
+#   make it: `origin/main` is fetched once per sweep and each candidate then
+#   burns minutes of wall clock before its write, so the "not parked" read is
+#   stale by the time the park runs. Every `park-node` call therefore carries
+#   `--base <id>=<blob>` pinned to the blob the decision was read from, and a
+#   park that landed inside that window makes park-node REFUSE (exit 3) instead
+#   of overwriting it — a stale-diagnosis skip, not a park failure.
 #
 #   The "no other live session" term is the stand-down interlock. A stood-down
 #   LOSER (the duplicate-worker protocol in lib-standdown-recheck.sh) has
@@ -476,6 +483,21 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
         continue
       fi
 
+      # (7b) Diagnosis-time base (ref-diagnosis-time-cas). The decision this
+      # sweep is about to make — "not parked, so park it" — is made against the
+      # blob read HERE, from a ref last fetched once at step (6). Pin that exact
+      # blob through park-node's --base so a park landing in the window between
+      # this read and the write below is REFUSED (exit 3) rather than
+      # overwritten. `rev-parse` is the identical expression park-node resolves
+      # FRESH_BLOB with (park-node:205), so the two are bit-for-bit comparable;
+      # hashing $body instead would not match, because command substitution
+      # strips its trailing newlines.
+      local diagnosis_blob
+      if ! diagnosis_blob=$(git -C "$repo_root" rev-parse "origin/main:intentions/${name}.md" 2>/dev/null); then
+        printf 'lib-frozen-session-park: keeping %s (could not resolve the origin/main blob sha for intentions/%s.md; refusing to park without a compare-and-swap base)\n' "$name" "$name" >&2
+        continue
+      fi
+
       # (8) Already parked. Idiom deliberately inlined rather than shared (same
       # frontmatter-scoped, column-0-anchored idiom `node_kind_on_main` in
       # `packages/intentionsutil/scripts/office-hours-graph` uses). The
@@ -503,10 +525,18 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
         continue
       fi
 
-      # (10) Park. Three positional args: <node-id> <reason> [recommendation].
-      # No `--pr` (this caller is gh-free and has no PR number) and no `--base`
-      # (there is no diagnosis/execution gap to pin — park-node's own fresh
-      # origin/main re-read is the correct guard here).
+      # (10) Park. Three positional args: <node-id> <reason> [recommendation],
+      # preceded by `--base`. No `--pr` (this caller is gh-free and has no PR
+      # number), but `--base` IS threaded: there is a real diagnosis/execution
+      # gap to pin. `origin/main` is fetched ONCE per sweep at step (6), and each
+      # candidate then burns wall clock on transcript stats, job-dir reads, and
+      # (for earlier candidates) a full park-node landing — so the window between
+      # the step-(8) "not parked" read and the write below is minutes wide in
+      # practice. park-node's own fresh origin/main re-read is NOT a guard against
+      # that: it re-reads to build the write, not to verify the decision still
+      # holds, so a specific human-facing park that landed in the window is
+      # silently overwritten with this sweep's generic boilerplate. Pinning the
+      # step-(7b) blob turns that race into an exit-3 refusal instead.
       local reason recommendation
       printf -v reason \
         'worker session froze at a permission/classifier denial — claude agents reports state=blocked and the transcript has had no activity for %ss; the session cannot make progress and cannot park itself (a blocked session never reaches the Stop hook), so the dispatch-tick frozen-session sweep parked this node' \
@@ -519,13 +549,30 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
       # default. The tick must keep scheduling even when the lock is busy.
       # `</dev/null`: park-node runs a long chain of git/node subprocesses, none
       # of which has any business reading the sweep's inherited stdin.
+      #
+      # park-node's parse is leading-flags-only: the first non-flag argument ends
+      # flag parsing and everything after it is verbatim free text, so `--base`
+      # must come first. The `<id>=<sha>` pair form (rather than a bare sha) is a
+      # free guard — park-node rejects a pair whose id is not the node id, so a
+      # mis-threaded `$name` fails loudly instead of pinning the wrong file.
+      local -a park_args=(--base "$name=$diagnosis_blob" "$name" "$reason" "$recommendation")
       local rc=0
       GRAPH_COMMIT_LOCK_WAIT_SECONDS="$lock_wait" \
-        "$timeout_bin" "$park_timeout" "$park_node" "$name" "$reason" "$recommendation" >/dev/null </dev/null || rc=$?
+        "$timeout_bin" "$park_timeout" "$park_node" "${park_args[@]}" >/dev/null </dev/null || rc=$?
       if (( rc == 0 )); then
         parked_count=$(( parked_count + 1 ))
         printf 'lib-frozen-session-park: parked %s (denied-command-frozen after %ss; session=%s)\n' "$name" "$idle" "$sid" >&2
         _frozen_session_log_decision "$name" "$sid" "$idle" "parked"
+      elif (( rc == 3 )); then
+        # NOT a park failure. park-node refused the compare-and-swap because the
+        # node changed on origin/main after this sweep read it — it is already
+        # parked, or already under human review. Nothing was written, nothing is
+        # broken, and the correct response is to re-diagnose next tick, never to
+        # retry without the base and never to park again
+        # (.claude/skills/ref-diagnosis-time-cas/SKILL.md:73-83).
+        printf 'lib-frozen-session-park: stale-diagnosis skip for %s — intentions/%s.md on origin/main changed after this sweep read it (pinned base %s); park-node REFUSED rather than overwriting a park that landed in the meantime. Nothing was written; the next tick re-reads and re-decides\n' \
+          "$name" "$name" "$diagnosis_blob" >&2
+        _frozen_session_log_decision "$name" "$sid" "$idle" "stale-diagnosis"
       elif (( rc == 124 )); then
         # A timeout is just another park failure — same non-fatal handling, but
         # named distinctly so a contended landing lock is greppable as itself.
@@ -984,6 +1031,22 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
         continue
       fi
 
+      # (7b) Diagnosis-time base (ref-diagnosis-time-cas), exactly as
+      # frozen_session_sweep step (7b) does it. The decision this sweep is about
+      # to make — "not parked, still at a working phase, so park it" — is made
+      # against the blob read HERE, from a ref last fetched once at step (6).
+      # Pin that exact blob through park-node's --base so a park landing in the
+      # window between this read and the write at step (12) is REFUSED (exit 3)
+      # rather than overwritten. `rev-parse` is the identical expression
+      # park-node resolves FRESH_BLOB with (park-node:205), so the two are
+      # bit-for-bit comparable; hashing $body instead would not match, because
+      # command substitution strips its trailing newlines.
+      local diagnosis_blob
+      if ! diagnosis_blob=$(git -C "$repo_root" rev-parse "origin/main:intentions/${name}.md" 2>/dev/null); then
+        printf 'lib-frozen-session-park: keeping %s (could not resolve the origin/main blob sha for intentions/%s.md; refusing to park without a compare-and-swap base)\n' "$name" "$name" >&2
+        continue
+      fi
+
       # (8) Already parked. Idiom deliberately inlined rather than shared (same
       # frontmatter-scoped, column-0-anchored idiom `node_kind_on_main` in
       # `packages/intentionsutil/scripts/office-hours-graph` uses; also the same
@@ -1099,10 +1162,17 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
       # The tick must keep scheduling even when the landing lock is busy — the
       # header's "retries on the next tick if a landing-lock wait is in progress"
       # is only true because of these two bounds.
+      #
+      # park-node's parse is leading-flags-only, so every flag precedes the
+      # positionals. The `<id>=<sha>` pair form of `--base` (rather than a bare
+      # sha) is a free guard — park-node rejects a pair whose id is not the node
+      # id, so a mis-threaded `$name` fails loudly instead of pinning the wrong
+      # file.
       local -a park_args=()
       if [[ -n "$pr" ]]; then
         park_args+=(--pr "$pr")
       fi
+      park_args+=(--base "$name=$diagnosis_blob")
       park_args+=("$name" "$reason" "$recommendation")
       local rc=0
       GRAPH_COMMIT_LOCK_WAIT_SECONDS="$lock_wait" \
@@ -1164,6 +1234,18 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
             "$name" "$name" >&2
           _terminal_disposition_log_decision "$name" "$sid" "$idle" "park-not-landed"
         fi
+      elif (( rc == 3 )); then
+        # NOT a park failure. park-node refused the compare-and-swap because the
+        # node changed on origin/main after this sweep read it — it is already
+        # parked, or already under human review. Nothing was written, nothing is
+        # broken, and the correct response is to re-diagnose next tick, never to
+        # retry without the base and never to park again
+        # (.claude/skills/ref-diagnosis-time-cas/SKILL.md:73-83). The escalation
+        # markers stay where the failure paths leave them: they are only ever
+        # deleted from the confirmed-landed branch above.
+        printf 'lib-frozen-session-park: stale-diagnosis skip for %s — intentions/%s.md on origin/main changed after this sweep read it (pinned base %s); park-node REFUSED rather than overwriting a park that landed in the meantime. Nothing was written, keeping the escalation markers; the next tick re-reads and re-decides\n' \
+          "$name" "$name" "$diagnosis_blob" >&2
+        _terminal_disposition_log_decision "$name" "$sid" "$idle" "stale-diagnosis"
       elif (( rc == 124 )); then
         # A timeout is just another park failure — same non-fatal handling, the
         # markers are retained, but it is named distinctly so a contended landing

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-frozen-session-park.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-frozen-session-park.sh
@@ -231,6 +231,12 @@ fs_park_calls() {
   printf '%s' "$c"
 }
 
+fs_park_arg() {
+  # fs_park_arg <n> — the nth positional argument of the FIRST park-node call.
+  # Sibling of td_park_arg below.
+  grep '^ARG=' "$FS_PARKLOG" | sed -n "${1}p" | sed 's/^ARG=//'
+}
+
 fs_err_count() {
   local c
   c=$(grep -c -- "$1" <<<"$FS_ERR") || c=0
@@ -255,8 +261,8 @@ fs_install_claude 0
 fs_run
 assert_eq "park: sweep returns 0" "0" "$FS_RC"
 assert_eq "park: park-node invoked exactly once" "1" "$(fs_park_calls)"
-assert_eq "park: park-node received 3 positional args" "ARGC=3" "$(grep '^ARGC=' "$FS_PARKLOG")"
-assert_eq "park: node id is \$1" "tactic-frozen-one" "$(grep '^ARG=' "$FS_PARKLOG" | head -n1 | sed 's/^ARG=//')"
+assert_eq "park: park-node received 5 positional args" "ARGC=5" "$(grep '^ARGC=' "$FS_PARKLOG")"
+assert_eq "park: node id is \$3 (after --base <id>=<sha>)" "tactic-frozen-one" "$(fs_park_arg 3)"
 assert_eq "park: stderr reports the park" "yes" "$(fs_contains 'parked tactic-frozen-one (denied-command-frozen')"
 assert_eq "park: one decision record, disposition=parked" "parked" "$(fs_log_dispositions)"
 assert_eq "park: the call carries the short landing-lock wait" "LOCK=60" "$(grep '^LOCK=' "$FS_PARKLOG")"
@@ -312,7 +318,7 @@ assert_eq "already-parked: sweep returns 0" "0" "$FS_RC"
 assert_eq "already-parked: stderr reports the skip" "yes" "$(fs_contains 'skipping tactic-already (already parked to office_hours)')"
 assert_eq "already-parked: exactly one park-node invocation" "1" "$(fs_park_calls)"
 assert_eq "already-parked: the body-mention node is the one parked" "tactic-body-mention" \
-  "$(grep '^ARG=' "$FS_PARKLOG" | head -n1 | sed 's/^ARG=//')"
+  "$(fs_park_arg 3)"
 fs_teardown
 
 # --- Test 5: no blocked sessions at all --------------------------------------
@@ -576,7 +582,7 @@ assert_eq "dup-pair: stderr reports the duplicate hold" "yes" \
   "$(fs_contains 'keeping tactic-dup-pair (2 live sessions registered under this node name')"
 assert_eq "dup-pair: exactly one park-node invocation" "1" "$(fs_park_calls)"
 assert_eq "dup-pair: the lone frozen worker is the one parked" "tactic-lone" \
-  "$(grep '^ARG=' "$FS_PARKLOG" | head -n1 | sed 's/^ARG=//')"
+  "$(fs_park_arg 3)"
 fs_teardown
 
 # --- Test 18: the grace boundary is inclusive (idle == grace parks) -----------
@@ -741,9 +747,16 @@ td_write_park_node() {
 } >> "$TD_PARKLOG"
 sleep $sleep_s
 if [ "$rc" = 0 ] && [ "$mode" != none ]; then
-  # The sweep may prefix the positionals with '--pr <n>'.
+  # The sweep prefixes the positionals with leading flags ('--pr <n>',
+  # '--base <id>=<sha>'). Skip any number of them, exactly as park-node's own
+  # leading-flags-only parse does, so this fake survives a changed flag set.
+  while [ "\$#" -gt 0 ]; do
+    case "\$1" in
+      --*) shift 2 ;;
+      *) break ;;
+    esac
+  done
   node="\$1"
-  [ "\$node" = "--pr" ] && node="\$3"
   f="$TD_REPO/intentions/\$node.md"
   case "$mode" in
     land)   sed -i 's/^office_hours: null\$/office_hours:\n  reason: landed by the fake park-node\n  recommendation: null/' "\$f" ;;
@@ -906,7 +919,7 @@ td_install_claude 0
 td_run
 assert_eq "terminal: sweep returns 0" "0" "$TD_RC"
 assert_eq "terminal: park-node invoked exactly once" "1" "$(td_park_calls)"
-assert_eq "terminal: node id is \$1" "tactic-terminal-one" "$(td_park_arg 1)"
+assert_eq "terminal: node id is \$3 (after --base <id>=<sha>)" "tactic-terminal-one" "$(td_park_arg 3)"
 assert_eq "terminal: stderr reports the park" "yes" \
   "$(td_contains 'parked tactic-terminal-one (terminal-without-disposition after 2000s')"
 assert_eq "terminal: one decision record, disposition=parked" "parked" "$(td_log_dispositions)"
@@ -947,7 +960,7 @@ assert_eq "already-parked: sweep returns 0" "0" "$TD_RC"
 assert_eq "already-parked: stderr reports the skip" "yes" \
   "$(td_contains 'skipping tactic-td-already (already parked to office_hours)')"
 assert_eq "already-parked: exactly one park-node invocation" "1" "$(td_park_calls)"
-assert_eq "already-parked: the body-mention node is the one parked" "tactic-td-body-mention" "$(td_park_arg 1)"
+assert_eq "already-parked: the body-mention node is the one parked" "tactic-td-body-mention" "$(td_park_arg 3)"
 td_teardown
 
 # --- Test 23: idle below the grace is observed, not parked -------------------
@@ -1051,9 +1064,9 @@ td_install_claude 0
 td_run
 assert_eq "escalation: sweep returns 0" "0" "$TD_RC"
 assert_eq "escalation: park-node invoked once" "1" "$(td_park_calls)"
-assert_eq "escalation: three positional args" "ARGC=3" "$(grep '^ARGC=' "$TD_PARKLOG")"
-assert_eq "escalation: reason is the worker's own text" "the worker's own reason" "$(td_park_arg 2)"
-assert_eq "escalation: recommendation is the worker's own text" "the worker's own recommendation" "$(td_park_arg 3)"
+assert_eq "escalation: five positional args" "ARGC=5" "$(grep '^ARGC=' "$TD_PARKLOG")"
+assert_eq "escalation: reason is the worker's own text" "the worker's own reason" "$(td_park_arg 4)"
+assert_eq "escalation: recommendation is the worker's own text" "the worker's own recommendation" "$(td_park_arg 5)"
 assert_eq "escalation: the reason marker was removed" "gone" \
   "$([[ -e "$TD_JOBS/efb0aaaa/office-hours-reason" ]] && printf 'present' || printf 'gone')"
 assert_eq "escalation: the recommendation marker was removed" "gone" \
@@ -1077,7 +1090,7 @@ td_install_claude 0
 td_run
 assert_eq "resumed: sweep returns 0" "0" "$TD_RC"
 assert_eq "resumed: park-node invoked once" "1" "$(td_park_calls)"
-assert_eq "resumed: the worker's own reason was recovered" "the resumed worker's own reason" "$(td_park_arg 2)"
+assert_eq "resumed: the worker's own reason was recovered" "the resumed worker's own reason" "$(td_park_arg 4)"
 td_teardown
 
 # --- Test 28c: a job dir owned by another node is neither read nor deleted ----
@@ -1100,7 +1113,7 @@ td_run
 assert_eq "foreign-job: sweep returns 0" "0" "$TD_RC"
 assert_eq "foreign-job: park-node invoked once" "1" "$(td_park_calls)"
 assert_eq "foreign-job: the other session's reason was NOT used" "yes" \
-  "$(case "$(td_park_arg 2)" in *"ended without declaring a disposition"*) printf 'yes' ;; *) printf 'no' ;; esac)"
+  "$(case "$(td_park_arg 4)" in *"ended without declaring a disposition"*) printf 'yes' ;; *) printf 'no' ;; esac)"
 assert_eq "foreign-job: stderr reports the ownership mismatch" "yes" \
   "$(td_contains 'does not belong to tactic-td-victim (state.json name=tactic-someone-else)')"
 assert_eq "foreign-job: the other session's marker survives" "present" \
@@ -1122,7 +1135,7 @@ assert_eq "bad-jobid: park-node invoked once" "1" "$(td_park_calls)"
 assert_eq "bad-jobid: stderr reports the unusable job id" "yes" \
   "$(td_contains 'terminal worker tactic-td-badjob has no usable job id (id=../escape)')"
 assert_eq "bad-jobid: the synthesized reason is used" "yes" \
-  "$(case "$(td_park_arg 2)" in *"ended without declaring a disposition"*) printf 'yes' ;; *) printf 'no' ;; esac)"
+  "$(case "$(td_park_arg 4)" in *"ended without declaring a disposition"*) printf 'yes' ;; *) printf 'no' ;; esac)"
 td_teardown
 
 # --- Test 29: office-hours-pr is threaded as --pr; a non-numeric one is not --
@@ -1139,10 +1152,10 @@ td_write_job_file "fac0aaaa" "tactic-td-pr" office-hours-pr "2994"
 td_install_claude 0
 td_run
 assert_eq "pr: sweep returns 0" "0" "$TD_RC"
-assert_eq "pr: five positional args" "ARGC=5" "$(grep '^ARGC=' "$TD_PARKLOG")"
+assert_eq "pr: seven positional args" "ARGC=7" "$(grep '^ARGC=' "$TD_PARKLOG")"
 assert_eq "pr: --pr is first" "--pr" "$(td_park_arg 1)"
 assert_eq "pr: the number is second" "2994" "$(td_park_arg 2)"
-assert_eq "pr: the node id is third" "tactic-td-pr" "$(td_park_arg 3)"
+assert_eq "pr: the node id is fifth (after --pr <n> --base <id>=<sha>)" "tactic-td-pr" "$(td_park_arg 5)"
 assert_eq "pr: the pr marker was removed on success" "gone" \
   "$([[ -e "$TD_JOBS/fac0aaaa/office-hours-pr" ]] && printf 'present' || printf 'gone')"
 td_teardown
@@ -1158,8 +1171,8 @@ td_write_job_file "abd0aaaa" "tactic-td-badpr" office-hours-pr "not-a-number"
 td_install_claude 0
 td_run
 assert_eq "bad-pr: sweep returns 0" "0" "$TD_RC"
-assert_eq "bad-pr: three positional args (no --pr)" "ARGC=3" "$(grep '^ARGC=' "$TD_PARKLOG")"
-assert_eq "bad-pr: the node id is first" "tactic-td-badpr" "$(td_park_arg 1)"
+assert_eq "bad-pr: five positional args (no --pr)" "ARGC=5" "$(grep '^ARGC=' "$TD_PARKLOG")"
+assert_eq "bad-pr: the node id is third" "tactic-td-badpr" "$(td_park_arg 3)"
 td_teardown
 
 # --- Test 30: with no job dir the reason is synthesized ----------------------
@@ -1175,9 +1188,9 @@ td_run
 assert_eq "synth: sweep returns 0" "0" "$TD_RC"
 assert_eq "synth: park-node invoked once" "1" "$(td_park_calls)"
 assert_eq "synth: the synthesized reason names the missing disposition" "yes" \
-  "$(case "$(td_park_arg 2)" in *"ended without declaring a disposition"*) printf 'yes' ;; *) printf 'no' ;; esac)"
+  "$(case "$(td_park_arg 4)" in *"ended without declaring a disposition"*) printf 'yes' ;; *) printf 'no' ;; esac)"
 assert_eq "synth: the synthesized recommendation warns against a bare reap" "yes" \
-  "$(case "$(td_park_arg 3)" in *"restarts the churn loop"*) printf 'yes' ;; *) printf 'no' ;; esac)"
+  "$(case "$(td_park_arg 5)" in *"restarts the churn loop"*) printf 'yes' ;; *) printf 'no' ;; esac)"
 td_teardown
 
 # --- Test 31: a park-node failure retains the markers for the next tick ------
@@ -1414,7 +1427,7 @@ assert_eq "td-live-dup: stderr reports the live hold" "yes" \
   "$(td_contains 'keeping tactic-td-held (live sessions still registered under this node name')"
 assert_eq "td-live-dup: exactly one park-node invocation" "1" "$(td_park_calls)"
 assert_eq "td-live-dup: the lone terminal worker is the one parked" "tactic-td-alone" \
-  "$(td_park_arg 1)"
+  "$(td_park_arg 3)"
 td_teardown
 
 # --- Test 40: an unqueryable ACTIVE view aborts the sweep --------------------
@@ -1469,7 +1482,7 @@ td_install_claude 0
 td_run
 assert_eq "td-nullid: sweep returns 0" "0" "$TD_RC"
 assert_eq "td-nullid: park-node invoked once" "1" "$(td_park_calls)"
-assert_eq "td-nullid: the node id survived the parse" "tactic-td-nullid" "$(td_park_arg 1)"
+assert_eq "td-nullid: the node id survived the parse" "tactic-td-nullid" "$(td_park_arg 3)"
 assert_eq "td-nullid: stderr reports the unusable job id" "yes" \
   "$(td_contains 'terminal worker tactic-td-nullid has no usable job id')"
 td_teardown

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-frozen-session-park.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-frozen-session-park.sh
@@ -635,6 +635,54 @@ assert_eq "stdin-drain: summary counts both" "yes" \
   "$(fs_contains 'sweep complete (blocked=2 parked=2 observing=0 unmeasurable=0 deferred=0)')"
 fs_teardown
 
+# --- Test: --base pins the exact pre-park origin/main blob -------------------
+#
+# Regression test for the diagnosis-time CAS (ref-diagnosis-time-cas): the pin
+# threaded through park-node's --base must be the SAME blob the guard read at
+# step (7b), not merely present. If a stale or wrong sha were pinned, a
+# concurrent writer's park could still be silently clobbered even though a
+# `--base` flag is on the command line.
+
+echo "Test: --base pins the exact origin/main blob read at diagnosis time"
+fs_setup
+fs_write_node "tactic-base-pin" unparked
+fs_commit_nodes
+EXPECTED=$(git -C "$FS_REPO" rev-parse "origin/main:intentions/tactic-base-pin.md")
+fs_write_transcript "0aaa-2020" $(( FS_NOW - 4000 ))
+fs_add_session "0aaa-2020" "tactic-base-pin" "blocked"
+fs_install_claude 0
+fs_run
+assert_eq "base-pin: sweep returns 0" "0" "$FS_RC"
+assert_eq "base-pin: first arg is --base" "--base" "$(fs_park_arg 1)"
+assert_eq "base-pin: second arg pins the exact blob" "tactic-base-pin=$EXPECTED" "$(fs_park_arg 2)"
+fs_teardown
+
+# --- Test: park-node exit 3 is its own outcome, not a park failure -----------
+#
+# `rc==3` is the stale-diagnosis compare-and-swap refusal — a park that landed
+# on origin/main between this sweep's guard read and its write. It must get its
+# own disposition, distinct from an ordinary park failure, and must never
+# increment parked_count.
+
+echo "Test: park-node exit 3 is logged as stale-diagnosis, not a park failure (frozen sweep)"
+fs_setup
+fs_write_park_node 3
+fs_write_node "tactic-stale-frozen" unparked
+fs_commit_nodes
+fs_write_transcript "0bbb-2121" $(( FS_NOW - 4000 ))
+fs_add_session "0bbb-2121" "tactic-stale-frozen" "blocked"
+fs_install_claude 0
+fs_run
+assert_eq "stale-frozen: sweep returns 0" "0" "$FS_RC"
+assert_eq "stale-frozen: stderr reports stale-diagnosis" "yes" \
+  "$(fs_contains 'stale-diagnosis skip for tactic-stale-frozen')"
+assert_eq "stale-frozen: stderr does NOT report a park failure" "no" \
+  "$(fs_contains 'park failed for tactic-stale-frozen')"
+assert_eq "stale-frozen: the decision record says stale-diagnosis" "stale-diagnosis" "$(fs_log_dispositions)"
+assert_eq "stale-frozen: summary counts zero parks" "yes" \
+  "$(fs_contains 'sweep complete (blocked=1 parked=0 observing=0 unmeasurable=0 deferred=0)')"
+fs_teardown
+
 echo ""
 echo "=== terminal_without_disposition_sweep ==="
 
@@ -733,11 +781,71 @@ td_teardown() {
 #           origin/main after an rc-0 park.
 #   body    append a column-0 `office_hours:` block to the markdown BODY while
 #           the frontmatter stays `null` — the frontmatter-scoping trap.
-# Landing is skipped entirely for a non-zero <exit-code>: a park-node that fails
-# does not land, and a hang killed by `timeout` never reaches this code at all
-# (the sleep comes first).
+#   race    faithfully emulates a concurrent writer plus real park-node's own
+#           compare-and-swap (park-node:218-221): FIRST land a SPECIFIC park
+#           (distinctive sentinel reason/recommendation strings) onto
+#           origin/main — the concurrent writer landing inside this sweep's
+#           guard-to-write window — then compare the received `--base` pin
+#           against the NOW-current origin/main blob. On mismatch, log
+#           `RACED=1` and exit 3 WITHOUT writing anything else; on (the
+#           unexercised) match, write generic text and exit 0. <exit-code> and
+#           <landing-mode> interact differently here than for the other modes:
+#           `race` decides its OWN exit code from the compare-and-swap, not
+#           from <exit-code>.
+# Landing is skipped entirely for a non-zero <exit-code> (all modes but
+# `race`): a park-node that fails does not land, and a hang killed by `timeout`
+# never reaches this code at all (the sleep comes first).
 td_write_park_node() {
   local rc="$1" sleep_s="${2:-0}" mode="${3:-land}"
+
+  if [[ "$mode" == "race" ]]; then
+    cat > "$TD_PARK" <<PARK
+#!/usr/bin/env bash
+{
+  printf 'ARGC=%s\n' "\$#"
+  for a in "\$@"; do printf 'ARG=%s\n' "\$a"; done
+  printf 'LOCK=%s\n' "\${GRAPH_COMMIT_LOCK_WAIT_SECONDS:-unset}"
+} >> "$TD_PARKLOG"
+
+# Leading-flags-only parse, mirroring park-node and the sweep itself: walk
+# flags until the first positional (the node id), capturing --base's value
+# along the way. Works regardless of whether --pr precedes --base.
+base_pair=""
+node=""
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    --base) base_pair="\$2"; shift 2 ;;
+    --*) shift 2 ;;
+    *) node="\$1"; break ;;
+  esac
+done
+pinned="\${base_pair#*=}"
+f="$TD_REPO/intentions/\${node}.md"
+
+# 1. Land a concurrent writer's SPECIFIC park FIRST — the guard-to-write
+# window this fix closes. Distinctive sentinels let the test assert the exact
+# text survived, not just that some office_hours block exists.
+sed -i 's/^office_hours: null\$/office_hours:\n  reason: RACE_SENTINEL_REASON_7f3a\n  recommendation: RACE_SENTINEL_RECOMMENDATION_9c2e/' "\$f"
+git -C "$TD_REPO" add -A
+git -C "$TD_REPO" commit -q -m 'fake park-node: race concurrent writer'
+git -C "$TD_REPO" update-ref refs/remotes/origin/main HEAD
+
+# 2. park-node's own compare-and-swap against the NOW-current blob.
+current=\$(git -C "$TD_REPO" rev-parse "origin/main:intentions/\${node}.md" 2>/dev/null)
+if [ "\$current" != "\$pinned" ]; then
+  printf 'RACED=1\n' >> "$TD_PARKLOG"
+  exit 3
+fi
+printf '\nGeneric park text (unreachable in the race regression test).\n' >> "\$f"
+git -C "$TD_REPO" add -A
+git -C "$TD_REPO" commit -q -m 'fake park-node: race match'
+git -C "$TD_REPO" update-ref refs/remotes/origin/main HEAD
+exit 0
+PARK
+    chmod +x "$TD_PARK"
+    return 0
+  fi
+
   cat > "$TD_PARK" <<PARK
 #!/usr/bin/env bash
 {
@@ -1611,6 +1719,106 @@ assert_eq "body-only: origin/main really carries the body line (the fixture is n
   "$(git -C "$TD_REPO" show 'origin/main:intentions/tactic-td-bodyonly.md' | grep -c '^office_hours:$')"
 assert_eq "body-only: the sweep counts no park" "yes" \
   "$(td_contains 'terminal-disposition sweep complete (terminal=1 parked=0 observing=0 unmeasurable=0 deferred=0)')"
+td_teardown
+
+# --- Test 46: --pr/--base ordering is the leading-flags-only regression guard -
+#
+# park-node's parse is leading-flags-only: the first non-flag argument ends
+# flag parsing and everything after it is verbatim free text. If a flag ever
+# ended up after the first positional, park-node would silently swallow it as
+# part of the reason/recommendation text rather than erroring — so the exact
+# threaded shape ($1=--pr $2=<n> $3=--base $4=<id>=<sha> $5=<node-id> ...) is
+# asserted here, not just "the flags are present somewhere".
+
+echo "Test: --pr/--base thread in the correct leading-flags-only order"
+td_setup
+td_write_node "tactic-order-pr" working
+td_commit_nodes
+EXPECTED=$(git -C "$TD_REPO" rev-parse "origin/main:intentions/tactic-order-pr.md")
+td_write_transcript "0aab-4040" $(( TD_NOW - 4000 ))
+td_add_session "0aab-4040" "tactic-order-pr" "done" "aab04040"
+td_write_job_file "aab04040" "tactic-order-pr" office-hours-reason "reason with a pr for ordering"
+td_write_job_file "aab04040" "tactic-order-pr" office-hours-pr "3300"
+td_install_claude 0
+td_run
+assert_eq "order: sweep returns 0" "0" "$TD_RC"
+assert_eq "order: seven positional args" "ARGC=7" "$(grep '^ARGC=' "$TD_PARKLOG")"
+assert_eq "order: \$1 is --pr" "--pr" "$(td_park_arg 1)"
+assert_eq "order: \$2 is the pr number" "3300" "$(td_park_arg 2)"
+assert_eq "order: \$3 is --base" "--base" "$(td_park_arg 3)"
+assert_eq "order: \$4 pins tactic-order-pr=<sha>" "tactic-order-pr=$EXPECTED" "$(td_park_arg 4)"
+assert_eq "order: \$5 is the node id" "tactic-order-pr" "$(td_park_arg 5)"
+td_teardown
+
+# --- Test 47: park-node exit 3 is its own outcome, not a park failure --------
+#
+# Sibling of the frozen-sweep exit-3 test: `rc==3` is the stale-diagnosis
+# compare-and-swap refusal and must get its own disposition, must never be
+# reported as an ordinary park failure, must not increment parked_count, and —
+# unlike a real ordinary failure — the escalation markers are retained exactly
+# as every other non-landed path already keeps them.
+
+echo "Test: park-node exit 3 is logged as stale-diagnosis, not a park failure (terminal sweep)"
+td_setup
+td_write_park_node 3
+td_write_node "tactic-stale-terminal" working
+td_commit_nodes
+td_write_transcript "0bbc-4141" $(( TD_NOW - 4000 ))
+td_add_session "0bbc-4141" "tactic-stale-terminal" "done" "bbc04141"
+td_write_job_file "bbc04141" "tactic-stale-terminal" office-hours-reason "reason that must survive a stale-diagnosis refusal"
+td_install_claude 0
+td_run
+assert_eq "stale-terminal: sweep returns 0" "0" "$TD_RC"
+assert_eq "stale-terminal: stderr reports stale-diagnosis" "yes" \
+  "$(td_contains 'stale-diagnosis skip for tactic-stale-terminal')"
+assert_eq "stale-terminal: stderr does NOT report a park failure" "no" \
+  "$(td_contains 'park failed for tactic-stale-terminal')"
+assert_eq "stale-terminal: the decision record says stale-diagnosis" "stale-diagnosis" "$(td_log_dispositions)"
+assert_eq "stale-terminal: summary counts zero parks" "yes" \
+  "$(td_contains 'terminal-disposition sweep complete (terminal=1 parked=0 observing=0 unmeasurable=0 deferred=0)')"
+assert_eq "stale-terminal: the escalation marker is retained" "present" \
+  "$([[ -e "$TD_JOBS/bbc04141/office-hours-reason" ]] && printf 'present' || printf 'gone')"
+td_teardown
+
+# --- Test 48: a concurrent writer inside the guard-to-write window is REFUSED,
+#              not clobbered — THE regression test for this defect -----------
+#
+# The end-to-end race: a different park lands on origin/main between this
+# sweep's diagnosis-time read and its own park-node write. Before the Unit 1
+# fix, the sweep's write would silently overwrite that park with its own
+# generic boilerplate. With the fix, park-node's compare-and-swap sees the
+# pinned --base no longer matches origin/main and REFUSES (exit 3) instead —
+# so the concurrent writer's specific park must survive byte-for-byte and the
+# sweep's generic text must never appear.
+
+echo "Test: a concurrent writer landing inside the guard-to-write window is REFUSED, not clobbered"
+td_setup
+td_write_park_node 0 0 race
+td_write_node "tactic-race" working
+td_commit_nodes
+td_write_transcript "0ccd-4242" $(( TD_NOW - 4000 ))
+td_add_session "0ccd-4242" "tactic-race" "done" "ccd04242"
+td_write_job_file "ccd04242" "tactic-race" office-hours-reason "reason that must survive the race"
+td_install_claude 0
+td_run
+assert_eq "race: sweep returns 0" "0" "$TD_RC"
+RACE_BODY=$(git -C "$TD_REPO" show 'origin/main:intentions/tactic-race.md')
+assert_eq "race: the concurrent writer's reason sentinel survives byte-for-byte" "yes" \
+  "$(case "$RACE_BODY" in *"RACE_SENTINEL_REASON_7f3a"*) printf 'yes' ;; *) printf 'no' ;; esac)"
+assert_eq "race: the concurrent writer's recommendation sentinel survives byte-for-byte" "yes" \
+  "$(case "$RACE_BODY" in *"RACE_SENTINEL_RECOMMENDATION_9c2e"*) printf 'yes' ;; *) printf 'no' ;; esac)"
+assert_eq "race: the sweep's generic disposition text is ABSENT" "no" \
+  "$(case "$RACE_BODY" in *"ended without declaring a disposition"*) printf 'yes' ;; *) printf 'no' ;; esac)"
+assert_eq "race: the decision record says stale-diagnosis" "stale-diagnosis" "$(td_log_dispositions)"
+assert_eq "race: the sweep counts no park" "yes" \
+  "$(td_contains 'terminal-disposition sweep complete (terminal=1 parked=0 observing=0 unmeasurable=0 deferred=0)')"
+assert_eq "race: the escalation marker is retained" "present" \
+  "$([[ -e "$TD_JOBS/ccd04242/office-hours-reason" ]] && printf 'present' || printf 'gone')"
+# Non-vacuity control: without this, the test would pass trivially if the fake
+# never actually advanced origin/main, or if the sweep stopped calling
+# park-node at all. Assert the race actually fired.
+assert_eq "race: non-vacuity — the fake park-node's CAS actually raced" "yes" \
+  "$(grep -q '^RACED=1$' "$TD_PARKLOG" && printf 'yes' || printf 'no')"
 td_teardown
 
 report_results

--- a/.claude/skills/ref-diagnosis-time-cas/SKILL.md
+++ b/.claude/skills/ref-diagnosis-time-cas/SKILL.md
@@ -7,21 +7,50 @@ description: Diagnosis-time compare-and-swap reference — how a batched drain c
 
 ## When this applies
 
-Any caller with a gap between DECIDING a disposition for a node and EXECUTING
-it. Canonical case: a batched office-hours drain diagnoses several parked
-nodes, then interviews the human author about each proposed disposition before
+The rule is stated by shape, not by caller class: any caller that makes a
+decision from a read of a node and later writes that node must capture the
+blob at the deciding read and pin it through `--base`. It does not matter
+whether the gap is a human interview or a loop over subprocess calls — what
+matters is whether a decision was made from a read that a later write could
+silently invalidate.
+
+Canonical case: a batched office-hours drain diagnoses several parked nodes,
+then interviews the human author about each proposed disposition before
 executing any of them — minutes can pass. Without a pin, a fleet write landing
 during that interview window would be silently absorbed by park-node's /
 clear-park's own execution-time self-refresh of origin/main, including one
-that changes what the human should have decided.
+that changes what the human should have decided. This is the widest instance
+of the shape, not the only one.
 
-NOT needed for immediate mechanical parks that diagnose and execute in the
-same breath — e.g. `dispatch-tick`'s `frozen_session_sweep` and
-`terminal_without_disposition_sweep`
-(`.claude/skills/dispatch-propagate/scripts/lib-frozen-session-park.sh`), which
-read the node and call `park-node` with no interview gap in between. Their
-diagnosis→execution window is a handful of subprocesses, and `park-node`'s own
-fresh `origin/main` re-read is the correct guard at that scale.
+Worked example of a narrower instance: `dispatch-tick`'s `frozen_session_sweep`
+and `terminal_without_disposition_sweep`
+(`.claude/skills/dispatch-propagate/scripts/lib-frozen-session-park.sh`) fetch
+`origin/main` once per sweep, then loop over N candidates, each candidate's
+already-parked guard read served from that single fetch, each candidate's
+`park-node` call bounded by a 120s timeout over a 60s landing-lock wait.
+Observed windows were not "a handful of subprocesses": 351s, 441s, and 809s.
+`park-node`'s own fresh `origin/main` re-read is not the guard for this
+hazard — it protects against a stale local copy diverging from origin/main,
+but it does nothing for a park that lands inside the caller's own
+guard-to-write window, because absent `--base` `park-node` has no
+already-parked check of its own and overwrites `office_hours`
+unconditionally. Before these two sweeps threaded a diagnosis-time `--base`
+(this pin landed in this PR), that gap produced four confirmed clobbers on
+origin/main in four days — a specific
+human-authored `office_hours` park silently overwritten with generic
+"session ended without declaring a disposition" boilerplate on the same node:
+
+- `tactic-attention-surface-graph-read` — specific park `1c09ccf1`, clobbered 351s later
+- `tactic-explicit-node-reservation-sweep-policy` — `ac4c24f7`, 441s later
+- `tactic-office-hours-select-fresh-main` — `69cf82b3`, 809s later
+
+Both sweeps now thread `--base` through their diagnosis-time reads exactly as
+described in this reference.
+
+The only genuine exemption is a caller with no guard decision at all: an
+unconditional park that would write the same thing regardless of what it
+read. That is not a compare-and-swap situation because there is no decision
+for a later write to invalidate.
 
 ## The three-step protocol
 
@@ -51,10 +80,8 @@ clear-park selects only its own id's line out of the shared manifest, so a
 single `dump-node.ts` capture at the start of a drain serves every disposition
 executed later in that drain.
 
-`clear-park` is described here even though it may not exist yet on
-`origin/main` — it lands via the sibling tactic `tactic-clear-park-primitive`,
-mirroring park-node's `--base <blobsha>|<id>=<blobsha>|<manifest-file>` shape
-exactly.
+`clear-park` mirrors park-node's `--base <blobsha>|<id>=<blobsha>|<manifest-file>`
+shape exactly.
 
 ## Exit-code contract
 


### PR DESCRIPTION
## What

`lib-frozen-session-park.sh`'s two sweeps (`frozen_session_sweep`,
`terminal_without_disposition_sweep`) gate a park on an "already parked" check
that reads `origin/main`, but pass no `--base` to the subsequent `park-node`
call. `park-node` without `--base` overwrites `office_hours` unconditionally,
so a specific human-facing office-hours park landing in the guard-to-write
window is silently clobbered by generic boilerplate. Confirmed 4 clobbers on
`origin/main` in 4 days (gaps 351s-809s) — each a specific park immediately
overwritten with "session ended without declaring a disposition" text that
points at evidence (job dir, transcript) the reap already deleted.

**Unit 1** — threads a diagnosis-time `--base` pin through both sweeps'
`park-node` calls (the identical `git rev-parse
origin/main:intentions/$NODE_ID.md` expression `park-node` itself uses to
resolve `FRESH_BLOB`), and gives `park-node`'s exit 3 (stale-diagnosis) its own
outcome — a distinct log line and disposition, no `parked_count` increment, no
retry-without-base, markers retained. Mechanical test-index updates in
`test-lib-frozen-session-park.sh` land in the same commit so the suite stays
green.

**Unit 2** — regression tests: the pin matches the pre-park blob at the guard
read, `--pr`/`--base` thread in the correct leading-flags-only order, exit 3
gets its own disposition without touching `parked_count` or markers on both
sweeps, and an end-to-end race test (new `race` landing-mode on the
`td_write_park_node` fixture) proving a concurrent writer landing inside the
guard-to-write window is refused rather than clobbered.

**Unit 3** — reverses the now-falsified "no `--base` needed" carve-out these
two sweeps were named in at `.claude/skills/ref-diagnosis-time-cas/SKILL.md`,
restating the rule by shape instead of caller class and citing the confirmed
clobbers.

Out of scope (per the plan): `park-node`/`clear-park` themselves (the `--base`
contract there is already complete), the qa-main/qa-fix marker-writing gap
that supplies these candidates, the reap path, and
`lib-standdown-recheck.sh:700` (same defect shape, different call site,
tracked separately).

## Verification

- `bash -n` on both changed shell scripts.
- `test-lib-frozen-session-park.sh`: 238/238 passed, 0 failed.
- `run-lint.sh --prose`: clean.
