### PR TITLE
README: ship the ratified data-structure-first rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,331 +1,230 @@
-# commons.systems: a long-horizon agent orchestrator
+# commons.systems
 
-A harness for long-horizon autonomous agent workflows, built around one data
-structure: the **intention graph**. Intent is recorded as a graph of virtues,
-strategies, and tactics in [`intentions/`](intentions/); a **dispatch router**
-reads that graph to decide what runs next, launches autonomous agent sessions
-to do the work, and writes execution state back into the graph. The human
-stays in intent — recording strategy under interview, engaging escalations at
-office hours — and the router converts that intent into merged PRs.
+**A data structure for managing project goals and alignment. An agentic
+harness that runs on it.**
 
-Owned and self-managed, local-first, built to be forked: not a platform, not a
-library, but a reference setup an individual runs on their own GitHub,
-Firebase, and Anthropic accounts.
+The **intention graph** is a versioned graph of goals. It is human authored
+with AI assistance. The graph is rooted by unconditional *virtues*
+(your virtues, your principles) with condition-bearing, persistent
+*strategies* as child nodes, and completable, transient *tactics* at the leaves.
+The graph is encoded as markdown documents in the repo it governs.
+It is AI-native specification tracking — it is designed with AI in mind both:
+- as a first-class consumer
+- to enable specification tracking at a level of detail not feasible with
+  legacy technology.
 
-**Status:** the live router still runs on GitHub issues and labels (the
-projection-era implementation documented below); the graph-native router that
-replaces it is recorded in
-[`intentions/strategy-graph-native-dispatch.md`](intentions/strategy-graph-native-dispatch.md),
-with the build-out drafted in the graph itself on
-[`intentions/tactic-graph-native-dispatch.md`](intentions/tactic-graph-native-dispatch.md).
-The two run concurrently until the GitHub queue drains; then the legacy
-router is removed.
+The intention graph builds on legacy software documentation — such as
+architectural decision records — and contemporary methods such as
+spec-driven development. It maintains the context
+of the *why* for every *what* at a level of specificity not feasible
+except with AI. The result is alignment for longer horizon tasks —
+alignment between team members, collaborators, and AI.
 
-## The intention graph
+In addition to the graph, this repo contains a reference harness that
+operates on the graph to manage context and orchestrate long horizon
+agentic workflows. The harness coordinates between:
+- agent activities, the "dispatch" queue: coding, planning,
+  documenting, monitoring, sensor-based alignment
+- human activities, the "office hours" queue: refining requirements,
+  recording knowledge, resolving escalations
 
-The graph is the orchestrator's state store and the owner's record of intent —
-one markdown file per node under [`intentions/`](intentions/), schema
-declared by [`intentions/kind-kind.md`](intentions/kind-kind.md) and tooling
-in [`packages/intentionsutil/`](packages/intentionsutil/).
-Four kinds:
+## Runbook
 
-- **Virtues** — permanent dispositions, the roots (`parent: null`). Never
-  complete, never ranked; everything else exists to serve them.
-- **Strategies** — the first goal layer. Persistent and conditional: a
-  strategy carries the author circumstances it is contingent on
-  (`attributes.conditions`), a `success_signal` (observable, sensor,
-  threshold), the current `reading`, and the derived `gap`. Strategies
-  outlive their tactics — they keep tracking signals after all child work
-  completes, and leave the graph only when a condition fails or the author
-  retires them.
-- **Tactics** — the bottom layer: concrete, completable, delegable. A tactic
-  is PR-sized (a leaf tactic maps to exactly one PR) or a subtree of tactics
-  (the graph's epic). Tactics are transient — completion prunes them.
-- **Delegations** — attachment records for external dependencies, reviewed on
-  triggers, recoverable via strategy `recovers` edges.
+Get from idea to a recorded strategy in your own repo:
 
-Two mechanisms make the graph executable:
+1. **Install the skills as a plugin.** Add this repo as a Claude Code plugin
+   in your own project — the align skill family and the graph tooling come
+   with it.
+2. **Run `/mount`.** The mounting skill bootstraps your graph:
+   it orients you in the data structure (virtues, strategies, tactics,
+   delegations), probes what you already believe about goals and alignment,
+   and teaches the load-bearing concepts using the same methods the
+   graph itself is maintained by. Mechanically, it creates your own
+   `intentions/` graph — your virtue roots, your first nodes — and mounts this
+   repo's graph as a **delegatee**: a recorded delegation with audited
+   divergence and reversibility. Everything you take
+   on trust from this project enrolls in your own review curriculum as
+   born-parked review items, so all dependencies are tracked and managed.
+3. **Run `/align <directive>`.** The mounting skill converges on a
+   directive in your own words; `/align` records it as your first strategy
+   under interview, and the graph is live.
 
-- **Attention.** Authored injections (`boost`/`override`, each with a
-  rationale) live in node frontmatter; rank is derived on read — undecayed,
-  undiluted, never stored — and is the router's outermost ordering axis.
-  Escalating work means authoring a boost, not applying a label.
-- **Signals.** A strategy that has no child tactics and an unvalidated signal
-  is itself schedulable work: the router starts a session to break it into
-  tactics. Sensors write readings back; validated signals quiet the strategy
-  until a condition or reading changes.
+## Technical summary
 
-Authority doctrine: the graph is the source of truth for all data — intent
-*and* execution state. GitHub is a projection the graph emits into and reads
-back as a sensor, never the origin.
+One markdown file per node under [`intentions/`](intentions/); the schema is
+declared by the graph's own kind nodes —
+[`intentions/kind-kind.md`](intentions/kind-kind.md) is the entry point, and
+drift between code and kind nodes is a guarded defect. Tooling lives in
+[`packages/intentionsutil/`](packages/intentionsutil/).
 
-## The align skill family
+- **Virtues** are unconditional dispositions — the roots. Virtues serve
+  as principles that are fed forward through all graph operations.
+  **Strategies** carry the conditions they are contingent on and a
+  `success_signal` (observable, sensor, threshold); sensors
+  are a feedback mechanism, and a validated signal
+  quiets the strategy until a condition or reading changes. **Tactics** are
+  PR-sized, completable, and pruned on completion. **Delegations** record
+  external attachments with divergence and irreversibility axes; external
+  graphs **mount** recursively, with auditable capture and deference.
+- **Attention** is authored injection (`boost`/`override`, each with a
+  rationale); rank is derived on read, never stored, and is the router's
+  outermost ordering axis. Escalating work means authoring a boost.
+- **The dispatch router** is a headless, self-perpetuating tick — bash plus
+  systemd transient units, no model in the control loop; model tokens are
+  spent on work, never on deciding to work. Each tick selects the
+  highest-rank eligible node and spawns one bounded agent session per
+  selection into an isolated worktree. Work advances through phases — plan,
+  implement, qa, review, merge, qa-main — with interventions invoked
+  when there is a variance in node progression.
+- **Two queues** route every item: autonomous dispatch, and human office
+  hours. Parking is first-class node state; success requires a positive
+  completion marker, and any failed intervention fails safe to a
+  human park.
+- **The interview is the audit.** Strategies enter the graph through an
+  interview (`/align`); every resolution lands as a dated
+  clarification on the node, so provenance is append-only and legible.
 
-Two skills are the human interface to the graph (superseding the
-issue-based `/file-issue` and `/plan-issue` — coverage matrix on the draft
-tactic [`tactic-graph-native-dispatch`](intentions/tactic-graph-native-dispatch.md)):
+## References
 
-- **`/align <optional requirements>`** — the single entrypoint for forks,
-  consuming repos, and ongoing strategy work, in one session. With no prompt
-  it funnels into onboarding: orients the user in the node kinds above,
-  validates the deployment
-  ([`validate-deployment.sh`](.claude/skills/align/scripts/validate-deployment.sh):
-  workspace installed, graph clean, router heartbeat, each with its own
-  remediation diagnostic), then walks the user Socratically to a crafted
-  prompt and falls through into the interview in the same session — no
-  hand-off to a separate skill. A fork starts from this repo's virtue roots,
-  and the harness assumes inherited virtues and strategies are preserved;
-  there is no separate virtue-review step, because recording a virtue falls
-  out of a normal `/align <requirements>` run — the interview's placement
-  step identifies which `virtue-*` node a new strategy serves and surfaces
-  the gap when none fits. Given requirements, it records new strategies
-  or edits under a dialectic interview: intent, justification by virtues or
-  parent strategies, benefit, signals, and the conditions the strategy is
-  contingent on. Disambiguation happens here — edge cases are put to the
-  author and resolutions are recorded as dated `clarifications` on the node.
-  The interview is the audit; the push to `origin/main` makes the record
-  schedulable.
-- **`/align-tactics <strategy-node-id>`** — scheduled by the router for an
-  eligible strategy (not parked, no child tactics, signal unvalidated). It
-  decomposes the strategy into the minimum PR-sized tactics that would
-  validate the signal this round, writes each tactic's full clean-session
-  plan into the node body (per-unit `sonnet`/`opus` delegation tags — the
-  cheapest model that will reliably complete the unit), and parks
-  non-claude-eligible work as office-hours tactics chunked to ≤30
-  author-minutes. Runs autonomously; parks to office hours on genuine
-  ambiguity rather than asking mid-run.
+The design descends from and differentiates against several bodies of work.
 
-## The dispatch router
-
-The router is a headless, self-perpetuating tick — bash plus systemd transient
-units, no model in the control loop. Each tick selects the highest-rank
-eligible node, spawns one worker session per selection into an isolated git
-worktree, and each worker's exit re-launches the tick. Work advances through
-phases — plan (`/align-tactics`), implement, fix, qa, review — with a
-multi-agent fan-out at the review and fix phases, and auto-merge on a clean
-terminal review.
-
-Two queues route every item:
-
-- **Dispatch queue** — autonomous work the chain advances unattended.
-- **Office-hours queue** — human-driven work: strategy interviews, judgment
-  calls, escalations. Parking is first-class node state
-  (`office_hours: {reason, since}`); an autonomous session that hits a
-  user-input boundary parks its node instead of guessing, and the item
-  returns to the dispatch queue when the human engages it.
-
-Execution state lives in the graph: a tactic node persists its `phase`,
-branch/PR anchors, attempt counters, and parking; the router reads PR/CI
-status as sensors before committing a transition, and every state change is a
-single-node commit pushed to `main` with a rebase-retry loop. Token spend is
-paced against a weekly budget curve, so the fleet spreads work across the
-rate-limit window instead of burning early and idling.
-
-The projection-era mechanics that still run today — issue labels as phase
-markers, GitHub-derived phase, the selection ladder details — are documented
-in
-[.claude/skills/dispatch-propagate/reference.md](.claude/skills/dispatch-propagate/reference.md);
-their graph-native replacements are drafted on
-[`tactic-graph-native-dispatch`](intentions/tactic-graph-native-dispatch.md).
-
-## As a harness
-
-Birgitta Böckeler's framing splits an agent into Model + Harness — the harness
-is everything around the model that turns a single call into reliable work.
-This repo is the *outer harness*: the half you write and own, on top of the
-built-in harness Claude Code ships.
-
-- **Guides (feedforward)** — `.claude/rules/*.md` and the per-skill
-  `SKILL.md` files.
-- **Sensors (feedback)** — **computational**: CI (lint, type-check, test) and
-  the graph's registered signal sensors; **inferential**: the `/review-fix`
-  reviewer fan-out and the QA pass — LLM-as-judge over the diff.
-- **Steering loop** — the intention graph itself: strategies carry signals,
-  sensors write readings back, the dialectic re-derives priorities, and
-  lessons feed edits to the rules and skills.
-
-## Design principles
-
-- Intent is explicit and owned: the graph is the single authority for what
-  the system is trying to do and where that work stands.
-- The system controls the agent, not the agent the workflow: the control
-  loop is headless script, phase skills are bounded sessions, and escalation
-  is fail-safe — a missing completion marker parks to a human, never to a
-  false "done."
-- Work flows through two queues — autonomous dispatch and human office
-  hours — with well-defined break points for human quality control.
-- Prefer [skills](https://code.claude.com/docs/en/skills) over other agentic
-  artifacts (system instructions, hooks, sub-agents) for portability and
-  ease of maintenance.
-- Delegate each unit to the cheapest model that will reliably complete it.
-
-## PR control flow (live implementation)
-
-| Phase | Meaning | Skill |
-|-------|---------|-------|
-| plan | Unplanned work item | [plan-issue](.claude/skills/plan-issue/SKILL.md) → `/align-tactics` |
-| implement | Planned, no PR | [implement](.claude/skills/implement/SKILL.md) |
-| fix-checks | Draft PR, CI failed | [fix-checks](.claude/skills/fix-checks/SKILL.md) |
-| fix-conflicts | Draft PR, `origin/main` merge conflict | [dispatch-conflict](.claude/skills/dispatch-conflict/SKILL.md) |
-| qa | Draft PR, CI green | [qa-fix](.claude/skills/qa-fix/SKILL.md) |
-| review | QA passed — terminal code + security review, flips draft→ready | [review-fix](.claude/skills/review-fix/SKILL.md) |
-
-Auto-merge lands a reviewed, green, ready PR; completion prunes the tactic
-from the graph (today: closes the issue).
-
-## CI/CD
-
-Seven workflows handle all CI/CD. Change detection determines which apps to
-test and deploy.
-
-### Workflows
-
-| Trigger | Workflow | Jobs |
-|---------|----------|------|
-| Push to non-`main` branch | `unit-tests.yml` | `unit-tests`, `lint` |
-| PR opened/synchronized | `pr-checks.yml` | `acceptance`, `preview-and-smoke` |
-| PR merged to `main` | `prod-deploy.yml` | `deploy-and-smoke`, `cleanup-preview` |
-| Push `firestore.rules`/`firestore.indexes.json` to `main` | `firestore-deploy.yml` | deploy rules and indexes |
-| Push `functions/**` to `main` (or manual dispatch) | `functions-deploy.yml` | deploy Cloud Functions |
-| Push `storage.rules` to `main` | `storage-deploy.yml` | deploy storage rules |
-| Push a `budget-etl-v*` tag | `budget-etl-release.yml` | build and publish the `budget-etl` release |
-
-### Change detection
-
-`get-changed-apps.sh` determines which apps are affected by a change:
-
-- **Direct changes** to `<app>/**` mark that app
-- **Shared package changes** (e.g. `authutil/`) scan every app's
-  `package.json` for `@commons-systems/` dependencies referencing the changed
-  package and mark all matches
-- **Global triggers** (`firebase.json`, `firestore.rules`, `storage.rules`,
-  `package.json`, `package-lock.json`) mark all apps
-
-An "app" is any workspace listed in the root `package.json` `workspaces`
-array.
-
-### Script call chain
-
-Wrapper scripts delegate to per-app scripts:
-
-```
-run-all-acceptance-tests.sh
-  get-changed-apps.sh            -> <app1>, <app2>, ...
-  run-acceptance-tests.sh <app>     (emulators, seed, playwright)
-
-run-all-preview-deploy-smoke.sh <channel-id>
-  get-changed-apps.sh
-  run-preview-deploy.sh <app> <channel-id>   -> PREVIEW_URL
-  run-smoke-tests.sh <app> <url>
-
-run-all-prod-deploy-smoke.sh
-  get-changed-apps.sh --base HEAD~1
-  run-prod-deploy.sh <app>
-  run-smoke-tests.sh <app> https://<hosting-site>.web.app
-
-run-all-cleanup-preview.sh <pr-number>
-  get-changed-apps.sh --base HEAD~1
-  run-cleanup-preview.sh <app> <pr-number>
-```
-
-## Pre-requisites
-
-- **Version Control** (git + GitHub): a repo; during the migration period a
-  GitHub [project](https://github.com/users/natb1/projects/2) still backs the
-  legacy queue.
-- **Agentic Coding Tools** (Claude Code): stand up your own `office-hours-nate` instance flake (template: [examples/office-hours-nate/flake.nix](examples/office-hours-nate/flake.nix)) that imports this framework's `homeManagerModules.default` and sets your identity, then `home-manager switch -b backup --flake <your-instance>#<system>` (evaluates purely on every platform — the `wezterm-windows` Windows binary is fetched at activation runtime via `curl`, not at eval time, so no `--impure` is needed).
-- **Infrastructure** (Firebase): hosting and storage for the apps this
-  instance of the workflow builds.
-- **Intent**: run `/align` with no prompt — it orients you, validates the
-  deployment, and helps you craft your first strategy prompt in the same
-  session.
-
-## Where to go next
-
-- **Landing page** — [commons.systems](https://commons.systems): the project
-  showcase and overview.
-- **Graph schema** — [intentions/kind-kind.md](intentions/kind-kind.md): node
-  format, layer rules, attention, authority doctrine — the entry point for the
-  self-describing graph.
-- **Router design** — [intentions/tactic-graph-native-dispatch.md](intentions/tactic-graph-native-dispatch.md):
-  the graph-native dispatch draft and migration plan, held in the graph as a
-  draft tactic.
-- **Design system** — [packages/ds](packages/ds/README.md): tokens,
-  components, and the visual language.
-- **License** — CC-BY-SA; forking is encouraged.
-
-### Differentiation
-
-This workflow is owned and self-managed, and it is built to be left. The
-measure of success is the practitioner's eventual independence from it — the
-inverse of a platform's retention metric. The human stays in intent, so intent
-is never captured: what is worth keeping is decided by the person, recorded in
-the graph, not accumulated by the system.
-
-The individual mechanisms have prior art — worktree isolation, "the system
-controls the agent," the self-perpetuating tick, self-hosting. What is
-distinctive is the combination:
-
-- **Intent as the state machine.** The orchestrator's authoritative state is
-  a human-authored intention graph — virtues → strategies → tactics — in the
-  practitioner's own repo, not a task queue, a SQLite store, or a platform
-  backlog. Priorities are authored attention with rationales; escalation is a
-  graph edit; an unvalidated strategy signal *is* the work request.
-- **Office-hours as a symmetric peer escalation queue.** Autonomous work
-  parks into a human queue, and human engagement is the de-escalation event
-  that hands the item back — a peer queue, not an approval gate.
-- **Marker-absence-as-escalation.** Success requires a positive completion
-  marker; any abnormal exit fails safe to a human park rather than a false
-  "done."
-- **Zero-token control loop.** The tick is bash plus `systemd-run` transient
-  units; model tokens are spent on work, never on deciding to work.
-
-## Related work / prior art
-
-The "harness" vocabulary this README uses comes from a body of recent writing
-on building reliable systems around coding agents.
+**Harness engineering** — the vocabulary for everything around the model:
 
 - Birgitta Böckeler, ["Harness engineering for coding agent
-  users"](https://martinfowler.com/articles/harness-engineering.html) (02 April
-  2026, hosted on martinfowler.com) — the Model + Harness split and the
-  guides/sensors framing this README borrows.
+  users"](https://martinfowler.com/articles/harness-engineering.html)
+  (martinfowler.com, 02 Apr 2026) — the Model + Harness split and the
+  guides/sensors taxonomy this repo's rules and CI/reviewer fan-out map onto.
 - Anthropic, ["Effective harnesses for long-running
   agents"](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
-  (26 November 2025) and ["Harness design for long-running application
+  (26 Nov 2025) — bounded sessions with no memory, state carried in a durable
+  on-disk artifact; its one-file progress log is a degenerate intention graph.
+- Anthropic, ["Harness design for long-running application
   development"](https://www.anthropic.com/engineering/harness-design-long-running-apps)
-  (24 March 2026) — the generator/evaluator harness pattern, which maps onto
-  this workflow's QA and review sensor phases.
+  (24 Mar 2026) — the generator/evaluator finding (models praise their own
+  mediocre work) that justifies QA and review as separate sessions.
 - OpenAI, ["Harness engineering: leveraging Codex in an agent-first
-  world"](https://openai.com/index/harness-engineering/) (11 February 2026) — an
-  agent-first repository where the harness, not the human, writes the code.
-- LangChain (Vivek Trivedy), ["The Anatomy of an Agent
-  Harness"](https://www.langchain.com/blog/the-anatomy-of-an-agent-harness) (10
-  March 2026) — its articulation of *Agent = Model + Harness*.
-- Mitchell Hashimoto, ["My AI Adoption
-  Journey"](https://mitchellh.com/writing/my-ai-adoption-journey) (05 February
-  2026) — the Ghostty `AGENTS.md` practice of adding one line per past bad agent
-  behavior. We call that accumulation a *ratchet*; Hashimoto does not use the
-  word.
-- METR (Kwa et al.), ["Measuring AI Ability to Complete Long Software
-  Tasks"](https://arxiv.org/abs/2503.14499) (arXiv:2503.14499, 18 March 2025) —
-  the long-horizon capability trend that makes a leave-it-alone workflow worth
-  building. (METR's companion blog post drops "Software" from the title.)
+  world"](https://openai.com/index/harness-engineering/) (11 Feb 2026) —
+  "manually writing code was treated as a failure mode": the sharpest
+  statement of the posture this repo takes.
 - Addy Osmani, ["Agent Harness
-  Engineering"](https://www.oreilly.com/radar/agent-harness-engineering/) (O'Reilly
-  Radar, 15 May 2026) — the "skill issue" reframe: most agent failures are
-  harness configuration, not model limits.
-- [`awesome-harness-engineering`](https://github.com/walkinglabs/awesome-harness-engineering)
-  (walkinglabs) — the most-referenced curated index of the field.
+  Engineering"](https://www.oreilly.com/radar/agent-harness-engineering/)
+  (O'Reilly Radar, 15 May 2026) — most agent failures are harness
+  configuration, not model limits; names *the ratchet* (every mistake becomes
+  a rule), the practice Mitchell Hashimoto demonstrates in ["My AI Adoption
+  Journey"](https://mitchellh.com/writing/my-ai-adoption-journey) (05 Feb
+  2026) and this repo implements as rule and skill edits fed by review.
 
-The failure modes this workflow's sensors guard against also have names. Khanal
-et al., ["Beyond pass@1: A Reliability Science Framework for Long-Horizon LLM
-Agents"](https://arxiv.org/abs/2603.29231) (arXiv:2603.29231, 31 March 2026),
-describes super-linear reliability decay as tasks lengthen. Orlanski et al.,
-["SlopCodeBench: Benchmarking How Coding Agents Degrade Over Long-Horizon
-Iterative Tasks"](https://arxiv.org/abs/2603.24755) (arXiv:2603.24755, 25 March
-2026), measures verbosity growth and structural erosion across iterative edits.
+**Spec-driven development** — the adjacent mainstream; the graph differs on
+hierarchy, state, and scheduling, not on spec persistence:
 
-## Usage and Contributing
-<a href="https://creativecommons.org/licenses/by-sa/4.0/"><img src="https://mirrors.creativecommons.org/presskit/buttons/88x31/png/by-sa.png" alt="CC-BY-SA" width="117" height="41"></a>
+- GitHub, [Spec Kit](https://github.com/github/spec-kit) (Sep 2025) — the
+  category-defining `/specify → /plan → /tasks → /implement` workflow; one
+  durable layer above the feature (a "constitution"), no goal hierarchy, no
+  signals, nothing a scheduler can rank.
+- Amazon, [Kiro](https://kiro.dev) (Jul 2025) — the largest commercial SDD
+  bet; steering files are shared context, not a governed goal hierarchy.
+- Fission AI, [OpenSpec](https://github.com/Fission-AI/OpenSpec) (Aug 2025) —
+  ephemeral by design (propose → apply → archive), the explicit counterpoint
+  to a persistent graph.
+- BMad Code, [BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD)
+  (Apr 2025) — persistent PRD/architecture/story artifacts across the SDLC;
+  role-based agents producing documents, not a typed graph with edges and
+  attention.
+- Tessl, [spec registry and framework](https://tessl.io) (Sep 2025) — specs
+  as versioned dependencies; describes what correct code does, not what
+  should be worked on next and why.
+- Sean Grove (OpenAI), ["The New
+  Code"](https://www.youtube.com/watch?v=BIvILtt164I) (AI Engineer World's
+  Fair, Jun 2025) — code as "a lossy projection from the specification"; the
+  motivation for durable versioned intent, without a structure for it.
 
-For using and/or extending the artifacts in this repo: forking is encouraged.
+**AI-native work tracking** — incumbents attach agents to human-first
+schemas; the graph *is* the work item:
+
+- GitHub, [Agent HQ](https://github.blog/news-insights/company-news/welcome-home-agents/)
+  (Oct 2025) — mission control over many agents, all still anchored to the
+  Issue as the atomic unit: the architecture this project migrated off.
+- Linear, [Linear Agent](https://linear.app/docs/linear-agent) (2026) — the
+  agent as a special assignee type in an otherwise human-first schema.
+- Atlassian, [Rovo agents in
+  Jira](https://www.atlassian.com/blog/rovo/ai-agents-in-jira) (Feb 2026) —
+  its Teamwork Graph *indexes* work that exists elsewhere; the intention
+  graph *is* the work.
+- [Hiveship](https://hiveship.app/) (2026) — "issue tracking, rebuilt for the
+  agent era"; the same agent-first positioning over a conventional flat issue
+  schema in a proprietary store — the differentiation is mechanism, not
+  adjective.
+
+**Goal-oriented requirements engineering** — the academic ancestor; the
+refinement hierarchy is a solved, named structure, and this project says so:
+
+- Dardenne, van Lamsweerde & Fickas, ["Goal-directed requirements
+  acquisition"](https://www.sciencedirect.com/science/article/pii/016764239390021G)
+  (*Sci. Comput. Program.* 20, 1993) — KAOS: goals AND/OR-refined until
+  assignable to an agent; the strategy → tactic pattern, thirty-three years
+  earlier.
+- van Lamsweerde, ["Goal-Oriented Requirements Engineering: A Guided
+  Tour"](https://webperso.info.ucl.ac.be/~avl/files/RE01.pdf) (RE'01) — why
+  goals anchor completeness, traceability, and conflict management; and
+  *Requirements Engineering* (Wiley, 2009), whose obstacle analysis is the
+  precedent for strategy conditions — analyzed at design time there, held
+  open and re-read at runtime here.
+- Yu, ["Towards Modelling and Reasoning Support for Early-Phase Requirements
+  Engineering"](https://ieeexplore.ieee.org/document/566873) (RE'97) — i*:
+  hard goals vs. satisficed softgoals, the precursor of signal/gap semantics;
+  with Chung, Nixon & Mylopoulos, *Non-Functional Requirements in Software
+  Engineering* (Kluwer, 2000) formalizing graded satisfaction. There the
+  labels are analyst-assigned; here a sensor reading drives the gap.
+- Yu & Zhao, ["4D-ARE: Bridging the Attribution Gap in LLM Agent Requirements
+  Engineering"](https://arxiv.org/abs/2601.04556) (2026) — GORE assumed
+  deterministic agents; the probabilistic-agent gap this design occupies.
+- What the graph adds to that lineage: agent-executable rather than
+  analysis-only; versioned in the working repo beside the code it governs;
+  authored attention with derived rank; a live sensor/reading loop; dated
+  interview provenance; and a completable, pruned tactic layer.
+
+**Agent memory and context engineering** — the contrast category: those
+systems machine-extract *descriptive recall* of what happened; the intention
+graph is human-authored and *prescriptive* about what should happen:
+
+- Edge et al., ["From Local to Global: A Graph RAG
+  Approach"](https://arxiv.org/abs/2404.16130) (2024); Packer et al.,
+  ["MemGPT"](https://arxiv.org/abs/2310.08560) (2023); Rasmussen et al.,
+  ["Zep: A Temporal Knowledge Graph Architecture for Agent
+  Memory"](https://arxiv.org/abs/2501.13956) (2025) — extracted graphs and
+  tiered memory over data that already exists.
+- Mei et al., ["A Survey of Context Engineering for Large Language
+  Models"](https://arxiv.org/abs/2507.13334) (2025) and Anthropic,
+  ["Effective context engineering for AI
+  agents"](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+  (Sep 2025) — the per-turn context assembly discipline; the graph is the
+  durable artifact just-in-time retrieval reads *from*.
+
+**Long-horizon reliability** — why a leave-it-alone workflow needs sensors:
+
+- METR, ["Measuring AI Ability to Complete Long Software
+  Tasks"](https://arxiv.org/abs/2503.14499) (2025) and ["Time Horizon
+  1.1"](https://metr.org/blog/2026-1-29-time-horizon-1-1/) (Jan 2026) — task
+  horizons doubling every ~3–4 months, and accelerating.
+- Sinha et al., ["The Illusion of Diminishing
+  Returns"](https://arxiv.org/abs/2509.09677) (2025) — long-task failure is
+  execution slips, not reasoning gaps, and models self-condition on their own
+  errors: the case for bounded fresh-context sessions.
+- Khanal et al., ["Beyond pass@1: A Reliability Science Framework for
+  Long-Horizon LLM Agents"](https://arxiv.org/abs/2603.29231) (2026) —
+  reliability decay is worst in software engineering, and memory scaffolds
+  universally hurt long-horizon performance — a finding this design confronts
+  rather than omits: the graph is not an in-context scaffold; it is read
+  just-in-time, per bounded session.
+- Orlanski et al., ["SlopCodeBench"](https://arxiv.org/abs/2603.24755) (v2,
+  May 2026) — structural erosion and verbosity growth across iterative edits;
+  guidance alone does not prevent degradation, which is why the sensors are
+  separate sessions.
+- Cemri et al., ["Why Do Multi-Agent LLM Systems Fail?"
+  (MAST)](https://arxiv.org/abs/2503.13657) (2025) — the failure taxonomy the
+  review/QA fan-out phases exist to cover.
+
+## License
+
+[CC-BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/). Forking is
+encouraged.


### PR DESCRIPTION
Replaces the harness-first README with the author-ratified copy carried verbatim in `tactic-readme-data-structure-first`'s body (2026-08-04 practitioner-selection round).

The new README is the five fixed sections the strategy specifies — abstract, runbook, technical summary, references, license — with the intention graph leading and the reference harness presented as one consumer of it.

## Scope

- `README.md` only. 223 insertions, 324 deletions.
- The copy is reproduced byte-for-byte from the node body; no wording was settled in this session.

## Known gaps, shipped deliberately at the author's direction

- Three citations remain flagged unverified at `tactic-readme-reference-curriculum`: the Sean Grove talk date, the OpenAI Codex product-page bodies (403 to automated fetch), and the Lutke/Karpathy tweets.
- The displaced technical documentation — CI/CD workflows, router internals, PR control flow, prerequisites — has not migrated into the owning graph-node bodies. `tactic-readme-doc-migration` carries that work.
- Per `strategy-data-structure-first`'s target-state doctrine the README tracks the graph's greenfield design rather than implementation status, so it describes `/mount` and plugin installation ahead of their landing.

## Verification

Relative links resolve against the tree: `intentions/`, `intentions/kind-kind.md`, `packages/intentionsutil/`.

```verify
test -e intentions/kind-kind.md && test -d packages/intentionsutil && test -d intentions
```

Documentation-only change: no code QA or review lane applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)