### PR TITLE
reconcile-graph-merged: pin the diagnosis-time base blob so a concurrent park survives

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/reconcile-graph-merged
+++ b/.claude/skills/dispatch-propagate/scripts/reconcile-graph-merged
@@ -70,14 +70,28 @@ NOW=${GRAPH_RECONCILE_NOW:-$(date -u +%s)}
 # Enumeration is STRICT (`listNodesStrict`): a corrupt node file dropped by the
 # tolerant reader would silently never be reconciled, stranding its merged PR at
 # a stale phase. Abort the pass loudly instead.
+#
+# The id shape is validated HERE, at the point unvalidated frontmatter strings
+# first enter the sweep, because the tab/newline-delimited `read` loops below
+# cannot see the difference between a multi-line id and two records. See
+# validate_node_id() for why an id carrying `=`, whitespace, or a control
+# character is unsafe downstream (it silently re-keys graph-commit's
+# `--base <id>=<sha>` pin). Refuse the sweep rather than reconcile the node with
+# a broken or mis-keyed compare-and-swap base.
 OPEN_TACTICS="$( (cd "$REPO_ROOT" && node --import tsx/esm -e '
   const { listNodesStrict } = await import("./packages/intentionsutil/src/store.js");
   const open = new Set(["implement","fix","qa","review","main-qa"]);
+  const idOk = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
   for (const n of listNodesStrict("./intentions")) {
     if (n.kind !== "tactic") continue;
     if (n.phase === null || !open.has(n.phase)) continue;
     const pr = n.execution && n.execution.pr;
     if (pr === null || pr === undefined) continue;
+    if (!idOk.test(n.id)) {
+      process.stderr.write("unsafe node id " + JSON.stringify(n.id) +
+        " (must match /^[A-Za-z0-9][A-Za-z0-9._-]*$/)\n");
+      process.exit(1);
+    }
     process.stdout.write(n.id + "\t" + pr + "\n");
   }
 ') )" || { echo "reconcile-graph-merged: node enumeration failed" >&2; exit 1; }
@@ -161,6 +175,34 @@ fi
 STATES_FILE="$(mktemp)" || { echo "reconcile-graph-merged: mktemp failed" >&2; exit 1; }
 declare -A BASE_BLOB=()
 RESTORE_ON_FAILURE=0
+# HEAD as of the moment the rollback is armed — the exact commit the apply run's
+# disk mutation sits on top of, and the only commit `git checkout --` can be
+# trusted to restore to. Captured in Step 3; read by restore_node_files().
+HEAD_AT_ARM=""
+
+# A node id must be safe both as a single path component and as the KEY of
+# graph-commit's `--base <id>=<blobsha>` pair. add_blob_pair() splits the pair at
+# the FIRST `=` (packages/intentionsutil/scripts/graph-commit:369-378), so an id
+# containing `=` is silently re-keyed: `tactic-a=b` records the pin under the
+# truncated id `tactic-a` with the garbage sha `b=<real-sha>`. If a genuine
+# `tactic-a` is in the same batch its correct pin is overwritten, and
+# check_base_freshness then three-way merges against the wrong (or unresolvable)
+# base — defeating the very lost-update protection the pin exists to provide.
+# Whitespace and control characters are equally unsafe: the pin loop reads the
+# planned edit ids line by line, so a multi-line id would hash the wrong path and
+# leave the true id unpinned.
+#
+# Node ids are unvalidated frontmatter strings, so gate them here. Hard-error
+# (.claude/rules/code-style.md: clear errors over fallbacks) rather than skipping
+# the pin — a skipped pin is an UNPROTECTED write, exactly the failure this
+# compare-and-swap closes.
+validate_node_id() {
+  [[ "$1" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || {
+    echo "reconcile-graph-merged: unsafe node id $(printf '%q' "$1") — ids must match ^[A-Za-z0-9][A-Za-z0-9._-]*\$ (no '=', whitespace, or control characters) to be a valid --base pair key" >&2
+    exit 1
+  }
+}
+
 # Roll the apply run's disk mutations back to the checkout's CURRENT HEAD — not
 # to a captured blob. Restoring captured bytes is wrong on graph-commit's park
 # path: park_and_exit() does `git reset --hard FETCH_HEAD`, lands an office_hours
@@ -168,19 +210,96 @@ RESTORE_ON_FAILURE=0
 # leave the tree dirty with stale, park-erased content — the shared-checkout
 # residue that bricks graph-commit's assert_clean_outside_ids guard for every
 # other writer, and that re-erases the very park this node exists to protect.
-# `checkout --` is correct on every failure path uniformly: after a park the
-# files already match HEAD (no-op, park preserved); before any commit HEAD is
-# unmoved (reverts the apply run exactly as the old restore did). It also closes
-# a latent residue bug — when this checkout sits behind origin/main, the old
-# restore wrote origin/main bytes over files whose HEAD version differed,
-# leaving them dirty. Precedent: resolve-hold's clean_node_file(), same guard,
-# same reason.
+# It also closes a latent residue bug — when this checkout sits behind
+# origin/main, the old restore wrote origin/main bytes over files whose HEAD
+# version differed, leaving them dirty. Precedent: resolve-hold's
+# clean_node_file(), same guard, same reason.
+#
+# But `checkout --` is NOT a universal rollback, because HEAD moving does not
+# always mean the write landed. graph-commit runs commit_files() BEFORE land()
+# (graph-commit:770-777) and, on rc 11 — landing lock never acquired, scratch
+# push failed, required checks never green, or main advanced through every
+# MAX_PUSH_ATTEMPTS — exits 1 with no reset (graph-commit:1954-1957). HEAD then
+# carries this sweep's un-landed, un-CAS-checked mutation, and `checkout --`
+# would restore each node file to that MUTATED content: a no-op dressed up as a
+# rollback. Worse, graph-commit pushes HEAD rather than just the named node, so
+# the next unrelated graph-commit from this shared checkout would rebase and push
+# the stranded commit to main — a write that never passed check_base_freshness.
+#
+# So classify HEAD before restoring, and never report a rollback that did not
+# happen:
+#   - HEAD unmoved                 → checkout -- (the ordinary rollback).
+#   - HEAD moved, nothing unpushed → graph-commit landed what it moved to (its
+#                                    pushed park path); checkout -- is a no-op
+#                                    that preserves it.
+#   - HEAD moved, unpushed commits that are all graph-commit PARK commits
+#                                  → keep them (an unpushed park is a record a
+#                                    human still needs) and say so loudly.
+#   - HEAD moved, any unpushed NON-park commit → that is the escaped write.
+#                                    Discard it by resetting to HEAD_AT_ARM when
+#                                    that is safe, else refuse loudly.
 restore_node_files() {
-  local sid
+  local sid head_now
+  head_now="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null)" || {
+    echo "reconcile-graph-merged: cannot read HEAD — the apply run's node writes were NOT rolled back; inspect intentions/ by hand" >&2
+    return
+  }
+  if [[ -n "$HEAD_AT_ARM" && "$head_now" != "$HEAD_AT_ARM" ]]; then
+    local rl_out
+    if ! rl_out="$(git -C "$REPO_ROOT" rev-list origin/main..HEAD 2>&1)"; then
+      echo "reconcile-graph-merged: HEAD moved to ${head_now:0:8} during the write and origin/main is unreadable ($rl_out) — the apply run's node writes were NOT rolled back; inspect by hand before any other graph-commit runs from this checkout" >&2
+      return
+    fi
+    local -a unpushed=() nonpark=()
+    [[ -n "$rl_out" ]] && mapfile -t unpushed <<<"$rl_out"
+    local sha
+    for sha in "${unpushed[@]}"; do
+      # park_and_exit()'s commit subject is `graph: park <ids> (...)`; anything
+      # else on top of origin/main is this sweep's own un-landed content commit.
+      [[ "$(git -C "$REPO_ROOT" log -1 --format=%s "$sha")" == 'graph: park '* ]] || nonpark+=("$sha")
+    done
+    if [[ "${#nonpark[@]}" -gt 0 ]]; then
+      # Either the stranded commit is dropped (the tree is back at HEAD_AT_ARM,
+      # nothing left to check out) or the refusal was reported — either way the
+      # `checkout --` rollback below must not run and must not be claimed.
+      discard_stranded_commits "${nonpark[@]}"
+      return
+    fi
+    if [[ "${#unpushed[@]}" -gt 0 ]]; then
+      echo "reconcile-graph-merged: graph-commit's park commit ${unpushed[0]:0:8} is not on the local origin/main ref — treat the park as possibly unpushed; the node files are restored to HEAD, which KEEPS it" >&2
+    fi
+  fi
   for sid in "${!BASE_BLOB[@]}"; do
     git -C "$REPO_ROOT" checkout -- "intentions/$sid.md" ||
       echo "reconcile-graph-merged: rollback could not restore intentions/$sid.md to HEAD" >&2
   done
+  echo "reconcile-graph-merged: rolled the apply run's node writes back to HEAD ${head_now:0:8}" >&2
+}
+
+# Drop the un-landed commit(s) graph-commit left on HEAD, restoring the checkout
+# to the state the sweep found. Only safe when HEAD still descends from
+# HEAD_AT_ARM and every stranded commit is a single-parent, intentions/-only
+# commit — i.e. unmistakably this sweep's own write and not some other process's
+# work in the shared checkout. When it is not safe, refuse loudly: leaving the
+# commit with a warning that names it beats both silently stranding it and
+# destroying someone else's commit.
+discard_stranded_commits() { # <sha>...
+  local -a stranded=("$@")
+  local unsafe=0 sha parents files
+  git -C "$REPO_ROOT" merge-base --is-ancestor "$HEAD_AT_ARM" HEAD || unsafe=1
+  for sha in "${stranded[@]}"; do
+    parents="$(git -C "$REPO_ROOT" log -1 --format=%P "$sha" | wc -w)"
+    [[ "$parents" -eq 1 ]] || unsafe=1
+    files="$(git -C "$REPO_ROOT" show --name-only --format= "$sha")"
+    [[ -n "$files" ]] || unsafe=1
+    grep -qv '^intentions/' <<<"$files" && unsafe=1
+  done
+  if [[ "$unsafe" -eq 0 ]] && git -C "$REPO_ROOT" reset -q --hard "$HEAD_AT_ARM"; then
+    echo "reconcile-graph-merged: graph-commit committed but never landed ${#stranded[@]} commit(s) (${stranded[0]:0:8}) — discarded by resetting to ${HEAD_AT_ARM:0:8}; NOTHING was written to main" >&2
+    return 0
+  fi
+  echo "reconcile-graph-merged: graph-commit left un-landed commit(s) on HEAD (${stranded[0]}) that never passed check_base_freshness, and they are NOT safely discardable — the write was NOT rolled back. Drop them by hand before any other graph-commit runs from this checkout: it pushes HEAD, not just the node it names" >&2
+  return 1
 }
 # Single EXIT trap (bash traps REPLACE on a signal, not stack): always drop the
 # temp file, and roll the write back when a post-pin step armed the flag.
@@ -209,6 +328,7 @@ PLAN_ONLY="$( (cd "$REPO_ROOT" && node --import tsx/esm "$UTIL_SCRIPTS/reconcile
 # — a hash-object failure on a planned edit id is a real error, not a skip.
 while IFS= read -r sid; do
   [[ -n "$sid" ]] || continue
+  validate_node_id "$sid"
   blob=$(git -C "$REPO_ROOT" hash-object -w -- "intentions/$sid.md") || {
     echo "reconcile-graph-merged: cannot pin base blob for $sid (no CAS base, no rollback path)" >&2; exit 1; }
   BASE_BLOB[$sid]="$blob"
@@ -216,9 +336,16 @@ done < <(jq -r '.edit[]?' <<<"$PLAN_ONLY")
 
 # Step 3: real apply run — mutates disk; its stdout drives the rest of the
 # script. Arm the rollback: any failure from here through graph-commit restores.
+# Pin HEAD first: it is the commit the mutation sits on, and restore_node_files()
+# compares against it to tell an ordinary rollback from graph-commit having moved
+# HEAD (landed park vs. un-landed, stranded commit). Only the rollback path
+# reports what it actually did — the failure sites below name the CAUSE only, and
+# never claim the write was rolled back.
+HEAD_AT_ARM="$(git -C "$REPO_ROOT" rev-parse HEAD)" || {
+  echo "reconcile-graph-merged: cannot read HEAD before the apply run (no rollback reference point)" >&2; exit 1; }
 RESTORE_ON_FAILURE=1
 PLAN="$( (cd "$REPO_ROOT" && node --import tsx/esm "$UTIL_SCRIPTS/reconcile-graph.ts" --pr-states "$STATES_FILE") )" || {
-  echo "reconcile-graph-merged: reconcile-graph.ts failed (write rolled back)" >&2; exit 1; }
+  echo "reconcile-graph-merged: reconcile-graph.ts failed" >&2; exit 1; }
 
 # Report deferrals (residue→main-qa, inert until tactic-main-qa-phase).
 while IFS= read -r d; do
@@ -242,7 +369,12 @@ GC_ARGS=(-C "$REPO_ROOT" -m "graph: reconcile terminal tactics (record completio
 # die()s on a malformed pair. Every planned edit id was pinned in Step 2 from
 # the same deterministic plan, so a missing pin means the plan drifted between
 # the two runs: hard-error rather than land an unprotected write.
+#
+# Re-gate the id shape here too, at the exact point the `<id>=<sha>` pair is
+# built: graph-commit splits the pair at the FIRST `=`, so an id carrying one
+# would be silently re-keyed onto a different node (see validate_node_id()).
 for id in "${EDIT[@]}"; do
+  validate_node_id "$id"
   [[ -n "${BASE_BLOB[$id]:-}" ]] || {
     echo "reconcile-graph-merged: no pinned base blob for planned edit id $id (plan drifted between the --no-apply and apply runs)" >&2
     exit 1; }
@@ -251,7 +383,10 @@ done
 for id in "${EDIT[@]}"; do GC_ARGS+=("$id"); done
 
 if ! "$GRAPH_COMMIT" "${GC_ARGS[@]}"; then
-  echo "reconcile-graph-merged: graph-commit failed (write rolled back)" >&2
+  # No rollback claim here — restore_node_files() (EXIT trap) inspects HEAD and
+  # reports what it actually did, since graph-commit can fail with the write
+  # already committed locally (rc 11, busy main) or with a park landed.
+  echo "reconcile-graph-merged: graph-commit failed" >&2
   exit 1
 fi
 # Landed — disarm the rollback so the clean exit keeps the committed state.

--- a/.claude/skills/dispatch-propagate/scripts/reconcile-graph-merged
+++ b/.claude/skills/dispatch-propagate/scripts/reconcile-graph-merged
@@ -21,7 +21,13 @@
 #     on, distinct from silent deletion.
 #   - The serving strategy's round is still stamped here, at the done-transition,
 #     when its last non-draft child reaches `done`.
-# The whole plan (edits only) lands as ONE graph-commit.
+# The whole plan (edits only) lands as ONE graph-commit, under a diagnosis-time
+# compare-and-swap: each edited id's pre-mutation on-disk blob is pinned and
+# passed as `graph-commit --base <id>=<blob>`, so an edit that lands on
+# origin/main between this sweep's read and its commit is three-way merged
+# rather than silently overwritten. See Step 2 for why the pin is the DISK blob
+# and why `hash-object -w` is mandatory, and
+# .claude/skills/ref-diagnosis-time-cas/SKILL.md for the doctrine.
 #
 # Manual completion backfill (office-hours workflow, no script): when a tactic's
 # PR is closed-unmerged but its content genuinely landed on `main` out-of-band,
@@ -123,42 +129,89 @@ if [[ "$STATES" == "{}" ]]; then
 fi
 
 # --- Decide + apply the store mutations --------------------------------------
-# Plan-then-apply for a rollback path: a --no-apply run yields the plan's exact
-# edit id set WITHOUT touching disk; we snapshot each of those ids from
-# origin/main, THEN run the real apply. Both runs read the same unmutated
-# intentions/ dir (nothing else writes it between them), so the plan is
-# deterministic — the snapshotted ids match the ids the apply run mutates. The
-# plan is edit-only (nothing is pruned here anymore), so on any failure of the
-# apply run or the graph-commit, RESTORE_ON_FAILURE simply dumps each snapshot
-# blob back over its file, leaving intentions/ clean rather than tripping
-# graph-commit's assert_clean_outside_ids guard for every other node.
+# Plan-then-apply: a --no-apply run yields the plan's exact edit id set WITHOUT
+# touching disk; we pin each of those ids' pre-mutation on-disk blob, THEN run
+# the real apply. Both runs read the same unmutated intentions/ dir (nothing
+# else writes it between them), so the plan is deterministic — the pinned ids
+# match the ids the apply run mutates.
+#
+# The pinned blob is the diagnosis-time compare-and-swap base handed to
+# graph-commit as --base <id>=<blob>. Without it, graph-commit's
+# check_base_freshness() short-circuits on its first line and the sweep lands
+# whatever reconcile-graph.ts's writeNode put on disk, silently overwriting any
+# edit that landed on origin/main between this sweep's read and its commit.
+# That lost update is bug X: writeNode rewrites the WHOLE node from the
+# in-memory read, so a live office_hours park landed by another writer inside
+# that window was erased with `phase` left untouched.
+#
+# Ruling 31, read side vs write side — do NOT "simplify" this pin away as
+# redundant with the read-side ungating. This sweep deliberately stays UNGATED
+# on office_hours for its phase/merge decisions: it must keep advancing and
+# merging parked nodes. The pin governs the WRITE side only. It makes the sweep
+# skip nothing; it makes graph-commit merge a concurrently landed field instead
+# of clobbering it. Both properties hold at once.
+#
+# graph-commit MERGES rather than refuses on drift: on a stale base it runs the
+# structural three-way merge (base = the pinned blob, ours = our on-disk edit,
+# theirs = origin/main's landed content) and parks only when a divergence is
+# genuinely unresolvable. office_hours is a SCALAR_FIELD this sweep never
+# touches, so ours == base and scalarMerge takes theirs — the concurrent park
+# survives — while our phase/completion edits take the "theirs unchanged → take
+# ours" leg. Absorbing the park beats refusing the whole sweep.
 STATES_FILE="$(mktemp)" || { echo "reconcile-graph-merged: mktemp failed" >&2; exit 1; }
-declare -A SNAPSHOT=()
+declare -A BASE_BLOB=()
 RESTORE_ON_FAILURE=0
-restore_snapshot() {
-  local sid blob
-  for sid in "${!SNAPSHOT[@]}"; do
-    blob="${SNAPSHOT[$sid]}"
-    git -C "$REPO_ROOT" show "$blob" > "$REPO_ROOT/intentions/$sid.md"
+# Roll the apply run's disk mutations back to the checkout's CURRENT HEAD — not
+# to a captured blob. Restoring captured bytes is wrong on graph-commit's park
+# path: park_and_exit() does `git reset --hard FETCH_HEAD`, lands an office_hours
+# park, and exits non-zero, so HEAD has MOVED. Writing pre-park bytes back would
+# leave the tree dirty with stale, park-erased content — the shared-checkout
+# residue that bricks graph-commit's assert_clean_outside_ids guard for every
+# other writer, and that re-erases the very park this node exists to protect.
+# `checkout --` is correct on every failure path uniformly: after a park the
+# files already match HEAD (no-op, park preserved); before any commit HEAD is
+# unmoved (reverts the apply run exactly as the old restore did). It also closes
+# a latent residue bug — when this checkout sits behind origin/main, the old
+# restore wrote origin/main bytes over files whose HEAD version differed,
+# leaving them dirty. Precedent: resolve-hold's clean_node_file(), same guard,
+# same reason.
+restore_node_files() {
+  local sid
+  for sid in "${!BASE_BLOB[@]}"; do
+    git -C "$REPO_ROOT" checkout -- "intentions/$sid.md" ||
+      echo "reconcile-graph-merged: rollback could not restore intentions/$sid.md to HEAD" >&2
   done
 }
 # Single EXIT trap (bash traps REPLACE on a signal, not stack): always drop the
-# temp file, and roll the write back when a post-snapshot step armed the flag.
-trap 'rc=$?; rm -f "$STATES_FILE"; [[ "$RESTORE_ON_FAILURE" -ne 0 ]] && restore_snapshot; exit $rc' EXIT
+# temp file, and roll the write back when a post-pin step armed the flag.
+trap 'rc=$?; rm -f "$STATES_FILE"; [[ "$RESTORE_ON_FAILURE" -ne 0 ]] && restore_node_files; exit $rc' EXIT
 printf '%s' "$STATES" > "$STATES_FILE"
 
-# Step 1: plan-only run (no disk mutation) to learn the id set to snapshot.
+# Step 1: plan-only run (no disk mutation) to learn the id set to pin.
 PLAN_ONLY="$( (cd "$REPO_ROOT" && node --import tsx/esm "$UTIL_SCRIPTS/reconcile-graph.ts" --pr-states "$STATES_FILE" --no-apply) )" || {
   echo "reconcile-graph-merged: reconcile-graph.ts --no-apply failed" >&2; exit 1; }
 
-# Step 2: snapshot every planned edit id from origin/main. All planned ids are
-# landed nodes present on origin/main; a rev-parse miss is a hard error —
-# that id can't be safely mutated without a rollback path.
+# Step 2: pin every planned edit id's diagnosis-time base blob — the blob of the
+# ON-DISK file, which is exactly the content reconcile-graph.ts's readNode reads
+# in Step 3. NOT origin/main's blob: graph-commit defines base as "the blob the
+# writer read", and when this checkout sits behind origin/main the two differ.
+# Pinning origin/main would make scalarMerge compute a spurious "ours" delta on
+# fields this sweep never touched and could revert landed content — the exact
+# failure class the pin exists to close. In the normal synced case the two are
+# byte-identical and the distinction is a no-op.
+#
+# `-w` is MANDATORY, not an optimization: check_base_freshness resolves the base
+# with `git cat-file -p <sha>` and die()s with "base blob … is unreadable in the
+# local object database" when it misses. A disk blob differing from every
+# committed blob is absent from the object database unless -w writes it there,
+# so omitting -w would convert a benign stale base into a hard die. Keep the
+# hard-error posture (.claude/rules/code-style.md: clear errors over fallbacks)
+# — a hash-object failure on a planned edit id is a real error, not a skip.
 while IFS= read -r sid; do
   [[ -n "$sid" ]] || continue
-  blob=$(git -C "$REPO_ROOT" rev-parse "origin/main:intentions/$sid.md" 2>/dev/null) || {
-    echo "reconcile-graph-merged: cannot snapshot $sid from origin/main (no rollback path)" >&2; exit 1; }
-  SNAPSHOT[$sid]="$blob"
+  blob=$(git -C "$REPO_ROOT" hash-object -w -- "intentions/$sid.md") || {
+    echo "reconcile-graph-merged: cannot pin base blob for $sid (no CAS base, no rollback path)" >&2; exit 1; }
+  BASE_BLOB[$sid]="$blob"
 done < <(jq -r '.edit[]?' <<<"$PLAN_ONLY")
 
 # Step 3: real apply run — mutates disk; its stdout drives the rest of the
@@ -182,6 +235,19 @@ if [[ "${#EDIT[@]}" -eq 0 ]]; then
 fi
 
 GC_ARGS=(-C "$REPO_ROOT" -m "graph: reconcile terminal tactics (record completion)")
+# Thread the diagnosis-time pins as repeated --base flags. graph-commit accepts
+# both a manifest file and repeated flags; the repeated form drops straight into
+# the existing edit-id loop. The <id>=<sha> PAIR form (never a bare sha) is
+# required for a multi-id call and is a free correctness guard — graph-commit
+# die()s on a malformed pair. Every planned edit id was pinned in Step 2 from
+# the same deterministic plan, so a missing pin means the plan drifted between
+# the two runs: hard-error rather than land an unprotected write.
+for id in "${EDIT[@]}"; do
+  [[ -n "${BASE_BLOB[$id]:-}" ]] || {
+    echo "reconcile-graph-merged: no pinned base blob for planned edit id $id (plan drifted between the --no-apply and apply runs)" >&2
+    exit 1; }
+  GC_ARGS+=(--base "$id=${BASE_BLOB[$id]}")
+done
 for id in "${EDIT[@]}"; do GC_ARGS+=("$id"); done
 
 if ! "$GRAPH_COMMIT" "${GC_ARGS[@]}"; then

--- a/.claude/skills/dispatch-propagate/scripts/test-graph-write-rollback.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-graph-write-rollback.sh
@@ -41,6 +41,26 @@
 #      land / reset-back dance, and the freshness computation
 #      dispatch-graph-scope-sweep runs afterward reports scopeStale=false. This
 #      is the ONE case whose graph-commit stub SUCCEEDS.
+#   6. reconcile-graph-merged pins exactly one `--base <id>=<blob>` per planned
+#      edit id, and pins the ON-DISK blob rather than origin/main's (bug X,
+#      tactic-reconcile-park-clobber Unit 1).
+#   7. The race itself: an office_hours park landed between the sweep's read and
+#      its commit SURVIVES, while the sweep's own phase→done and merge evidence
+#      still land. This case runs the REAL graph-commit (only `gh` is stubbed) —
+#      its check_base_freshness three-way merge is the machinery under test.
+#   8. The graph-commit park path — which Unit 1 makes reachable from this
+#      script for the first time — rolls back to HEAD, leaving a clean tree and
+#      preserving the park rather than restoring stale park-erased bytes
+#      (Unit 2).
+#
+# Cases 6 and 7 are both verified to go RED when Unit 1's `--base` threading is
+# reverted. Case 7 needed care to avoid being vacuous: if the checkout is left
+# BEHIND origin/main, graph-commit's push is rejected, it rebases, git reports a
+# textual conflict, and layer-2's field-level auto-merge preserves the park all
+# on its own — passing with or without the fix. The fixture therefore
+# fast-forwards HEAD onto the park commit (see the wrapper in case 7), which is
+# the shape production erasures actually took: no conflict to rescue, so --base
+# is the only thing that can catch the lost update.
 #
 # No network needed; requires bash + git + jq + a real node/npx tsx (resolved
 # against a read-only node_modules symlink to this repo's own — never written).
@@ -93,6 +113,12 @@ build_seed_repo() {
   cp "$UTIL_SCRIPTS_SRC/write-node.ts" "$dst/packages/intentionsutil/scripts/write-node.ts"
   cp "$UTIL_SCRIPTS_SRC/graph-census-debt.ts" "$dst/packages/intentionsutil/scripts/graph-census-debt.ts"
   cp "$UTIL_SCRIPTS_SRC/restamp-scope-fingerprint.ts" "$dst/packages/intentionsutil/scripts/restamp-scope-fingerprint.ts"
+  # reconcile-graph.ts is the real decision+write primitive behind
+  # reconcile-graph-merged (cases 6-8); merge-node.ts is the layer-2/3 field
+  # merge CLI the REAL graph-commit shells out to via `npx tsx` when a --base
+  # pin is stale (case 7's whole point).
+  cp "$UTIL_SCRIPTS_SRC/reconcile-graph.ts" "$dst/packages/intentionsutil/scripts/reconcile-graph.ts"
+  cp "$UTIL_SCRIPTS_SRC/merge-node.ts" "$dst/packages/intentionsutil/scripts/merge-node.ts"
   chmod +x "$dst/packages/intentionsutil/scripts/graph-commit"
   cp "$HARNESS_DIR/lib.sh" "$dst/.claude/skills/dispatch-propagate/scripts/lib.sh"
   cp "$HARNESS_DIR/dispatch-config-load" "$dst/.claude/skills/dispatch-propagate/scripts/dispatch-config-load"
@@ -567,6 +593,369 @@ else
   printf 'landed residue lines: %s / worktree residue lines: %s\n' \
     "$(grep -c 'needs-main' <<<"$landed_body" || true)" \
     "$(grep -c 'needs-main' <<<"$worktree_body" || true)"
+fi
+
+# ===========================================================================
+# Cases 6-8: reconcile-graph-merged's diagnosis-time compare-and-swap
+# (tactic-reconcile-park-clobber, bug X).
+#
+# The defect: reconcile-graph.ts rewrites the WHOLE node from its in-memory
+# read, and reconcile-graph-merged used to hand graph-commit ZERO --base flags —
+# so check_base_freshness() short-circuited and the sweep silently overwrote any
+# edit that landed on origin/main between its read and its commit. Measured
+# effect: a live office_hours park erased with `phase` untouched.
+#
+# Case 6 guards the pin's construction, case 7 the end-to-end race outcome, and
+# case 8 the park-path rollback Unit 1 newly makes reachable.
+# ===========================================================================
+
+# reconcile_gh_stub <bin-dir> <fixture-dir> — a `gh` standing in for both API
+# surfaces this family touches:
+#   - `gh api repos/{owner}/{repo}/pulls/<n>` → a REST-shaped MERGED PR (REST
+#     reports a merged PR as state "closed" with merged_at set; the
+#     merged/closed discriminator is merged_at, never the state string).
+#   - `gh api .../check-runs --jq <prog>` → runs graph-commit's REAL --jq
+#     program against an all-green fixture, so the filter itself is exercised
+#     rather than a hardcoded count string (test-park-node.sh's approach).
+# `app.slug` is required, not decorative: graph-commit's required-check gate
+# only counts rows authored by the github-actions App.
+reconcile_gh_stub() {
+  local bindir="$1" fixdir="$2"
+  mkdir -p "$bindir" "$fixdir"
+  cat >"$fixdir/green.json" <<'JSON'
+{"check_runs": [
+  {"name": "acceptance", "status": "completed", "conclusion": "success", "id": 1, "app": {"slug": "github-actions"}},
+  {"name": "preview-and-smoke", "status": "completed", "conclusion": "success", "id": 2, "app": {"slug": "github-actions"}},
+  {"name": "lint", "status": "completed", "conclusion": "success", "id": 3, "app": {"slug": "github-actions"}},
+  {"name": "unit-tests", "status": "completed", "conclusion": "success", "id": 4, "app": {"slug": "github-actions"}}
+]}
+JSON
+  cat >"$bindir/gh" <<'SH'
+#!/usr/bin/env bash
+# Args always arrive as: gh api <path> [--jq <prog>] ...
+path=""
+jq_program=""
+prev=""
+for a in "$@"; do
+  case "$prev" in
+    --jq) jq_program="$a" ;;
+  esac
+  case "$a" in
+    */pulls/*|*/check-runs) path="$a" ;;
+  esac
+  prev="$a"
+done
+case "$path" in
+  */check-runs)
+    jq -r "$jq_program" "$GC_FIXTURE_DIR/green.json" ;;
+  */pulls/*)
+    num="${path##*/}"
+    jq -n --argjson n "$num" '{
+      number: $n, title: "harness pr", body: "",
+      state: "closed",
+      merged_at: "2026-08-01T00:00:00Z",
+      merge_commit_sha: "0123456789abcdef0123456789abcdef01234567",
+      mergeable: true, mergeable_state: "clean",
+      head: {ref: "harness-branch", sha: "89abcdef0123456789abcdef0123456789abcdef"},
+      labels: []
+    }' ;;
+  *)
+    echo "gh stub: unhandled invocation: $*" >&2; exit 1 ;;
+esac
+SH
+  chmod +x "$bindir/gh"
+}
+
+# reconcile_node <file> <id> <pr> — a tactic at an OPEN phase carrying a PR and
+# NO `## needs-main residue` section, so the sweep classifies it merged→done.
+reconcile_node() {
+  cat >"$1" <<NODE
+---
+id: $2
+kind: tactic
+statement: harness node for the reconcile CAS test
+owner: ai
+status: codified
+phase: implement
+serves: []
+execution:
+  branch: $2
+  pr: $3
+  attempts: {}
+  markers: []
+  strategy_fingerprint: null
+  fix: null
+  completion: null
+office_hours: null
+---
+# harness node for the reconcile CAS test
+NODE
+}
+
+# Fixed clock: GRACE=0 + a pinned NOW keeps every case off real time.
+RECON_ENV=(GRAPH_RECONCILE_GRACE=0 GRAPH_RECONCILE_NOW=1800000000)
+
+# ===========================================================================
+# Case 6: reconcile-graph-merged pins one --base per planned edit id, and pins
+# the ON-DISK blob rather than origin/main's.
+#
+# t-r2's copy on origin/main is deliberately moved AHEAD of the clone's checkout
+# after cloning, so disk and origin/main genuinely differ for that node. The
+# pin must follow the disk (what reconcile-graph.ts's readNode actually reads) —
+# pinning origin/main would make scalarMerge compute a spurious "ours" delta on
+# untouched fields and could revert landed content.
+# ===========================================================================
+T6="$WORK/t6-seed"
+build_seed_repo "$T6"
+cp "$HARNESS_DIR/reconcile-graph-merged" "$T6/.claude/skills/dispatch-propagate/scripts/reconcile-graph-merged"
+chmod +x "$T6/.claude/skills/dispatch-propagate/scripts/reconcile-graph-merged"
+reconcile_node "$T6/intentions/t-r1.md" t-r1 101
+reconcile_node "$T6/intentions/t-r2.md" t-r2 102
+new_origin t6
+init_and_push "$T6"
+
+C6="$WORK/t6-clone"
+clone_with_node_modules "$C6"
+BIN6="$WORK/t6-bin"; FIX6="$WORK/t6-fixtures"
+reconcile_gh_stub "$BIN6" "$FIX6"
+# graph-commit stub: record argv, succeed.
+cat >"$C6/packages/intentionsutil/scripts/graph-commit" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$@" >"$WORK/t6-argv.txt"
+exit 0
+SH
+chmod +x "$C6/packages/intentionsutil/scripts/graph-commit"
+
+# Move t-r2's copy on origin/main ahead of the clone (the clone never pulls),
+# so hash-object(disk) != rev-parse(origin/main:...) for t-r2.
+printf '\nlanded on origin after the clone\n' >>"$T6/intentions/t-r2.md"
+git -C "$T6" commit -qam 'move t-r2 ahead on origin/main'
+git -C "$T6" push -q origin main
+git -C "$C6" fetch -q origin
+
+# The pre-apply disk blobs — exactly what the pin must equal.
+disk_r1_before="$(git -C "$C6" hash-object -- intentions/t-r1.md)"
+disk_r2_before="$(git -C "$C6" hash-object -- intentions/t-r2.md)"
+origin_r2="$(git -C "$C6" rev-parse origin/main:intentions/t-r2.md)"
+
+out="$(
+  cd "$C6" || exit 99
+  export PATH="$BIN6:$PATH" GC_FIXTURE_DIR="$FIX6"
+  export "${RECON_ENV[@]}"
+  bash .claude/skills/dispatch-propagate/scripts/reconcile-graph-merged 2>&1
+)"; rc=$?
+argv6="$(cat "$WORK/t6-argv.txt" 2>/dev/null || true)"
+base_count="$(grep -c -- '^--base$' <<<"$argv6" || true)"
+pin_r1="$(grep -o '^t-r1=[0-9a-f]\{40\}$' <<<"$argv6" || true)"
+pin_r2="$(grep -o '^t-r2=[0-9a-f]\{40\}$' <<<"$argv6" || true)"
+
+if [[ $rc -eq 0 ]] \
+   && [[ "$base_count" -eq 2 ]] \
+   && [[ "$pin_r1" == "t-r1=$disk_r1_before" ]] \
+   && [[ "$pin_r2" == "t-r2=$disk_r2_before" ]] \
+   && [[ "$disk_r2_before" != "$origin_r2" ]] \
+   && [[ "$pin_r2" != "t-r2=$origin_r2" ]]; then
+  ok "reconcile-graph-merged --base construction: exactly one pin per planned edit id, each the PRE-apply on-disk blob (t-r2 proves it follows disk, not origin/main)"
+else
+  no "reconcile-graph-merged --base construction (rc=$rc, --base count=$base_count)"
+  printf '%s\n' "$out"
+  printf 'argv: %s\n' "$argv6"
+  printf 'want t-r1=%s t-r2=%s (origin t-r2=%s)\n' "$disk_r1_before" "$disk_r2_before" "$origin_r2"
+fi
+
+# ===========================================================================
+# Case 7: THE RACE — a park landed between the sweep's read and its commit
+# survives the reconcile. This is the case that actually reproduces bug X, and
+# the one that runs the REAL graph-commit (its check_base_freshness is the
+# machinery under test; only `gh` is stubbed).
+#
+# There is no natural injection point between reconcile-graph-merged's pin and
+# graph-commit's fetch — they are back-to-back in one synchronous process — so,
+# exactly as test-park-node.sh:486-520 does, graph-commit is moved aside to
+# graph-commit.real and a thin wrapper lands the concurrent park ONCE (sentinel
+# guarded) before delegating. The real check_base_freshness then re-fetches,
+# sees origin's blob no longer matches the pinned base, and three-way merges:
+# office_hours is a SCALAR_FIELD the sweep never touches (ours == base) so
+# scalarMerge takes THEIRS (the park survives), while `phase` is unchanged on
+# origin (theirs == base) so it takes OURS (done).
+#
+# REVERT UNIT 1's --base threading and this case goes red with
+# office_hours: null — the exact erasure this node exists to stop.
+# ===========================================================================
+T7="$WORK/t7-seed"
+build_seed_repo "$T7"
+cp "$HARNESS_DIR/reconcile-graph-merged" "$T7/.claude/skills/dispatch-propagate/scripts/reconcile-graph-merged"
+chmod +x "$T7/.claude/skills/dispatch-propagate/scripts/reconcile-graph-merged"
+reconcile_node "$T7/intentions/t-race.md" t-race 4242
+
+# The concurrent-park wrapper is installed in the SEED and pushed, so the clone
+# sits EXACTLY at origin/main. This is load-bearing, not tidiness: installing it
+# in the clone instead requires committing it (graph-commit's
+# assert_clean_outside_ids refuses to start on a dirty tracked file), and that
+# commit makes the worktree "ahead of origin/main with non-intentions changes".
+# graph-commit then takes its ensure_intentions_only_base() path, whose
+# `git reset --hard FETCH_HEAD` DISCARDS the file check_base_freshness just
+# merged and re-materializes the caller's pre-merge edit — so the park is lost
+# and this case fails for a reason that has nothing to do with the code under
+# test. The production reconciler runs from a main checkout at-or-behind
+# origin/main and never takes that path, so seeding the wrapper reproduces the
+# real shape. (The far-ahead path's interaction with a CAS merge is a separate
+# latent concern, deliberately out of scope for this node.)
+mv "$T7/packages/intentionsutil/scripts/graph-commit" \
+   "$T7/packages/intentionsutil/scripts/graph-commit.real"
+cat >"$T7/packages/intentionsutil/scripts/graph-commit" <<'SH'
+#!/usr/bin/env bash
+set -uo pipefail
+SD="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ ! -f "$SD/.concurrent-landed" ]]; then
+  # Another writer (a main-qa pass, an office-hours park) lands an office_hours
+  # park on the SAME node AFTER the sweep pinned its base but before this land.
+  D="$(mktemp -d)"
+  git clone -q "$GC_ORIGIN" "$D"
+  git -C "$D" config user.email other@test
+  git -C "$D" config user.name other
+  awk '
+    /^office_hours: null$/ {
+      print "office_hours:"
+      print "  reason: concurrent park landed between the sweep read and its commit"
+      print "  since: 2026-08-05"
+      print "  recommendation: harness fixture park"
+      print "  session_type: other"
+      next
+    }
+    { print }
+  ' "$D/intentions/$GC_NODE.md" >"$D/intentions/$GC_NODE.md.new"
+  mv "$D/intentions/$GC_NODE.md.new" "$D/intentions/$GC_NODE.md"
+  git -C "$D" commit -qam 'concurrent office_hours park (bypassing the sweep)'
+  git -C "$D" push -q origin main
+  rm -rf "$D"
+  # Fast-forward THIS checkout's HEAD onto the park commit while leaving the
+  # working-tree node file (the sweep's stale-read edit) untouched. This is what
+  # makes the case a real bug-X reproduction rather than a layer-2 test:
+  #
+  # If HEAD stays behind, graph-commit's push is rejected, it rebases, git
+  # reports a textual conflict on the node file, and layer-2's field-level
+  # auto-merge rescues the park all by itself — the park survives with or
+  # without --base and the case proves nothing. Production erasures had no
+  # conflict to rescue: the park commit was ALREADY in the new commit's
+  # ancestry, so the sweep's whole-file rewrite from its stale in-memory read
+  # fast-forwarded cleanly and silently dropped the park. `reset --mixed` puts
+  # the checkout in exactly that state, leaving --base as the ONLY thing that
+  # can still catch the lost update.
+  git -C "$GC_CLONE" fetch -q origin main
+  git -C "$GC_CLONE" reset -q --mixed FETCH_HEAD
+  : >"$SD/.concurrent-landed"
+fi
+exec "$SD/graph-commit.real" "$@"
+SH
+chmod +x "$T7/packages/intentionsutil/scripts/graph-commit"
+chmod +x "$T7/packages/intentionsutil/scripts/graph-commit.real"
+new_origin t7
+init_and_push "$T7"
+
+C7="$WORK/t7-clone"
+clone_with_node_modules "$C7"
+BIN7="$WORK/t7-bin"; FIX7="$WORK/t7-fixtures"
+reconcile_gh_stub "$BIN7" "$FIX7"
+
+out="$(
+  cd "$C7" || exit 99
+  export PATH="$BIN7:$PATH" GC_FIXTURE_DIR="$FIX7"
+  export GC_ORIGIN="$ORIGIN" GC_NODE=t-race GC_CLONE="$C7"
+  export GRAPH_COMMIT_CHECK_POLL_SECONDS=1 GRAPH_COMMIT_CHECK_TIMEOUT_SECONDS=20
+  export "${RECON_ENV[@]}"
+  bash .claude/skills/dispatch-propagate/scripts/reconcile-graph-merged 2>&1
+)"; rc=$?
+
+landed7="$(git -C "$C7" fetch -q origin && git -C "$C7" show origin/main:intentions/t-race.md)"
+phase7="$(grep -m1 '^phase:' <<<"$landed7" | awk '{print $2}')"
+if [[ $rc -eq 0 ]] \
+   && [[ "$phase7" == "done" ]] \
+   && grep -q 'concurrent park landed between the sweep read and its commit' <<<"$landed7" \
+   && grep -q 'mergedAt: .*2026-08-01' <<<"$landed7" \
+   && grep -q '0123456789abcdef0123456789abcdef01234567' <<<"$landed7"; then
+  ok "reconcile-graph-merged CAS race: a concurrently landed office_hours park SURVIVES the reconcile while the sweep's own phase→done + merge evidence still land"
+else
+  no "reconcile-graph-merged CAS race (rc=$rc, phase=$phase7)"
+  printf '%s\n' "$out"
+  printf 'landed:\n%s\n' "$landed7"
+fi
+
+# ===========================================================================
+# Case 8: the park-path rollback leaves a CLEAN tree (Unit 2's guard).
+#
+# Unit 1 makes graph-commit's park_and_exit() path reachable from this script
+# for the first time. On that path graph-commit resets to origin/main, lands an
+# office_hours park, and exits NON-ZERO — so HEAD has MOVED. The old rollback
+# wrote each pinned blob back over its file, which under a moved HEAD leaves the
+# tree dirty with stale, PARK-ERASED content: the shared-checkout residue that
+# bricks graph-commit's assert_clean_outside_ids guard for every other writer.
+# Restoring to HEAD instead is clean-by-construction.
+# ===========================================================================
+T8="$WORK/t8-seed"
+build_seed_repo "$T8"
+cp "$HARNESS_DIR/reconcile-graph-merged" "$T8/.claude/skills/dispatch-propagate/scripts/reconcile-graph-merged"
+chmod +x "$T8/.claude/skills/dispatch-propagate/scripts/reconcile-graph-merged"
+reconcile_node "$T8/intentions/t-parked.md" t-parked 808
+new_origin t8
+init_and_push "$T8"
+
+C8="$WORK/t8-clone"
+clone_with_node_modules "$C8"
+BIN8="$WORK/t8-bin"; FIX8="$WORK/t8-fixtures"
+reconcile_gh_stub "$BIN8" "$FIX8"
+# graph-commit stub standing in for park_and_exit(): land a park commit (moving
+# HEAD), then fail — exactly the shape that makes a blob-restore leave residue.
+cat >"$C8/packages/intentionsutil/scripts/graph-commit" <<'SH'
+#!/usr/bin/env bash
+set -uo pipefail
+dir=""; ids=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -C) dir="${2:-}"; shift 2 ;;
+    -m|--base) shift 2 ;;
+    *) ids+=("$1"); shift ;;
+  esac
+done
+cd "$dir" || exit 2
+for id in "${ids[@]}"; do
+  awk '
+    /^office_hours: null$/ {
+      print "office_hours:"
+      print "  reason: graph-commit parked this node on an unresolvable divergence"
+      print "  since: 2026-08-05"
+      print "  recommendation: harness fixture park"
+      print "  session_type: other"
+      next
+    }
+    { print }
+  ' "intentions/$id.md" >"intentions/$id.md.new"
+  mv "intentions/$id.md.new" "intentions/$id.md"
+  git add "intentions/$id.md"
+done
+git commit -qm 'graph-commit stub: park_and_exit stand-in'
+echo "graph-commit: parked on unresolvable divergence" >&2
+exit 1
+SH
+chmod +x "$C8/packages/intentionsutil/scripts/graph-commit"
+
+out="$(
+  cd "$C8" || exit 99
+  export PATH="$BIN8:$PATH" GC_FIXTURE_DIR="$FIX8"
+  export "${RECON_ENV[@]}"
+  bash .claude/skills/dispatch-propagate/scripts/reconcile-graph-merged 2>&1
+)"; rc=$?
+status8="$(git -C "$C8" status --porcelain intentions/)"
+node8="$(cat "$C8/intentions/t-parked.md")"
+if [[ $rc -ne 0 ]] \
+   && [[ -z "$status8" ]] \
+   && grep -q 'graph-commit parked this node on an unresolvable divergence' <<<"$node8"; then
+  ok "reconcile-graph-merged park-path rollback: restoring to HEAD leaves a clean tree and preserves the park graph-commit just landed"
+else
+  no "reconcile-graph-merged park-path rollback (rc=$rc)"
+  printf '%s\n' "$out"
+  printf 'status: %s\n' "$status8"
+  printf 'node:\n%s\n' "$node8"
 fi
 
 echo

--- a/.claude/skills/dispatch-propagate/scripts/test-graph-write-rollback.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-graph-write-rollback.sh
@@ -52,6 +52,12 @@
 #      script for the first time — rolls back to HEAD, leaving a clean tree and
 #      preserving the park rather than restoring stale park-erased bytes
 #      (Unit 2).
+#   9. The graph-commit BUSY-MAIN path (rc 11): commit_files() ran, land() did
+#      not, so HEAD carries an un-landed content commit. `git checkout --`
+#      against that HEAD would restore the MUTATED bytes and report a rollback
+#      that never happened, stranding a commit the next graph-commit from this
+#      shared checkout would push. The un-landed commit must be discarded (HEAD
+#      back where the sweep found it) and the false claim must not be emitted.
 #
 # Cases 6 and 7 are both verified to go RED when Unit 1's `--base` threading is
 # reverted. Case 7 needed care to avoid being vacuous: if the checkout is left
@@ -933,7 +939,10 @@ for id in "${ids[@]}"; do
   mv "intentions/$id.md.new" "intentions/$id.md"
   git add "intentions/$id.md"
 done
-git commit -qm 'graph-commit stub: park_and_exit stand-in'
+# park_and_exit()'s real commit subject shape — `graph: park <ids> (...)` — is
+# load-bearing, not cosmetic: it is how the reconciler's rollback tells a park
+# commit apart from an un-landed content commit (case 9).
+git commit -qm "graph: park ${ids[*]} (concurrent-edit conflict)"
 echo "graph-commit: parked on unresolvable divergence" >&2
 exit 1
 SH
@@ -956,6 +965,82 @@ else
   printf '%s\n' "$out"
   printf 'status: %s\n' "$status8"
   printf 'node:\n%s\n' "$node8"
+fi
+
+# ===========================================================================
+# Case 9: graph-commit's BUSY-MAIN path (rc 11) — it runs commit_files() before
+# land(), so on `exit 1` HEAD has moved and carries the sweep's un-landed,
+# un-CAS-checked mutation with no reset. A bare `git checkout --` "rollback"
+# would restore each node file to that MUTATED HEAD: a no-op reported as a
+# rollback, leaving a stranded commit that the NEXT graph-commit from this
+# shared checkout would rebase and push to main (graph-commit pushes HEAD, not
+# just the node it names) — a write that never passed check_base_freshness.
+#
+# The stub differs from case 8's in exactly one way that matters: its commit is
+# an ordinary content commit, NOT a `graph: park ...` commit, and it is never
+# pushed. Assert the commit is discarded (HEAD back where the sweep found it,
+# the node file un-mutated, tree clean) and that the false "rolled back" claim
+# is replaced by an explicit report.
+# ===========================================================================
+T9="$WORK/t9-seed"
+build_seed_repo "$T9"
+cp "$HARNESS_DIR/reconcile-graph-merged" "$T9/.claude/skills/dispatch-propagate/scripts/reconcile-graph-merged"
+chmod +x "$T9/.claude/skills/dispatch-propagate/scripts/reconcile-graph-merged"
+reconcile_node "$T9/intentions/t-strand.md" t-strand 909
+new_origin t9
+init_and_push "$T9"
+
+C9="$WORK/t9-clone"
+clone_with_node_modules "$C9"
+BIN9="$WORK/t9-bin"; FIX9="$WORK/t9-fixtures"
+reconcile_gh_stub "$BIN9" "$FIX9"
+# graph-commit stub standing in for the rc-11 busy-main exit: commit the caller's
+# already-mutated node files (commit_files runs BEFORE land), then fail without
+# pushing and without resetting.
+cat >"$C9/packages/intentionsutil/scripts/graph-commit" <<'SH'
+#!/usr/bin/env bash
+set -uo pipefail
+dir=""; ids=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -C) dir="${2:-}"; shift 2 ;;
+    -m|--base) shift 2 ;;
+    *) ids+=("$1"); shift ;;
+  esac
+done
+cd "$dir" || exit 2
+for id in "${ids[@]}"; do
+  git add -- "intentions/$id.md"
+done
+git commit -qm "graph: reconcile terminal tactics (record completion)"
+echo "error: graph-commit: could not land ${ids[*]} — main advanced through every push attempt" >&2
+exit 1
+SH
+chmod +x "$C9/packages/intentionsutil/scripts/graph-commit"
+
+head9_before="$(git -C "$C9" rev-parse HEAD)"
+node9_before="$(cat "$C9/intentions/t-strand.md")"
+out="$(
+  cd "$C9" || exit 99
+  export PATH="$BIN9:$PATH" GC_FIXTURE_DIR="$FIX9"
+  export "${RECON_ENV[@]}"
+  bash .claude/skills/dispatch-propagate/scripts/reconcile-graph-merged 2>&1
+)"; rc=$?
+head9_after="$(git -C "$C9" rev-parse HEAD)"
+status9="$(git -C "$C9" status --porcelain intentions/)"
+node9_after="$(cat "$C9/intentions/t-strand.md")"
+if [[ $rc -ne 0 ]] \
+   && [[ "$head9_after" == "$head9_before" ]] \
+   && [[ -z "$status9" ]] \
+   && [[ "$node9_after" == "$node9_before" ]] \
+   && grep -q 'discarded by resetting to' <<<"$out" \
+   && ! grep -q 'rolled the apply run.s node writes back' <<<"$out"; then
+  ok "reconcile-graph-merged busy-main rollback: an un-landed commit graph-commit left on HEAD is discarded (HEAD restored, node un-mutated) instead of being reported as a rollback"
+else
+  no "reconcile-graph-merged busy-main rollback (rc=$rc, head moved: $([[ "$head9_after" == "$head9_before" ]] && echo no || echo yes))"
+  printf '%s\n' "$out"
+  printf 'status: %s\n' "$status9"
+  printf 'node:\n%s\n' "$node9_after"
 fi
 
 echo


### PR DESCRIPTION
Implements graph node `tactic-reconcile-park-clobber` (bug X) — all three units from its plan.

## The defect

`reconcile-graph.ts` rewrites the WHOLE node from its in-memory read, and
`reconcile-graph-merged` built its `graph-commit` argv with **zero `--base`
flags** — so `check_base_freshness()` short-circuited on its first line and the
sweep silently overwrote any edit that landed on `origin/main` between its read
and its commit.

Measured: 8 `office_hours` park erasures across 5 nodes in one 24h window, each
with `phase` left untouched.

## Units

- **Unit 1** — pin each planned edit id's PRE-apply **on-disk** blob via
  `hash-object -w` and thread it as `--base <id>=<blob>`. `-w` is mandatory:
  `check_base_freshness` resolves the base with `cat-file -p` and `die`s when it
  misses. The disk blob, not `origin/main`'s — `graph-commit` defines base as
  "the blob the writer read", and pinning `origin/main` would compute a spurious
  `ours` delta on untouched fields.
- **Unit 2** — roll back to `HEAD` rather than to a captured blob. Unit 1 makes
  `park_and_exit()` reachable, and on that path `HEAD` has already moved;
  writing pre-park bytes back would leave the tree dirty with stale, park-erased
  content — the residue that bricks `assert_clean_outside_ids` for every other
  writer. Precedent: `resolve-hold`'s `clean_node_file()`.
- **Unit 3** — three cases in `test-graph-write-rollback.sh`: `--base`
  construction, the end-to-end race against the REAL `graph-commit` (only `gh`
  stubbed), and the park-path rollback.

## Verification

- `test-graph-write-rollback.sh` — 8/8 pass.
- Cases 6 and 7 both verified **RED** with Unit 1's threading reverted.
- `npx vitest run --project packages/intentionsutil --root .` — 820/820.
- `run-lint.sh` — prose rules pass (non-vacuously, on the added lines).
- `run-unit-tests.sh` — all suites pass.

## Note on the test fixture

Case 7 needed care to avoid being vacuous. With the checkout left BEHIND
`origin/main`, `graph-commit`'s push is rejected, it rebases, git reports a
textual conflict, and **layer-2's field-level auto-merge preserves the park on
its own** — passing with or without the fix. The fixture therefore fast-forwards
HEAD onto the park commit, which is the shape production erasures actually took:
no conflict to rescue, so `--base` is the only thing that can catch the lost
update.

## Scope

Ruling 31 is not reopened — the sweep stays ungated on `office_hours` for its
phase/merge decisions. This is the write side only. `reconcile-graph.ts`,
`store.ts`, and `graph-commit` are unchanged. The identical zero-`--base` shape
in `reconcile-graph-review-stall:276-290` is deliberately out of scope; it is
carried by `tactic-reconcile-review-stall-base-pin`.