### PR TITLE
tactic-invalid-state-lane: one common invalid-state lane (detect, mechanical tier, intervention, escalation)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-invalid-state-route
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-invalid-state-route
@@ -1,0 +1,528 @@
+#!/usr/bin/env bash
+# dispatch-invalid-state-route — the ONE common ladder for every invalid-state
+# kind. A dispatch node can reach a state its phase ladder cannot progress from:
+# a session that ended without declaring a disposition but is still registered,
+# a session frozen at a permission/classifier denial, a `claude rm` reap that
+# exited 0 while declining, a provision merge conflict, a red CI loop past its
+# cap. Each of those had its own ad-hoc handling, invented separately. This is
+# the generalization ratified by the 2026-08-04 /align interview (strategy
+# `strategy-graph-native-dispatch`, invalid-state-lane clarification):
+#
+#   detect (any detector) → dispatch-invalid-state-route --node <id> --kind <k>
+#       ├─ tier 1  mechanical resolution (per-kind, optional, fails toward keep)
+#       ├─ tier 2  intervention skill session (per-node attempt cap)
+#       └─ tier 3  escalation (CALLER-OWNED this round — see "Escalation")
+#
+# Usage:
+#   dispatch-invalid-state-route --node <id> --kind <kind> --evidence-file <f>
+#                                [--session <sid>] [--job-id <jid>] [--no-intervene]
+#
+# EXIT CODES — the contract every detector codes against:
+#     0   handled  — an intervention was launched. The caller must NOT escalate
+#                    this pass and must NOT delete any escalation markers.
+#     4   keep     — positive evidence to do nothing this pass.
+#     10  escalate — the ladder is exhausted; the CALLER runs its own escalation.
+#     1   router failure — callers treat this as escalate (fail toward escalate).
+#     2   usage error.
+#
+# ESCALATION — in this round the router performs NO escalation write. It never
+# calls `park-node`, `hold-node`, `claude rm`, or `graph-commit` (outside the
+# --fleet latch block, which mints a node and touches no source). Exit 10 means
+# "the caller owns the escalation". The kind table below records which primitive
+# each kind's escalation MUST use, so the follow-on extraction (declared residual
+# (a) of the plan) has no decisions left to make.
+#
+# THE RETRY/HUMAN DISCRIMINATION is the generic form of what the 2026-07-31
+# clarification resolved for the exit-11 lineage, and it is a standing rule this
+# script must not regress: a retry-shaped state (a merge conflict against a
+# moving main, a bounded retry short of its cap) routes to `hold-node` /
+# `blocked_by`, NEVER `office_hours` on the source. Only genuinely human-required
+# shapes park. Asking this router to write office_hours for a `retry`-class kind
+# is a usage error (exit 2).
+#
+# THE INTERVENTION SPAWN is `--cwd $PROJECT_ROOT`, never the node's own worktree:
+# `dispatch-graph-execute:296-322` records two incidents where spawning into the
+# node worktree ran a stale skill body and deadlocked a worker slot for over an
+# hour. `--name "$id"` is required — it is what makes
+# `.claude/hooks/dispatch-stop.sh` discriminator 2 hand the session to
+# `dispatch-self-close --node "$id"`, and therefore what OBLIGES the intervention
+# to declare a disposition (`mark-node-terminal:22-35`). A session spawned
+# without it would freeze the very node it was sent to unfreeze.
+#
+# Sandbox: reads the Claude daemon over a Unix socket (occupancy re-probe) and
+# spawns a session. Callers MUST run this with `dangerouslyDisableSandbox: true`
+# — a sandboxed daemon read yields `[]` indistinguishably from "nothing there"
+# (.claude/rules/sandbox.md).
+#
+# Test overrides (all resolve-inside-the-scripts-dir checked, the same posture
+# lib-frozen-session-park.sh applies to park-node):
+#   DISPATCH_INVALID_STATE_SPAWN_JOB   — replaces dispatch-spawn-job
+#   DISPATCH_INVALID_STATE_REPO_ROOT   — replaces resolve_project_root
+#   DISPATCH_INVALID_STATE_SKILL_DIR   — replaces the intervention skill dir
+#   CLAUDE_AGENTS_CMD                  — the registry fake (lib-claude-agents.sh)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=lib-claude-agents.sh
+source "$SCRIPT_DIR/lib-claude-agents.sh"
+# shellcheck source=lib-standdown-recheck.sh
+source "$SCRIPT_DIR/lib-standdown-recheck.sh"
+# shellcheck source=lib-decision-log.sh
+source "$SCRIPT_DIR/lib-decision-log.sh"
+
+# Per-node intervention-attempt cap. A baked-in constant, deliberately NOT a
+# `dispatch.config` tunable — parity with FIX_ATTEMPT_CAP
+# (packages/intentionsutil/src/transitions.js, read via
+# `apply-fix-state.ts --check-cap`) and CONFLICT_STRIKE_CAP
+# (dispatch-graph-execute:145), the two bounded-attempt precedents this mirrors.
+# Lower than CONFLICT_STRIKE_CAP (3, not 5): an intervention spawns a whole
+# session, so its attempts are expensive where a conflict-lane tick is cheap.
+INVALID_STATE_INTERVENTION_CAP=3
+
+# Consecutive same-precondition failures before the fleet latch is minted
+# (--fleet mode / Unit 6). Two, not one, so a single transient drift (a dirty
+# `main`, a mid-fetch tree) does not mint a node.
+INVALID_STATE_FLEET_LATCH_MIN_OBSERVATIONS=2
+
+usage() {
+  sed -n '2,30p' "${BASH_SOURCE[0]}" >&2
+  exit 2
+}
+
+NODE_ID=""
+KIND=""
+EVIDENCE_FILE=""
+SESSION_ID=""
+JOB_ID=""
+NO_INTERVENE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --node)          NODE_ID="${2:-}"; shift 2 || usage ;;
+    --kind)          KIND="${2:-}"; shift 2 || usage ;;
+    --evidence-file) EVIDENCE_FILE="${2:-}"; shift 2 || usage ;;
+    --session)       SESSION_ID="${2:-}"; shift 2 || usage ;;
+    --job-id)        JOB_ID="${2:-}"; shift 2 || usage ;;
+    --no-intervene)  NO_INTERVENE=1; shift ;;
+    -h|--help)       usage ;;
+    *) printf 'dispatch-invalid-state-route: unknown argument %q\n' "$1" >&2; usage ;;
+  esac
+done
+
+[[ -n "$NODE_ID" ]] || { printf 'dispatch-invalid-state-route: --node is required\n' >&2; exit 2; }
+[[ -n "$KIND" ]]    || { printf 'dispatch-invalid-state-route: --kind is required\n' >&2; exit 2; }
+
+# --- Kind table ------------------------------------------------------------
+# kind | mechanical tier | escalation class | escalation primitive
+# -----------------------------------------------------------------------------
+# terminal-session   | re-probe occupancy | human | park-node   (caller-owned)
+# frozen-session     | none               | human | park-node   (caller-owned)
+# provision-conflict | (reserved)         | retry | hold-node --kind provision-conflict
+# worktree-residue   | (reserved)         | retry | hold-node --kind worktree-residue
+# fix-attempt-cap    | (reserved)         | retry | hold-node --kind fix-attempt-cap
+#
+# The three `(reserved)` rows carry no caller in this round. They exist so the
+# follow-on call-site swap for dispatch-graph-execute cases 11/14 and the
+# fix-attempt cap is a one-line change, and so the class discrimination is
+# written down exactly once instead of being re-derived per call site.
+kind_class() {
+  case "$1" in
+    terminal-session|frozen-session)                     printf 'human\n' ;;
+    provision-conflict|worktree-residue|fix-attempt-cap) printf 'retry\n' ;;
+    *)                                                   printf '\n' ;;
+  esac
+}
+
+KIND_CLASS="$(kind_class "$KIND")"
+if [[ -z "$KIND_CLASS" ]]; then
+  printf 'dispatch-invalid-state-route: unknown --kind %q (known: terminal-session frozen-session provision-conflict worktree-residue fix-attempt-cap)\n' "$KIND" >&2
+  exit 2
+fi
+
+# A `retry`-class kind must never reach an office_hours write. This router makes
+# no escalation write at all, so the guard is a refusal at the edge: it exists so
+# the rule is enforced HERE, at the one place that knows the class, rather than
+# being re-litigated at each future call site.
+if [[ "$KIND_CLASS" == "retry" && "${DISPATCH_INVALID_STATE_WRITE_OFFICE_HOURS:-0}" == "1" ]]; then
+  printf 'dispatch-invalid-state-route: refusing to write office_hours for retry-class kind %q — a retry-shaped state routes to hold-node/blocked_by, never office_hours on the source (2026-07-25 clarification)\n' "$KIND" >&2
+  exit 2
+fi
+
+# --- Tier 0: preconditions -------------------------------------------------
+# Each failure is loud on stderr, never silent. A precondition failure exits 10
+# (escalate — the caller's existing path still runs), EXCEPT an invalid node id,
+# which is a usage error (exit 2).
+
+# The node-id regex, identical to mark-node-terminal:66 / dispatch-graph-execute:138.
+if [[ ! "$NODE_ID" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]]; then
+  printf 'dispatch-invalid-state-route: invalid node id %q\n' "$NODE_ID" >&2
+  exit 2
+fi
+
+PROJECT_ROOT=""
+
+# --- Unit 6: the fleet-level latch -----------------------------------------
+# Some invalid states have no node to route: the router's own preconditions fail
+# FLEET-WIDE, so no node can be dispositioned and the failure would otherwise be
+# a silent exit. Per the ratified doctrine these mint a find-or-create latch node
+# that is simultaneously the alarm, the work item, and the dedup key — the
+# `tactic-main-red-*` shape.
+#
+# ANCHORED REGEX, ALWAYS. Any reader of these ids MUST use
+# `^tactic-invalid-state-[0-9a-f]{8}$`, never a bare prefix test. An unanchored
+# prefix match is a known live production bug: see dispatch-graph-main-red-sync:
+# 88-120 and the postmortem in intentions/tactic-main-red-sync-completion-test.md,
+# where a prefix match caught an unrelated hand-authored tactic id and deadlocked
+# auto-merge for weeks. Note `tactic-invalid-state-lane` — this very lane's own
+# node — shares the prefix and MUST NOT match.
+INVALID_STATE_FLEET_LATCH_ID_RE='^tactic-invalid-state-[0-9a-f]{8}$'
+
+# fleet_latch_id <kind> <slug> — the stable dedup key. sha256 over
+# "<kind>:<precondition-slug>" so the id is identical across ticks and sessions
+# for the same failure, and different for a different one.
+fleet_latch_id() {
+  local h
+  h=$(printf '%s' "$1:$2" | sha256sum 2>/dev/null | cut -c1-8) || h=""
+  [[ -n "$h" ]] || return 1
+  printf 'tactic-invalid-state-%s\n' "$h"
+}
+
+# fleet_latch_observe <precondition-slug> <message> — count CONSECUTIVE failures
+# of the same precondition and mint at the threshold. Bounded to at most one
+# latch per router invocation. A mint failure is logged and NEVER changes the
+# router's exit code for the node it was called about.
+fleet_latch_observe() {
+  local slug="$1" msg="$2"
+  [[ -n "$PROJECT_ROOT" && -d "$PROJECT_ROOT" ]] || return 0
+  local wt_dir="$PROJECT_ROOT/.claude/worktrees"
+  local sidecar="$wt_dir/.invalid-state-fleet-$slug"
+  mkdir -p "$wt_dir" 2>/dev/null || return 0
+
+  local n
+  n=$(cat "$sidecar" 2>/dev/null || echo 0)
+  [[ "$n" =~ ^[0-9]+$ ]] || n=0
+  n=$(( n + 1 ))
+  printf '%s\n' "$n" > "$sidecar" 2>/dev/null || true
+
+  if (( n < INVALID_STATE_FLEET_LATCH_MIN_OBSERVATIONS )); then
+    printf 'dispatch-invalid-state-route: fleet precondition %q failed (%d/%d observations); not minting yet\n' \
+      "$slug" "$n" "$INVALID_STATE_FLEET_LATCH_MIN_OBSERVATIONS" >&2
+    return 0
+  fi
+
+  local latch_id
+  latch_id=$(fleet_latch_id "$KIND" "$slug") || return 0
+  # Defensive: the id we just built MUST satisfy the anchored reader. If it does
+  # not, something changed in the id shape — refuse rather than mint into a
+  # keyspace no reader will match.
+  if [[ ! "$latch_id" =~ $INVALID_STATE_FLEET_LATCH_ID_RE ]]; then
+    printf 'dispatch-invalid-state-route: computed latch id %q does not match the anchored reader; not minting\n' "$latch_id" >&2
+    return 0
+  fi
+
+  if [[ "${DISPATCH_INVALID_STATE_FLEET_LATCH:-1}" != "1" ]]; then
+    printf 'dispatch-invalid-state-route: fleet latch disabled; would have minted %s\n' "$latch_id" >&2
+    return 0
+  fi
+
+  fleet_latch_mint "$latch_id" "$slug" "$msg" || \
+    printf 'dispatch-invalid-state-route: minting fleet latch %s failed (non-fatal)\n' "$latch_id" >&2
+  return 0
+}
+
+# fleet_latch_mint <id> <slug> <message> — classify / mint / edit-in-place, the
+# find-or-create idiom at .claude/skills/dispatch-diagnose-main/SKILL.md:80-135.
+#
+# `hold-node` is deliberately NOT reusable here: it requires a SOURCE node to
+# carry the `blocked_by` edge, and a fleet-level invalid state has none. Do not
+# "fix" this by reaching for it.
+fleet_latch_mint() {
+  local id="$1" slug="$2" msg="$3"
+  local store="$PROJECT_ROOT/packages/intentionsutil"
+  [[ -d "$store" ]] || return 1
+
+  # Classify against origin/main: open | closed | absent.
+  local state
+  if git -C "$PROJECT_ROOT" cat-file -e "origin/main:intentions/$id.md" 2>/dev/null; then
+    state="open"
+  else
+    state="absent"
+  fi
+
+  if [[ "$state" == "open" ]]; then
+    # Already latched — the node IS the dedup key, so there is nothing to add.
+    # Editing in place on every failing tick would churn a commit per tick for
+    # no new information; the occurrence count lives in the sidecar.
+    printf 'dispatch-invalid-state-route: fleet latch %s already open; not re-minting\n' "$id" >&2
+    return 0
+  fi
+
+  local tmp
+  tmp=$(mktemp) || return 1
+  # Born-parked: everything a fresh office-hours sitting needs must be IN the
+  # node, because session attach/resume is not a recovery path. The reason names
+  # the failing precondition and its observed values; the recommendation names
+  # the concrete operator act.
+  jq -n \
+    --arg id "$id" \
+    --arg slug "$slug" \
+    --arg msg "$msg" \
+    --arg kind "$KIND" \
+    --arg since "$(date -u +%FT%TZ)" \
+    '{id: $id, kind: "tactic", owner: "ai", status: "raw", parent: null,
+      statement: ("Fleet-level invalid state: the dispatch invalid-state router could not run its preconditions (" + $slug + ")"),
+      rationale: ("Auto-created by dispatch-invalid-state-route after " + $slug + " failed on consecutive observations. Kind: " + $kind + ". No source node could be dispositioned, so this latch node is simultaneously the alarm, the work item and the dedup key (the tactic-main-red-* shape)."),
+      reading: null, gap: null,
+      serves: ["strategy-graph-native-dispatch"],
+      recovers: [], clarifications: [], tooling_goals: [],
+      success_signal: null, attention: null, phase: null, execution: null,
+      validates: [], blocked_by: [],
+      office_hours: {reason: $msg, since: $since,
+                     recommendation: ("Resolve the failing precondition on the primary checkout, then delete the sidecar .claude/worktrees/.invalid-state-fleet-" + $slug + " so the observation counter restarts.")},
+      pace_exempt: false, rounds: null, attributes: {}}' > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+
+  # write-node.ts resolves intentions/ from the SCRIPT's own location, not cwd —
+  # invoke the copy under this project root.
+  ( cd "$PROJECT_ROOT" && npx tsx "$store/scripts/write-node.ts" --file "$tmp" ) >/dev/null 2>&1 || { rm -f "$tmp"; return 1; }
+  rm -f "$tmp"
+  ( cd "$PROJECT_ROOT" && "$store/scripts/graph-commit" -m "graph: latch fleet invalid state $slug" "$id" ) >/dev/null 2>&1 || return 1
+  printf 'dispatch-invalid-state-route: minted fleet latch %s\n' "$id" >&2
+  return 0
+}
+
+# fleet_latch_clear <precondition-slug> — reset the observation counter after a
+# successful precondition pass, so only CONSECUTIVE failures accumulate.
+fleet_latch_clear() {
+  [[ -n "$PROJECT_ROOT" && -d "$PROJECT_ROOT" ]] || return 0
+  rm -f "$PROJECT_ROOT/.claude/worktrees/.invalid-state-fleet-$1" 2>/dev/null || true
+  return 0
+}
+
+fail_precondition() { # <slug> <message>
+  local slug="$1" msg="$2"
+  printf 'dispatch-invalid-state-route: %s\n' "$msg" >&2
+  fleet_latch_observe "$slug" "$msg"
+  exit 10
+}
+
+REPO_ROOT="${DISPATCH_INVALID_STATE_REPO_ROOT:-}"
+if [[ -z "$REPO_ROOT" ]]; then
+  REPO_ROOT=$(resolve_project_root) || REPO_ROOT=""
+fi
+if [[ -z "$REPO_ROOT" || ! -d "$REPO_ROOT" ]]; then
+  # No project root: nothing can be resolved, so the fleet latch cannot be
+  # written either (its sidecar lives under the project root). Loud exit.
+  printf 'dispatch-invalid-state-route: could not resolve the project root; escalating\n' >&2
+  exit 10
+fi
+PROJECT_ROOT="$REPO_ROOT"
+
+if ! assert_primary_checkout_on_main "$PROJECT_ROOT"; then
+  fail_precondition "primary-checkout-not-on-main" \
+    "primary checkout $PROJECT_ROOT is not on main; escalating without acting"
+fi
+
+# The node must exist on origin/main — the authoritative tree. A node that is
+# not there is not this lane's to route.
+if ! git -C "$PROJECT_ROOT" cat-file -e "origin/main:intentions/$NODE_ID.md" 2>/dev/null; then
+  fail_precondition "node-absent-on-origin-main" \
+    "intentions/$NODE_ID.md is not present on origin/main; escalating without acting"
+fi
+
+# Every precondition passed: reset the observation counters, so the fleet latch
+# only ever counts CONSECUTIVE failures. A single transient drift followed by a
+# healthy pass must not accumulate toward a mint.
+fleet_latch_clear "primary-checkout-not-on-main"
+fleet_latch_clear "node-absent-on-origin-main"
+
+# --- Tier 1: mechanical resolution -----------------------------------------
+# Per-kind, optional, and EVERY gate fails toward keep/escalate. This tier NEVER
+# reaps and NEVER writes the graph.
+
+WORKTREES_DIR="$PROJECT_ROOT/.claude/worktrees"
+ATTEMPT_FILE="$WORKTREES_DIR/$NODE_ID.invalid-state-attempts"
+
+# The stand-down interlock, for EVERY kind. A stood-down loser has exactly the
+# shape of an invalid state by design, so intervening on one would fight the
+# interlock. Rationale: lib-frozen-session-park.sh:649-661.
+if standdown_exists "$NODE_ID" 2>/dev/null; then
+  printf 'dispatch-invalid-state-route: %s carries a stand-down marker — a stood-down loser is not an invalid state; keeping\n' "$NODE_ID" >&2
+  exit 4
+fi
+
+# done-but-parked is a VALID state (2026-08-04 author ruling): phase and
+# office_hours are ORTHOGONAL dimensions. Never classify it as invalid and never
+# try to resolve it mechanically.
+node_field() { # <jq-path>
+  git -C "$PROJECT_ROOT" show "origin/main:intentions/$NODE_ID.md" 2>/dev/null \
+    | awk '/^---$/{n++; next} n==1' \
+    | grep -E "^$1:" | head -1 | sed -E "s/^$1:[[:space:]]*//"
+}
+_phase="$(node_field phase)"
+_oh="$(node_field office_hours)"
+if [[ "$_phase" == "done" && -n "$_oh" && "$_oh" != "null" ]]; then
+  printf 'dispatch-invalid-state-route: %s is done-but-parked — phase and office_hours are orthogonal (2026-08-04 ruling), not an invalid state; keeping\n' "$NODE_ID" >&2
+  exit 4
+fi
+
+case "$KIND" in
+  terminal-session)
+    # Re-probe occupancy. The state may have resolved itself between detection
+    # and now — a sweep and this router do not run in the same instant.
+    worktree_occupancy_state "$WORKTREES_DIR/$NODE_ID" >/dev/null 2>&1
+    case "$WORKTREE_OCCUPANCY_STATE" in
+      free)
+        # Resolved itself (the session was reaped between detection and now).
+        # Clear the sidecar so a later, genuinely-new occurrence starts fresh.
+        rm -f "$ATTEMPT_FILE" 2>/dev/null || true
+        printf 'dispatch-invalid-state-route: %s is free — the state resolved itself; keeping\n' "$NODE_ID" >&2
+        exit 4
+        ;;
+      live)
+        # A live claim is a VALID skip, full stop. Never spawn into one.
+        printf 'dispatch-invalid-state-route: %s is held by a LIVE session — a valid claim, never an invalid state; keeping\n' "$NODE_ID" >&2
+        exit 4
+        ;;
+      terminal)
+        : # the invalid state is confirmed; continue down the ladder
+        ;;
+      *)
+        # UNKNOWN: no positive evidence. A daemon hiccup must never manufacture
+        # an intervention.
+        printf 'dispatch-invalid-state-route: occupancy of %s is UNKNOWN — no positive evidence; keeping\n' "$NODE_ID" >&2
+        exit 4
+        ;;
+    esac
+    ;;
+  frozen-session)
+    # No mechanical tier by design: a session frozen at a permission/classifier
+    # denial cannot be resolved by re-probing. Fall through to intervention.
+    :
+    ;;
+  *)
+    # The reserved kinds have no caller this round; if one arrives, escalate
+    # rather than guessing at a mechanical tier that was never designed.
+    printf 'dispatch-invalid-state-route: kind %q has no mechanical tier in this round; escalating to the caller\n' "$KIND" >&2
+    exit 10
+    ;;
+esac
+
+# A second live session registered under this node name is the duplicate-worker
+# shape, not an invalid state to intervene on.
+if command -v claude_agents_list_duplicate_node_names >/dev/null 2>&1; then
+  if dupes=$(claude_agents_list_duplicate_node_names 2>/dev/null); then
+    if printf '%s\n' "$dupes" | grep -qxF "$NODE_ID"; then
+      printf 'dispatch-invalid-state-route: %s has two or more LIVE sessions — a duplicate-worker shape, not an invalid state; keeping\n' "$NODE_ID" >&2
+      exit 4
+    fi
+  fi
+fi
+
+# --- Tier 2: intervention, bounded by a per-node attempt cap ---------------
+
+# Availability guard: the sibling tactic
+# (tactic-invalid-state-transcript-intervention) owns the skill. Until it lands,
+# this tier is INERT and today's behavior is preserved exactly — the caller's
+# existing escalation runs untouched.
+SKILL_DIR="${DISPATCH_INVALID_STATE_SKILL_DIR:-$PROJECT_ROOT/.claude/skills/dispatch-invalid-state}"
+if [[ ! -f "$SKILL_DIR/SKILL.md" ]]; then
+  printf 'dispatch-invalid-state-route: intervention skill absent at %s — tier inert; escalating to the caller\n' "$SKILL_DIR" >&2
+  exit 10
+fi
+
+if (( NO_INTERVENE )); then
+  printf 'dispatch-invalid-state-route: --no-intervene; escalating to the caller\n' >&2
+  exit 10
+fi
+
+# Attempt sidecar, OUTSIDE every checkout so it never dirties a tree and is never
+# a graph write — the same convention as dispatch-graph-execute's
+# `.conflict-strikes` and provision-node-worktree's `.scope-fingerprint`. Losing
+# it (daemon restart, reaped worktree) is deliberately fail-open: it grants more
+# free attempts rather than fewer.
+ATTEMPTS=$(cat "$ATTEMPT_FILE" 2>/dev/null || echo 0)
+[[ "$ATTEMPTS" =~ ^[0-9]+$ ]] || ATTEMPTS=0
+
+_log_decision() { # <disposition> <detail>
+  command -v decision_log_append >/dev/null 2>&1 || return 0
+  local json
+  json=$(jq -c -n \
+    --arg ts "$(date -u +%FT%TZ)" \
+    --arg site "dispatch-invalid-state-route" \
+    --arg node "$NODE_ID" \
+    --arg kind "$KIND" \
+    --arg class "$KIND_CLASS" \
+    --arg disposition "$1" \
+    --arg detail "$2" \
+    --arg session "$SESSION_ID" \
+    --arg job_id "$JOB_ID" \
+    --arg attempt "$ATTEMPTS" \
+    --arg cap "$INVALID_STATE_INTERVENTION_CAP" \
+    '{ts: $ts, site: $site, node: $node, kind: $kind, class: $class,
+      disposition: $disposition, detail: $detail, session: $session,
+      job_id: $job_id, attempt: ($attempt | tonumber), cap: ($cap | tonumber)}' \
+    2>/dev/null) || return 0
+  decision_log_append "$json" || true
+}
+
+if (( ATTEMPTS >= INVALID_STATE_INTERVENTION_CAP )); then
+  # The ratified "cap parks to office-hours" guard is satisfied by the CALLER's
+  # escalation tier — this router makes no escalation write (see "Escalation").
+  # The distinction between cap-exhausted and spawn-failed is logged so the two
+  # are separable after the fact.
+  _log_decision "escalate" "cap-exhausted"
+  printf 'dispatch-invalid-state-route: %s has reached the intervention cap (%d/%d); escalating to the caller\n' \
+    "$NODE_ID" "$ATTEMPTS" "$INVALID_STATE_INTERVENTION_CAP" >&2
+  exit 10
+fi
+
+# Provenance: the resolved spawner must be an executable regular file whose REAL
+# directory is this scripts dir. Canonicalize both sides (`pwd -P`) so `..`
+# segments and symlinked temp roots cannot slip an arbitrary executable past a
+# string prefix test. Same posture lib-frozen-session-park.sh:333-352 applies to
+# park-node, and it is what makes honouring the env override safe.
+SPAWN_JOB="${DISPATCH_INVALID_STATE_SPAWN_JOB:-$SCRIPT_DIR/dispatch-spawn-job}"
+_spawn_dir_real=$(cd "$(dirname -- "$SPAWN_JOB")" 2>/dev/null && pwd -P) || _spawn_dir_real=""
+_scripts_dir_real=$(cd "$SCRIPT_DIR" 2>/dev/null && pwd -P) || _scripts_dir_real=""
+if [[ -z "$_scripts_dir_real" || "$_spawn_dir_real" != "$_scripts_dir_real" ]]; then
+  printf 'dispatch-invalid-state-route: spawner %s does not resolve inside %s; escalating\n' \
+    "$SPAWN_JOB" "$SCRIPT_DIR" >&2
+  _log_decision "escalate" "spawner-provenance-failed"
+  exit 10
+fi
+if [[ ! -f "$SPAWN_JOB" || ! -x "$SPAWN_JOB" ]]; then
+  printf 'dispatch-invalid-state-route: spawner %s is not an executable regular file; escalating\n' "$SPAWN_JOB" >&2
+  _log_decision "escalate" "spawner-not-executable"
+  exit 10
+fi
+
+# The prompt carries the evidence-file PATH, not its content: the intervention
+# reads it itself, and passing a path keeps an unbounded, untrusted transcript
+# excerpt out of the spawn argv.
+PROMPT="/dispatch-invalid-state $NODE_ID"
+if [[ -n "$EVIDENCE_FILE" ]]; then
+  PROMPT="$PROMPT --evidence-file $EVIDENCE_FILE"
+fi
+
+# --cwd is the PROJECT ROOT, never the node worktree (see the header). --name is
+# the node id, which is what obliges the spawned session to declare a
+# disposition via the Stop hook's discriminator 2.
+if "$SPAWN_JOB" --no-verify --name "$NODE_ID" --cwd "$PROJECT_ROOT" \
+     --model opus "$PROMPT" >/dev/null 2>&1; then
+  ATTEMPTS=$(( ATTEMPTS + 1 ))
+  mkdir -p "$WORKTREES_DIR" 2>/dev/null || true
+  printf '%s\n' "$ATTEMPTS" > "$ATTEMPT_FILE" 2>/dev/null || true
+  _log_decision "intervened" "spawned"
+  printf 'intervened %s %d/%d\n' "$NODE_ID" "$ATTEMPTS" "$INVALID_STATE_INTERVENTION_CAP"
+  exit 0
+fi
+
+# A failed kick escalates. The sidecar is NOT incremented: the attempt cap counts
+# interventions actually launched, not failures to launch one — otherwise a
+# broken spawner would silently burn a node's whole intervention budget.
+_log_decision "escalate" "spawn-failed"
+printf 'dispatch-invalid-state-route: spawning the intervention for %s failed; escalating to the caller\n' "$NODE_ID" >&2
+exit 10

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-invalid-state-route
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-invalid-state-route
@@ -49,6 +49,13 @@
 # to declare a disposition (`mark-node-terminal:22-35`). A session spawned
 # without it would freeze the very node it was sent to unfreeze.
 #
+# THE PRIMARY-CHECKOUT GATE RUNS FIRST, before any fleet-latch code exists. The
+# latch's mint runs write-node.ts and graph-commit out of `$PROJECT_ROOT`, and
+# graph-commit force-pushes `refs/graph/**` and pushes `main`. Minting out of a
+# checkout that just FAILED the on-main assert would execute an unreviewed
+# branch's copy of exactly those scripts. That precondition therefore neither
+# observes nor mints — it logs and exits 10.
+#
 # Sandbox: reads the Claude daemon over a Unix socket (occupancy re-probe) and
 # spawns a session. Callers MUST run this with `dangerouslyDisableSandbox: true`
 # — a sandboxed daemon read yields `[]` indistinguishably from "nothing there"
@@ -164,6 +171,36 @@ fi
 
 PROJECT_ROOT=""
 
+# --- The primary-checkout gate, HOISTED ABOVE the fleet-latch machinery ------
+# Deliberately resolved and asserted here, before a single fleet-latch
+# definition or call site exists: `fleet_latch_mint` runs two PRIVILEGED
+# executables out of `$PROJECT_ROOT` — `write-node.ts`, and `graph-commit`,
+# which force-pushes `refs/graph/**` and pushes `main` — unattended, from the
+# headless tick, with the sandbox off. Minting out of a checkout that just
+# FAILED the on-main assert would execute an unreviewed branch's version of
+# exactly those scripts, which is the hazard the assert exists to prevent
+# (lib-frozen-session-park.sh:930-940 documents it verbatim). So this one
+# precondition never observes and never mints: it logs and exits 10 outright.
+# Every LATER precondition runs only after the checkout has been vouched for,
+# which is what makes routing them through `fail_precondition` safe.
+REPO_ROOT="${DISPATCH_INVALID_STATE_REPO_ROOT:-}"
+if [[ -z "$REPO_ROOT" ]]; then
+  REPO_ROOT=$(resolve_project_root) || REPO_ROOT=""
+fi
+if [[ -z "$REPO_ROOT" || ! -d "$REPO_ROOT" ]]; then
+  # No project root: nothing can be resolved, so the fleet latch cannot be
+  # written either (its sidecar lives under the project root). Loud exit.
+  printf 'dispatch-invalid-state-route: could not resolve the project root; escalating\n' >&2
+  exit 10
+fi
+PROJECT_ROOT="$REPO_ROOT"
+
+if ! assert_primary_checkout_on_main "$PROJECT_ROOT"; then
+  printf 'dispatch-invalid-state-route: primary checkout %s is not on main; escalating without acting, and WITHOUT observing or minting a fleet latch — the mint would have to run the graph-writing scripts of this same rejected checkout (they force-push refs/graph/** and push main)\n' \
+    "$PROJECT_ROOT" >&2
+  exit 10
+fi
+
 # --- Unit 6: the fleet-level latch -----------------------------------------
 # Some invalid states have no node to route: the router's own preconditions fail
 # FLEET-WIDE, so no node can be dispositioned and the failure would otherwise be
@@ -244,6 +281,46 @@ fleet_latch_mint() {
   local store="$PROJECT_ROOT/packages/intentionsutil"
   [[ -d "$store" ]] || return 1
 
+  # Provenance, the same posture the spawner gets below (and
+  # lib-frozen-session-park.sh:945-967 applies to park-node): the two privileged
+  # executables this mint runs must be regular files whose REAL directory is
+  # THIS project root's intentionsutil scripts dir. Canonicalize both sides with
+  # `pwd -P` so `..` segments and symlinked roots cannot slip an arbitrary
+  # executable past a string prefix test. It matters most for `graph-commit`,
+  # which force-pushes `refs/graph/**` and pushes `main` — unattended, from the
+  # headless tick, sandbox off, with push credentials available.
+  local scripts_dir scripts_dir_real
+  scripts_dir="$store/scripts"
+  scripts_dir_real=$(cd "$scripts_dir" 2>/dev/null && pwd -P) || scripts_dir_real=""
+  if [[ -z "$scripts_dir_real" ]]; then
+    printf 'dispatch-invalid-state-route: %s does not resolve; not minting\n' "$scripts_dir" >&2
+    return 1
+  fi
+  # Held in variables so the invocations below name no path of their own — the
+  # resolved-and-checked value is the ONLY thing that ever gets executed.
+  local write_node_exe commit_exe
+  write_node_exe="$scripts_dir/write-node.ts"
+  commit_exe="$scripts_dir/graph-commit"
+  local exe exe_dir_real
+  for exe in "$write_node_exe" "$commit_exe"; do
+    exe_dir_real=$(cd "$(dirname -- "$exe")" 2>/dev/null && pwd -P) || exe_dir_real=""
+    if [[ "$exe_dir_real" != "$scripts_dir_real" ]]; then
+      printf 'dispatch-invalid-state-route: %s does not resolve inside %s; not minting\n' "$exe" "$scripts_dir" >&2
+      return 1
+    fi
+    if [[ ! -f "$exe" ]]; then
+      printf 'dispatch-invalid-state-route: %s is not a regular file; not minting\n' "$exe" >&2
+      return 1
+    fi
+  done
+  # Only the committer is exec'd directly; the writer is a TypeScript source fed
+  # to `npx tsx`, and is checked in-repo non-executable (0644) on purpose, so an
+  # `-x` test on it would refuse every legitimate mint.
+  if [[ ! -x "$commit_exe" ]]; then
+    printf 'dispatch-invalid-state-route: %s is not executable; not minting\n' "$commit_exe" >&2
+    return 1
+  fi
+
   # Classify against origin/main: open | closed | absent.
   local state
   if git -C "$PROJECT_ROOT" cat-file -e "origin/main:intentions/$id.md" 2>/dev/null; then
@@ -285,10 +362,11 @@ fleet_latch_mint() {
       pace_exempt: false, rounds: null, attributes: {}}' > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
 
   # write-node.ts resolves intentions/ from the SCRIPT's own location, not cwd —
-  # invoke the copy under this project root.
-  ( cd "$PROJECT_ROOT" && npx tsx "$store/scripts/write-node.ts" --file "$tmp" ) >/dev/null 2>&1 || { rm -f "$tmp"; return 1; }
+  # invoke the copy under this project root. Both paths are the provenance-checked
+  # variables from above, never a freshly-composed string.
+  ( cd "$PROJECT_ROOT" && npx tsx "$write_node_exe" --file "$tmp" ) >/dev/null 2>&1 || { rm -f "$tmp"; return 1; }
   rm -f "$tmp"
-  ( cd "$PROJECT_ROOT" && "$store/scripts/graph-commit" -m "graph: latch fleet invalid state $slug" "$id" ) >/dev/null 2>&1 || return 1
+  ( cd "$PROJECT_ROOT" && "$commit_exe" -m "graph: latch fleet invalid state $slug" "$id" ) >/dev/null 2>&1 || return 1
   printf 'dispatch-invalid-state-route: minted fleet latch %s\n' "$id" >&2
   return 0
 }
@@ -308,23 +386,6 @@ fail_precondition() { # <slug> <message>
   exit 10
 }
 
-REPO_ROOT="${DISPATCH_INVALID_STATE_REPO_ROOT:-}"
-if [[ -z "$REPO_ROOT" ]]; then
-  REPO_ROOT=$(resolve_project_root) || REPO_ROOT=""
-fi
-if [[ -z "$REPO_ROOT" || ! -d "$REPO_ROOT" ]]; then
-  # No project root: nothing can be resolved, so the fleet latch cannot be
-  # written either (its sidecar lives under the project root). Loud exit.
-  printf 'dispatch-invalid-state-route: could not resolve the project root; escalating\n' >&2
-  exit 10
-fi
-PROJECT_ROOT="$REPO_ROOT"
-
-if ! assert_primary_checkout_on_main "$PROJECT_ROOT"; then
-  fail_precondition "primary-checkout-not-on-main" \
-    "primary checkout $PROJECT_ROOT is not on main; escalating without acting"
-fi
-
 # The node must exist on origin/main — the authoritative tree. A node that is
 # not there is not this lane's to route.
 if ! git -C "$PROJECT_ROOT" cat-file -e "origin/main:intentions/$NODE_ID.md" 2>/dev/null; then
@@ -334,8 +395,9 @@ fi
 
 # Every precondition passed: reset the observation counters, so the fleet latch
 # only ever counts CONSECUTIVE failures. A single transient drift followed by a
-# healthy pass must not accumulate toward a mint.
-fleet_latch_clear "primary-checkout-not-on-main"
+# healthy pass must not accumulate toward a mint. Only the latch-eligible
+# preconditions have a counter — `primary-checkout-not-on-main` deliberately has
+# none (see the hoisted gate above), so there is nothing to clear for it.
 fleet_latch_clear "node-absent-on-origin-main"
 
 # --- Tier 1: mechanical resolution -----------------------------------------
@@ -356,14 +418,25 @@ fi
 # done-but-parked is a VALID state (2026-08-04 author ruling): phase and
 # office_hours are ORTHOGONAL dimensions. Never classify it as invalid and never
 # try to resolve it mechanically.
-node_field() { # <jq-path>
-  git -C "$PROJECT_ROOT" show "origin/main:intentions/$NODE_ID.md" 2>/dev/null \
-    | awk '/^---$/{n++; next} n==1' \
-    | grep -E "^$1:" | head -1 | sed -E "s/^$1:[[:space:]]*//"
-}
-_phase="$(node_field phase)"
-_oh="$(node_field office_hours)"
-if [[ "$_phase" == "done" && -n "$_oh" && "$_oh" != "null" ]]; then
+#
+# The park test is a PRESENCE test over the frontmatter, NOT a value read. A
+# parked node serializes `office_hours` as a YAML BLOCK MAPPING — the key alone
+# on its line with `reason:`/`since:`/`recommendation:` indented beneath — so
+# reading the rest of the `office_hours:` line yields the empty string for every
+# parked node and the literal `null` for every unparked one, which makes a
+# value-based guard dead in both branches. Same frontmatter-scoped, column-0
+# anchored idiom the sweeps use (lib-frozen-session-park.sh:1167-1190); the
+# scoping is load-bearing, so a column-0 `office_hours:` line in the markdown
+# BODY can never be misread as park state.
+NODE_FRONTMATTER="$(git -C "$PROJECT_ROOT" show "origin/main:intentions/$NODE_ID.md" 2>/dev/null \
+  | awk 'NR==1&&/^---/{f=1;next} f&&/^---[[:space:]]*$/{exit} f')"
+_parked=0
+if grep -q '^office_hours:' <<<"$NODE_FRONTMATTER"; then
+  grep -qE '^office_hours:[[:space:]]*null[[:space:]]*$' <<<"$NODE_FRONTMATTER" || _parked=1
+fi
+_done=0
+grep -qE '^phase:[[:space:]]*done[[:space:]]*$' <<<"$NODE_FRONTMATTER" && _done=1
+if (( _done && _parked )); then
   printf 'dispatch-invalid-state-route: %s is done-but-parked — phase and office_hours are orthogonal (2026-08-04 ruling), not an invalid state; keeping\n' "$NODE_ID" >&2
   exit 4
 fi
@@ -502,6 +575,15 @@ fi
 # The prompt carries the evidence-file PATH, not its content: the intervention
 # reads it itself, and passing a path keeps an unbounded, untrusted transcript
 # excerpt out of the spawn argv.
+#
+# EVIDENCE-FILE LIFECYCLE. This router never creates the file and never deletes
+# it: the DETECTOR creates it and owns it until this router reports a launched
+# intervention (exit 0), at which point ownership passes to the spawned session,
+# which deletes it once it has read it. On every non-zero exit no session was
+# launched, so the detector still owns the file — see
+# dispatch-invalid-state-sweep's rc handling, the one detector that passes one
+# today. Stating the contract here is what keeps a future detector from creating
+# a file nobody reaps.
 PROMPT="/dispatch-invalid-state $NODE_ID"
 if [[ -n "$EVIDENCE_FILE" ]]; then
   PROMPT="$PROMPT --evidence-file $EVIDENCE_FILE"

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-invalid-state-sweep
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-invalid-state-sweep
@@ -37,6 +37,8 @@
 #   DISPATCH_INVALID_STATE_ROUTE_CMD   — replaces dispatch-invalid-state-route
 #   DISPATCH_INVALID_STATE_SWEEP_ROOT  — replaces resolve_project_root
 #   DISPATCH_INVALID_STATE_SWEEP_MAX   — per-invocation router-call cap
+#   DISPATCH_INVALID_STATE_ROUTE_TIMEOUT_S — per-router-call wall-clock budget
+#   DISPATCH_INVALID_STATE_LOCK_WAIT_S — landing-lock wait handed to the router
 #   CLAUDE_AGENTS_CMD                  — the registry fake
 
 set -uo pipefail
@@ -70,6 +72,34 @@ if [[ ! -x "$ROUTE" ]]; then
   exit 0
 fi
 
+# BOUND EVERY ROUTER CALL. The cap above bounds HOW MANY router calls a tick
+# makes; it says nothing about how long one may take, and the router's own work
+# is neither cheap nor self-bounding: git reads, and — when a fleet-level
+# precondition fails — a latch mint (`npx tsx write-node.ts` plus a graph landing
+# push whose lock wait defaults to roughly 1050 seconds). This sweep runs INLINE
+# on the tick's scheduling path, between two lock heartbeats, so an unbounded
+# call stalls the tick past its heartbeat window, lets another tick steal the
+# lock, and stalls the fleet. Same posture (and same 60s default) as
+# `invalid_state_route_gate`, the other call site of this router
+# (lib-frozen-session-park.sh) — including its refusal to run at all when
+# `timeout` cannot be resolved: an unbounded call on the tick path is a loud
+# abort, never a silent downgrade (.claude/rules/code-style.md).
+TIMEOUT_BIN=$(command -v timeout 2>/dev/null) || TIMEOUT_BIN=""
+if [[ -z "$TIMEOUT_BIN" ]]; then
+  echo "invalid-state-sweep: timeout not found; refusing an unbounded router call on the tick path; sweeping nothing"
+  exit 0
+fi
+ROUTE_TIMEOUT="${DISPATCH_INVALID_STATE_ROUTE_TIMEOUT_S:-60}"
+[[ "$ROUTE_TIMEOUT" =~ ^[0-9]+$ ]] || ROUTE_TIMEOUT=60
+
+# The same hazard bounded from the inside as well: a short landing-lock wait for
+# whatever graph landing the router performs, so a lock contended by any
+# concurrent graph writer DEFERS this candidate to the next tick instead of being
+# waited out inline. Mirrors the short lock wait this fleet already hands
+# park-node on the sweep path (lib-frozen-session-park.sh).
+ROUTE_LOCK_WAIT="${DISPATCH_INVALID_STATE_LOCK_WAIT_S:-60}"
+[[ "$ROUTE_LOCK_WAIT" =~ ^[0-9]+$ ]] || ROUTE_LOCK_WAIT=60
+
 # Step 1 — enumerate candidates. Columns are sessionId<TAB>id<TAB>name<TAB>cwd,
 # where `.id` is the JOB id and is NOT a prefix of the sessionId; any job-dir
 # lookup MUST key on that column.
@@ -101,6 +131,32 @@ while IFS=$'\t' read -r sid jid name cwd; do
     continue
   fi
 
+  # Doctrine gates, held INDEPENDENTLY of the router rather than delegated to
+  # it. terminal_without_disposition_sweep carries both as its own steps (8) and
+  # (9) (lib-frozen-session-park.sh:1167-1190) and this arm must not be the one
+  # detection path that lacks them: a completed node sitting in the normal
+  # post-completion reap window (session terminal, worktree not yet reaped) and
+  # an already-parked node are both states the ratified doctrine calls VALID, and
+  # routing either one spawns an Opus session against a node nobody asked about.
+  # Frontmatter-scoped and column-0 anchored, the same idiom the sweeps use: the
+  # scoping means a column-0 `phase:`/`office_hours:` line in the markdown BODY
+  # cannot be misread as node state. `office_hours` is a PRESENCE test, never a
+  # value read — a parked node serializes it as a block mapping, so the key's own
+  # line is empty after the colon.
+  frontmatter=$(awk 'NR==1&&/^---/{f=1;next} f&&/^---[[:space:]]*$/{exit} f' \
+    "$PROJECT_ROOT/intentions/$name.md" 2>/dev/null)
+  if grep -qE '^phase:[[:space:]]*done[[:space:]]*$' <<<"$frontmatter"; then
+    KEPT=$(( KEPT + 1 ))
+    echo "invalid-state-sweep: $name is phase: done — finished, not an invalid state; keeping"
+    continue
+  fi
+  if grep -q '^office_hours:' <<<"$frontmatter" \
+     && ! grep -qE '^office_hours:[[:space:]]*null[[:space:]]*$' <<<"$frontmatter"; then
+    KEPT=$(( KEPT + 1 ))
+    echo "invalid-state-sweep: $name is already parked to office_hours — a human owns it; keeping"
+    continue
+  fi
+
   if (( CALLS >= SWEEP_MAX )); then
     # Deliberately NOT silent: a silent cap reads as "covered everything".
     echo "invalid-state-sweep: per-invocation cap ($SWEEP_MAX) reached — $name and any further candidates deferred to a later tick"
@@ -119,6 +175,15 @@ while IFS=$'\t' read -r sid jid name cwd; do
 
   # Evidence file: what the router hands the intervention session. A PATH is
   # passed onward, never the content.
+  #
+  # LIFECYCLE. This sweep CREATES the file, so it owns the file until ownership
+  # transfers. Ownership transfers to the spawned intervention session exactly
+  # when the router reports it launched one (rc 0) — that session reads the path
+  # out of its own prompt, so the file must outlive this loop iteration. On every
+  # other router outcome no session was launched and nothing will ever read the
+  # file, so this sweep deletes it below. Without that, the inert-tier steady
+  # state (the intervention skill has not landed, so the router always escalates)
+  # would drop up to SWEEP_MAX files into the temp dir per tick, forever.
   EVIDENCE=$(mktemp "${TMPDIR:-/tmp}/invalid-state-evidence-XXXXXX") || EVIDENCE=""
   if [[ -n "$EVIDENCE" ]]; then
     {
@@ -141,16 +206,29 @@ while IFS=$'\t' read -r sid jid name cwd; do
   fi
 
   CALLS=$(( CALLS + 1 ))
-  "$ROUTE" --node "$name" --kind terminal-session \
-    --session "$sid" --job-id "$jid" --evidence-file "$EVIDENCE" >/dev/null 2>&1
+  # `</dev/null` so a router subprocess can never consume the remaining rows of
+  # the here-string this loop is reading from (the same hazard
+  # lib-frozen-session-park.sh drains its candidate list to avoid).
+  GRAPH_COMMIT_LOCK_WAIT_SECONDS="$ROUTE_LOCK_WAIT" \
+  "$TIMEOUT_BIN" "$ROUTE_TIMEOUT" "$ROUTE" --node "$name" --kind terminal-session \
+    --session "$sid" --job-id "$jid" --evidence-file "$EVIDENCE" >/dev/null 2>&1 </dev/null
   rc=$?
+  # Hand the evidence file back to its creator unless ownership transferred. rc 0
+  # transferred it to the launched session. rc 124 means `timeout` killed the
+  # router mid-call, which may have been AFTER its spawn returned — no positive
+  # evidence that nothing owns the file, so leave it rather than pull the
+  # evidence out from under a session that may be starting on it.
+  if [[ -n "$EVIDENCE" && "$rc" != 0 && "$rc" != 124 ]]; then
+    rm -f "$EVIDENCE" 2>/dev/null || true
+  fi
   case "$rc" in
     0)  INTERVENED=$(( INTERVENED + 1 )) ;;
     4)  KEPT=$(( KEPT + 1 )) ;;
     *)
-      # 10 (escalate), 1 (router failure) and anything else all defer to the
-      # sweep tier. terminal_without_disposition_sweep owns the escalation this
-      # round; this arm must not duplicate its park.
+      # 10 (escalate), 1 (router failure), 124 (the wall-clock budget above ran
+      # out) and anything else all defer to the sweep tier.
+      # terminal_without_disposition_sweep owns the escalation this round; this
+      # arm must not duplicate its park.
       ESCALATE_DEFERRED=$(( ESCALATE_DEFERRED + 1 ))
       echo "invalid-state-sweep: $name deferred (router rc=$rc) — terminal_without_disposition_sweep owns the escalation"
       ;;

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-invalid-state-sweep
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-invalid-state-sweep
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# dispatch-invalid-state-sweep — the invalid-state lane's SELECTION-TIME
+# detection arm (tactic-invalid-state-lane Unit 4). Runs pre-selection on the
+# tick, finds nodes held by a TERMINAL worker session, and hands each to
+# `dispatch-invalid-state-route`.
+#
+# Modelled directly on dispatch-graph-scope-sweep: same shape (pre-selection,
+# enumerate then act, decision/liveness/landing split) and the same invariant —
+#
+#   THE CLAIMED SET THIS HONORS MUST MATCH graph-select-target's EXACTLY.
+#
+# A node the selector will not touch must also be one this sweep will not act on,
+# else the sweep races the selector by intervening on a node selection considers
+# claimed. graph-select-target skips a node when `reservation_exists` OR its
+# occupancy is anything but `free`, so this sweep excludes both halves.
+#
+# THIS ARM NEVER PARKS, NEVER HOLDS, NEVER REAPS. That is deliberate and is the
+# single escalation-owner rule: dispatch-tick runs both defensive sweeps
+# (frozen_session_sweep, terminal_without_disposition_sweep) on every cadence, so
+# the sweep tier is ALWAYS the escalation path. Duplicating a park here would
+# create a second, unproven park implementation beside 1269 lines of
+# carefully-proven park machinery.
+#
+# UNKNOWN IS NOT AN EMPTY SET. `claude_agents_list_terminal_workers` returning
+# UNKNOWN aborts the sweep for this tick with a diagnostic. An empty set would
+# read as "nothing is wrong" — the exact sensors-rule failure this lane exists to
+# fix. (Same rule dispatch-graph-scope-sweep states for claude_agents_list_all.)
+#
+# Always exits 0 and prints one summary line: the tick's scheduling path must
+# never be aborted by this sweep.
+#
+# Sandbox: reads the Claude daemon over a Unix socket and spawns sessions
+# (through the router). dispatch-select-tick runs with the sandbox disabled,
+# which covers this — see .claude/rules/sandbox.md.
+#
+# Test overrides:
+#   DISPATCH_INVALID_STATE_ROUTE_CMD   — replaces dispatch-invalid-state-route
+#   DISPATCH_INVALID_STATE_SWEEP_ROOT  — replaces resolve_project_root
+#   DISPATCH_INVALID_STATE_SWEEP_MAX   — per-invocation router-call cap
+#   CLAUDE_AGENTS_CMD                  — the registry fake
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=lib-claude-agents.sh
+source "$SCRIPT_DIR/lib-claude-agents.sh"
+# shellcheck source=lib-reservation-ledger.sh
+source "$SCRIPT_DIR/lib-reservation-ledger.sh"
+
+# Bound the work: this runs INLINE on the tick's scheduling path, and each router
+# call can spawn a session. Two per invocation is enough to drain a backlog over
+# a few ticks without turning one tick into a fan-out.
+SWEEP_MAX="${DISPATCH_INVALID_STATE_SWEEP_MAX:-2}"
+[[ "$SWEEP_MAX" =~ ^[0-9]+$ ]] || SWEEP_MAX=2
+
+PROJECT_ROOT="${DISPATCH_INVALID_STATE_SWEEP_ROOT:-}"
+if [[ -z "$PROJECT_ROOT" ]]; then
+  PROJECT_ROOT=$(resolve_project_root) || PROJECT_ROOT=""
+fi
+if [[ -z "$PROJECT_ROOT" || ! -d "$PROJECT_ROOT" ]]; then
+  echo "invalid-state-sweep: could not resolve the project root; sweeping nothing"
+  exit 0
+fi
+
+ROUTE="${DISPATCH_INVALID_STATE_ROUTE_CMD:-$SCRIPT_DIR/dispatch-invalid-state-route}"
+if [[ ! -x "$ROUTE" ]]; then
+  echo "invalid-state-sweep: router not executable at $ROUTE; sweeping nothing"
+  exit 0
+fi
+
+# Step 1 — enumerate candidates. Columns are sessionId<TAB>id<TAB>name<TAB>cwd,
+# where `.id` is the JOB id and is NOT a prefix of the sessionId; any job-dir
+# lookup MUST key on that column.
+if ! ROWS=$(claude_agents_list_terminal_workers 2>/dev/null); then
+  echo "invalid-state-sweep: terminal-worker registry read is UNKNOWN — aborting this tick rather than reading it as an empty set"
+  exit 0
+fi
+
+CANDIDATES=0
+INTERVENED=0
+KEPT=0
+ESCALATE_DEFERRED=0
+CALLS=0
+
+while IFS=$'\t' read -r sid jid name cwd; do
+  [[ -n "${name:-}" ]] || continue
+
+  # Keyspace: only genuine graph node ids with a node file. A legacy `<N>-slug`
+  # issue worktree is not this lane's to route.
+  [[ "$name" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]] || continue
+  [[ -f "$PROJECT_ROOT/intentions/$name.md" ]] || continue
+
+  CANDIDATES=$(( CANDIDATES + 1 ))
+
+  # Claimed-set parity with the selector: a reserved node is one the selector
+  # will not touch either.
+  if reservation_exists "$name" 2>/dev/null; then
+    KEPT=$(( KEPT + 1 ))
+    continue
+  fi
+
+  if (( CALLS >= SWEEP_MAX )); then
+    # Deliberately NOT silent: a silent cap reads as "covered everything".
+    echo "invalid-state-sweep: per-invocation cap ($SWEEP_MAX) reached — $name and any further candidates deferred to a later tick"
+    break
+  fi
+
+  # Confirm with the granular classifier that the node's OWN-ID worktree really
+  # is terminal. The registry row says a session is terminal; this says the node
+  # is actually held by it. Called directly (not via `$( )`) so the evidence
+  # globals survive — see worktree_occupancy_state's CAVEAT.
+  worktree_occupancy_state "$PROJECT_ROOT/.claude/worktrees/$name" >/dev/null 2>&1
+  if [[ "$WORKTREE_OCCUPANCY_STATE" != "terminal" ]]; then
+    KEPT=$(( KEPT + 1 ))
+    continue
+  fi
+
+  # Evidence file: what the router hands the intervention session. A PATH is
+  # passed onward, never the content.
+  EVIDENCE=$(mktemp "${TMPDIR:-/tmp}/invalid-state-evidence-XXXXXX") || EVIDENCE=""
+  if [[ -n "$EVIDENCE" ]]; then
+    {
+      printf 'detected-by: dispatch-invalid-state-sweep\n'
+      printf 'node: %s\n' "$name"
+      printf 'session_id: %s\n' "$sid"
+      printf 'job_id: %s\n' "$jid"
+      printf 'session_cwd: %s\n' "$cwd"
+      printf 'registry_state: terminal\n'
+      printf 'occupancy: %s\n' "$WORKTREE_OCCUPANCY_STATE"
+      # The absence of this marker is the whole point: a terminal session that
+      # never declared a disposition is what freezes the node.
+      if [[ -n "$jid" && -f "$HOME/.claude/jobs/$jid/node-terminal" ]]; then
+        printf 'node_terminal_marker: present\n'
+      else
+        printf 'node_terminal_marker: absent\n'
+      fi
+      printf 'transcript_hint: %s\n' "$HOME/.claude/projects/*/$sid.jsonl"
+    } > "$EVIDENCE" 2>/dev/null || true
+  fi
+
+  CALLS=$(( CALLS + 1 ))
+  "$ROUTE" --node "$name" --kind terminal-session \
+    --session "$sid" --job-id "$jid" --evidence-file "$EVIDENCE" >/dev/null 2>&1
+  rc=$?
+  case "$rc" in
+    0)  INTERVENED=$(( INTERVENED + 1 )) ;;
+    4)  KEPT=$(( KEPT + 1 )) ;;
+    *)
+      # 10 (escalate), 1 (router failure) and anything else all defer to the
+      # sweep tier. terminal_without_disposition_sweep owns the escalation this
+      # round; this arm must not duplicate its park.
+      ESCALATE_DEFERRED=$(( ESCALATE_DEFERRED + 1 ))
+      echo "invalid-state-sweep: $name deferred (router rc=$rc) — terminal_without_disposition_sweep owns the escalation"
+      ;;
+  esac
+done <<< "$ROWS"
+
+echo "invalid-state-sweep: candidates=$CANDIDATES intervened=$INTERVENED kept=$KEPT escalate-deferred=$ESCALATE_DEFERRED"
+exit 0

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -579,11 +579,38 @@ fi
 # selection considers claimed. Best-effort (a failure must not abort the tick);
 # this whole script runs with the sandbox disabled (see the header note), which
 # covers the sweep's daemon socket read and the router's session spawn.
-INVALID_STATE_SWEEP_OUT=$("$SCRIPT_DIR/dispatch-invalid-state-sweep") || true
-if [[ -n "$INVALID_STATE_SWEEP_OUT" ]]; then
-  while IFS= read -r sweep_line; do
-    [[ -n "$sweep_line" ]] && echo "invalid-state: $sweep_line"
-  done <<< "$INVALID_STATE_SWEEP_OUT"
+#
+# BOUNDED. This runs INLINE on the scheduling path, between the heartbeat above
+# and the `refresh_lock` below, and it calls the invalid-state router (up to its
+# own per-invocation cap) — whose git reads, latch mint and graph landing push
+# are not self-bounding. Left unbounded, one contended graph landing lock (any
+# concurrent graph writer induces one) would hold this tick past its heartbeat
+# window, let another tick steal the lock, and stall the fleet. The sweep bounds
+# each router call itself; this is the outer bound on the whole sweep, and it
+# takes the same posture `invalid_state_route_gate` takes for its router call
+# (lib-frozen-session-park.sh): a missing `timeout` is a loud SKIP of the sweep,
+# never a silent unbounded call (.claude/rules/code-style.md). The default budget
+# covers the sweep's whole per-invocation router budget (cap 2 x the 60s per-call
+# timeout) plus slack.
+INVALID_STATE_TIMEOUT_BIN=$(command -v timeout 2>/dev/null) || INVALID_STATE_TIMEOUT_BIN=""
+INVALID_STATE_SWEEP_BUDGET="${DISPATCH_INVALID_STATE_SWEEP_TIMEOUT_S:-180}"
+[[ "$INVALID_STATE_SWEEP_BUDGET" =~ ^[0-9]+$ ]] || INVALID_STATE_SWEEP_BUDGET=180
+if [[ -z "$INVALID_STATE_TIMEOUT_BIN" ]]; then
+  echo "invalid-state: timeout not found; refusing to run an unbounded invalid-state sweep on the tick path; sweeping nothing"
+else
+  INVALID_STATE_SWEEP_RC=0
+  INVALID_STATE_SWEEP_OUT=$("$INVALID_STATE_TIMEOUT_BIN" "$INVALID_STATE_SWEEP_BUDGET" \
+    "$SCRIPT_DIR/dispatch-invalid-state-sweep" </dev/null) || INVALID_STATE_SWEEP_RC=$?
+  if [[ -n "$INVALID_STATE_SWEEP_OUT" ]]; then
+    while IFS= read -r sweep_line; do
+      [[ -n "$sweep_line" ]] && echo "invalid-state: $sweep_line"
+    done <<< "$INVALID_STATE_SWEEP_OUT"
+  fi
+  # 124 is `timeout`'s own code. Never silent: a truncated sweep that reads as a
+  # clean pass is the sensors-rule failure this lane exists to fix.
+  if (( INVALID_STATE_SWEEP_RC == 124 )); then
+    echo "invalid-state: sweep exceeded its ${INVALID_STATE_SWEEP_BUDGET}s budget and was cut short — remaining candidates deferred to the next tick (the lock heartbeat must not be starved)"
+  fi
 fi
 
 # Heartbeat: refresh after the auto-merge and reconcile-merged sub-steps complete (#2104, #2512).

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -569,6 +569,23 @@ if [[ -n "$SCOPE_SWEEP_OUT" ]]; then
   done <<< "$SCOPE_SWEEP_OUT"
 fi
 
+# Pre-selection invalid-state sweep (tactic-invalid-state-lane Unit 4). The
+# lane's selection-time detection arm: finds nodes held by a TERMINAL worker
+# session — an INVALID state, where nothing is running yet the claim survives —
+# and routes each through dispatch-invalid-state-route. It never parks, holds or
+# reaps; the two defensive sweeps in dispatch-tick own the escalation, so this
+# arm defers to them rather than adding a second park implementation. Its
+# claimed set matches graph-select-target's exactly, so it cannot act on a node
+# selection considers claimed. Best-effort (a failure must not abort the tick);
+# this whole script runs with the sandbox disabled (see the header note), which
+# covers the sweep's daemon socket read and the router's session spawn.
+INVALID_STATE_SWEEP_OUT=$("$SCRIPT_DIR/dispatch-invalid-state-sweep") || true
+if [[ -n "$INVALID_STATE_SWEEP_OUT" ]]; then
+  while IFS= read -r sweep_line; do
+    [[ -n "$sweep_line" ]] && echo "invalid-state: $sweep_line"
+  done <<< "$INVALID_STATE_SWEEP_OUT"
+fi
+
 # Heartbeat: refresh after the auto-merge and reconcile-merged sub-steps complete (#2104, #2512).
 refresh_lock
 

--- a/.claude/skills/dispatch-propagate/scripts/graph-select-target
+++ b/.claude/skills/dispatch-propagate/scripts/graph-select-target
@@ -791,11 +791,42 @@ while IFS=$'\t' read -r id kind phase pr pace_exempt pushed_sha fix_since; do
     [[ -n "$NODE_TARGET" ]] && echo "graph-select-target: reserved" >&2
     continue
   fi
-  if worktree_has_live_session "$NATIVE_ROOT/.claude/worktrees/$id"; then
-    skip_note "$id" "live-session"
-    [[ -n "$NODE_TARGET" ]] && echo "graph-select-target: live-session" >&2
-    continue
-  fi
+  # `worktree_occupancy_state` is the granular form of the same check: it makes
+  # the same claimed-set decision (everything but `free` is skipped) while
+  # naming WHY. `terminal` is an INVALID state — nothing is running, yet the
+  # claim survives — and folding it into `live-session`, as this call did
+  # before, made it invisible at the exact moment the router noticed it. The
+  # node is still skipped in all four cases; this unit adds no routing, no
+  # spawn and no graph write. The routing act lives in
+  # `dispatch-invalid-state-sweep`, which runs before selection over the same
+  # predicate, keeping session spawning out of a script humans invoke standalone.
+  # Called DIRECTLY with stdout redirected, not via `$( )`: the evidence
+  # globals are set in a subshell by a command substitution and would be lost,
+  # so the diagnostic below would name a stale session id. See the CAVEAT in
+  # `worktree_occupancy_state`'s header.
+  worktree_occupancy_state "$NATIVE_ROOT/.claude/worktrees/$id" >/dev/null
+  occupancy="$WORKTREE_OCCUPANCY_STATE"
+  case "$occupancy" in
+    free)
+      : # fall through to the sensor gate
+      ;;
+    terminal)
+      skip_note "$id" "terminal-session"
+      if [[ -n "$NODE_TARGET" ]]; then
+        echo "graph-select-target: terminal-session — $id is occupied-by-terminal (an INVALID state), not occupied-by-live: session ${WORKTREE_OCCUPANCY_SESSION_ID:-unknown} is registered but no longer running, and the claim survives until it is released" >&2
+      fi
+      continue
+      ;;
+    *)
+      # `live` (a valid claim) and `unknown` (a daemon read that failed) both
+      # report the unchanged `live-session` reason. UNKNOWN must NEVER surface
+      # as an invalid state: a daemon hiccup would otherwise manufacture
+      # interventions out of healthy nodes.
+      skip_note "$id" "live-session"
+      [[ -n "$NODE_TARGET" ]] && echo "graph-select-target: live-session" >&2
+      continue
+      ;;
+  esac
 
   # sensor_gate returns the PHASE TO EMIT on stdout when satisfied — it may
   # differ from the candidate's `phase` (a fresh CI-fix interrupt emits `fix`

--- a/.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh
@@ -14,6 +14,7 @@
 #   claude_agents_list_registered
 #   live_session_claimed_nums
 #   worktree_has_live_session          <worktree-path> [exclude_sid]
+#   worktree_occupancy_state           <worktree-path> [exclude_sid]
 #   claude_agents_count_busy_workers
 #   claude_agents_list_blocked_workers
 #   claude_agents_count_held_for_debug
@@ -389,6 +390,25 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
   _LIB_CLAUDE_AGENTS_LOADED=1
 
   set -uo pipefail
+
+  # CLAUDE_AGENTS_TERMINAL_STATES_JQ — the SINGLE definition of what "terminal"
+  # means, as a jq `def` fragment prepended to every program that needs it.
+  # Three consumers share it verbatim: `claude_agents_count_held_for_debug`,
+  # `claude_agents_list_terminal_workers`, and `worktree_occupancy_state`. They
+  # previously each carried their own copy of the same nine-state list; a
+  # divergence between them would mean the counter, the lister and the occupancy
+  # classifier disagreed about which sessions are dead, so the list lives here
+  # once and cannot drift.
+  #
+  # The enumeration is deliberate, not an oversight: a NEW state the daemon
+  # introduces reads as live (not terminal) until it is added here, which
+  # under-reports rather than inventing frozen nodes that do not exist. Keep
+  # that posture when extending the list.
+  CLAUDE_AGENTS_TERMINAL_STATES_JQ='
+      def terminal_states:
+        ["done","stopped","killed","failed","errored","error",
+         "cancelled","canceled","terminated"];
+'
 
   # _claude_agents_raw — emit the raw `claude agents --json` array on stdout.
   # Reads the tick snapshot (DISPATCH_AGENTS_SNAPSHOT) when set and readable —
@@ -973,6 +993,79 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
       printf 'lib-claude-agents: worktree_has_live_session requires a <path> argument\n' >&2
       return 0  # fail safe: treat as occupied
     fi
+    # Thin wrapper over `worktree_occupancy_state` — the granular classifier
+    # below. The boolean contract is UNCHANGED for every existing caller:
+    # only a definite `free` releases the worktree; `live`, `terminal` and
+    # `unknown` all report occupied, which preserves the fail-safe UNKNOWN fold
+    # verbatim. A terminal holder still blocks its node exactly as before; the
+    # only thing that changed is that callers who WANT to tell the two apart can
+    # now ask for the token instead of the exit code.
+    local _st
+    _st="$(worktree_occupancy_state "$pth" "${2:-}")"
+    [[ "$_st" == "free" ]] && return 1
+    return 0
+  }
+
+  # WORKTREE_OCCUPANCY_STATE / WORKTREE_OCCUPANCY_SESSION_ID — the granular
+  # verdict and the matched holder's sessionId from the most recent
+  # `worktree_occupancy_state` call. Initialized here so a read before the first
+  # call under `set -u` is not an unbound-variable error (same idiom as
+  # CLAUDE_SESSION_ID_LIVE_STATE).
+  WORKTREE_OCCUPANCY_STATE="unknown"
+  WORKTREE_OCCUPANCY_SESSION_ID=""
+
+  # worktree_occupancy_state <path> [exclude_sid] — the granular OCCUPANCY
+  # classifier behind `worktree_has_live_session`.
+  #
+  # Prints exactly ONE token on stdout and ALWAYS returns 0. The TOKEN, not the
+  # exit code, is the contract — the same shape `dispatch_pause_state`
+  # (`lib-pause-state.sh:30-45`) uses, and the reason this function cannot be
+  # written as a predicate: it has four outcomes, not two.
+  #
+  #   free      — the daemon answered and no session claims this worktree.
+  #   live      — a registered session claims it and is NOT in a terminal state.
+  #               A valid claim: callers skip the node and never spawn into it.
+  #   terminal  — a registered session claims it but its state is terminal
+  #               (see CLAUDE_AGENTS_TERMINAL_STATES_JQ). Nothing is running, yet
+  #               the claim survives until an explicit release. This is an
+  #               INVALID STATE — the distinction this function exists to make.
+  #   unknown   — the daemon could not be queried. NOT evidence of anything.
+  #               Callers MUST fold it toward occupied and MUST NOT treat it as
+  #               an invalid state: a daemon hiccup must never manufacture an
+  #               intervention.
+  #
+  # Also sets WORKTREE_OCCUPANCY_STATE (mirrors stdout) and
+  # WORKTREE_OCCUPANCY_SESSION_ID (the matched row's sessionId; empty for `free`
+  # and `unknown`) for callers that need the evidence rather than the verdict.
+  #
+  # CAVEAT — the two globals are observable ONLY on a DIRECT call:
+  #     worktree_occupancy_state "$wt" >/dev/null   # globals set
+  #     st=$(worktree_occupancy_state "$wt")        # globals NOT set in caller
+  # Command substitution runs the function in a subshell, so assignments made
+  # inside it die with that subshell. This is why the TOKEN, not a global, is
+  # the contract: a caller that reads `$st` is always correct, while a caller
+  # that reads the globals after a `$( )` call silently sees the previous call's
+  # values (or the file-scope initializers). Need the sessionId? Call directly
+  # and redirect stdout, as `dispatch-invalid-state-sweep` does.
+  #
+  # Everything about candidate matching is inherited unchanged from the
+  # `worktree_has_live_session` this function was extracted from: ONE
+  # `claude_agents_list_registered` fetch (never two round-trips per worktree),
+  # the two-name check (worktree basename, plus `office-hours-<N>` only for a
+  # genuine numeric prefix), exact column-3 matching (never a substring grep),
+  # and the `exclude_sid` semantics.
+  worktree_occupancy_state() {
+    WORKTREE_OCCUPANCY_STATE="unknown"
+    WORKTREE_OCCUPANCY_SESSION_ID=""
+    local pth="${1:-}"
+    if [[ -z "$pth" ]]; then
+      printf 'lib-claude-agents: worktree_occupancy_state requires a <path> argument\n' >&2
+      # Fail safe: no path is not evidence of freedom. `unknown` folds to
+      # occupied in every caller, matching worktree_has_live_session's own
+      # empty-arg handling.
+      printf 'unknown\n'
+      return 0
+    fi
     local exclude_sid="${2:-}"
     local base oh
     base="$(basename "$pth")"
@@ -999,7 +1092,12 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
     # clean worktree on dispatch-sweep's hot path.
     local all
     if ! all=$(claude_agents_list_registered); then
-      # Unknown — the daemon could not be queried. Fail safe: occupied.
+      # Unknown — the daemon could not be queried. Fail safe: the caller folds
+      # this toward occupied, but it is NOT reported as `terminal`: no positive
+      # evidence exists, and a blocked read must never manufacture an invalid
+      # state.
+      WORKTREE_OCCUPANCY_STATE="unknown"
+      printf 'unknown\n'
       return 0
     fi
 
@@ -1032,21 +1130,45 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
       # diagnostic. `%%`/`#` preserve empty fields on both sides.
       msid="${matched%%$'\t'*}"
       mstate="${matched#*$'\t'}"
-      # A `done` holder is the non-obvious case: nothing is running, yet the
-      # worktree stays blocked until a human releases it. Say so — on EVERY
-      # probe that matches it, one line per probe (there is no dedup: the
-      # per-skip diagnostic IS the pressure valve, and each skip is a distinct
-      # decision worth a trace line). Name the release act. Any other state
-      # (including empty) stays silent.
-      if [[ "$mstate" == "done" ]]; then
-        printf "lib-claude-agents: %s held by a done-but-not-removed session %s — release it with 'claude rm %s' (a stopped session keeps blocking its node by design)\n" \
-          "$pth" "$msid" "$msid" >&2
+      WORKTREE_OCCUPANCY_SESSION_ID="$msid"
+
+      # Classify the matched row's state against the single shared terminal
+      # enumeration. jq (not a bash case) so this cannot drift from the two
+      # other consumers of CLAUDE_AGENTS_TERMINAL_STATES_JQ. A jq failure here
+      # is treated as NOT terminal — under-report rather than invent a frozen
+      # node, the same posture the enumeration itself documents.
+      local is_terminal
+      if ! is_terminal=$(jq -rn --arg st "$mstate" \
+          "$CLAUDE_AGENTS_TERMINAL_STATES_JQ"'
+          if (terminal_states | index($st)) then "yes" else "no" end' 2>/dev/null); then
+        is_terminal="no"
       fi
+
+      if [[ "$is_terminal" == "yes" ]]; then
+        # A terminal holder is the non-obvious case: nothing is running, yet the
+        # worktree stays blocked until a human (or the invalid-state lane's
+        # intervention session) releases it. Say so — on EVERY probe that
+        # matches it, one line per probe (there is no dedup: the per-skip
+        # diagnostic IS the pressure valve, and each skip is a distinct decision
+        # worth a trace line). Name the release act, and name whichever terminal
+        # state actually matched rather than assuming `done`.
+        printf "lib-claude-agents: %s held by a %s-but-not-removed session %s — release it with 'claude rm %s' (a stopped session keeps blocking its node by design)\n" \
+          "$pth" "${mstate:-terminal}" "$msid" "$msid" >&2
+        WORKTREE_OCCUPANCY_STATE="terminal"
+        printf 'terminal\n'
+        return 0
+      fi
+
+      # Any other state (including empty) is a live claim, and stays silent.
+      WORKTREE_OCCUPANCY_STATE="live"
+      printf 'live\n'
       return 0
     fi
 
     # The query succeeded and matched neither name: definitely free.
-    return 1
+    WORKTREE_OCCUPANCY_STATE="free"
+    printf 'free\n'
+    return 0
   }
 
   # CLAUDE_SESSION_ID_LIVE_STATE — the granular verdict of the most recent
@@ -1250,7 +1372,10 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
   # The predicate keys on `(.state // .status)` and matches the SAME terminal
   # enumeration `claude_session_id_is_live` uses
   # (done|stopped|killed|failed|errored|error|cancelled|canceled|terminated),
-  # so the two agree on what "terminal" means. `.state` is the granular field
+  # so the two agree on what "terminal" means. That list lives in exactly one
+  # place — CLAUDE_AGENTS_TERMINAL_STATES_JQ at the top of this file — shared
+  # with `claude_agents_list_terminal_workers` and `worktree_occupancy_state`.
+  # `.state` is the granular field
   # the `--all` listing carries — a terminal row is
   # `{"state":"done"}` with NO `.status` key at all, while a live row is
   # `{"state":"working","status":"busy"|"idle"}`. A complement predicate
@@ -1290,10 +1415,7 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
     # row that has no `.state`, and "" for a row with neither (which is NOT
     # terminal → not counted).
     local count
-    if ! count=$(jq -r '
-      def terminal_states:
-        ["done","stopped","killed","failed","errored","error",
-         "cancelled","canceled","terminated"];
+    if ! count=$(jq -r "$CLAUDE_AGENTS_TERMINAL_STATES_JQ"'
       if type == "array"
       then [ .[]
         | select(.name | type == "string" and test("^[0-9]+-|^tactic-|^strategy-"))
@@ -1326,8 +1448,10 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
   # no `.id` emits an empty column (`@tsv` renders null as ""), which callers
   # must treat as "no job dir", never as a match.
   #
-  # Reuses `claude_agents_count_held_for_debug`'s `terminal_states` jq `def`
-  # verbatim, and its `(.state // .status) // ""` resolution: `.state` is the
+  # Shares the single `terminal_states` jq `def`
+  # (CLAUDE_AGENTS_TERMINAL_STATES_JQ, defined once at the top of this file) with
+  # `claude_agents_count_held_for_debug` and `worktree_occupancy_state`, and its
+  # `(.state // .status) // ""` resolution: `.state` is the
   # granular field the `--all` listing carries — a terminal row is
   # `{"state":"done"}` with NO `.status` key at all — falling back to the
   # coarse `.status` for a row that has no `.state`, and "" for a row with
@@ -1370,10 +1494,7 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
     # a terminal (.state // .status), and projects the TSV. Non-array input
     # errors out and the result is UNKNOWN.
     local lines
-    if ! lines=$(jq -r '
-      def terminal_states:
-        ["done","stopped","killed","failed","errored","error",
-         "cancelled","canceled","terminated"];
+    if ! lines=$(jq -r "$CLAUDE_AGENTS_TERMINAL_STATES_JQ"'
       if type == "array"
       then .[]
         | select(.name | type == "string" and test("^[0-9]+-|^tactic-|^strategy-"))

--- a/.claude/skills/dispatch-propagate/scripts/lib-frozen-session-park.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-frozen-session-park.sh
@@ -233,6 +233,83 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
 
   set -uo pipefail
 
+  # invalid_state_route_gate <repo-root> <node> <kind> <sid> [job-id] — the invalid-state
+  # lane's PRE-TIER, consulted by both sweeps immediately before their park block
+  # and AFTER every one of their existing gates (name shape, session-id shape,
+  # idle grace, stand-down interlock, `phase: done` gate, park cap, base-blob
+  # pin). This is the lane's second detection point; the first is
+  # dispatch-invalid-state-sweep at selection time.
+  #
+  # Returns the router's exit code, which the callers map as:
+  #     0  handled  → count `routed`, log `routed-to-lane`, DO NOT park, and DO
+  #                   NOT delete the job dir's office-hours-* markers.
+  #     4  keep     → count `kept`, log `kept-by-lane`.
+  #     anything else (10 escalate, 1 router failure, 2 usage, a timeout, or a
+  #                   missing/unresolvable router) → the caller FALLS THROUGH to
+  #                   its existing park path unchanged. Fail toward escalate.
+  #
+  # A routed candidate is DEFERRED, not resolved: the freeze persists until the
+  # intervention session (or a human) reaps. The sweep still owns escalation this
+  # round — extracting the park-with-landing-proof block into the router is a
+  # declared residual, deliberately not attempted here.
+  #
+  # Provenance and bounding mirror what this file already applies to `park-node`,
+  # INCLUDING where the executable is resolved from: the router is taken from the
+  # sweep's own `$repo_root` (which provenance check 1 has already asserted is a
+  # primary checkout on `main`), NOT from this library's own location. That is
+  # deliberate and load-bearing for two reasons:
+  #
+  #   1. Production: the router must run out of the same checkout the sweep is
+  #      operating on, the same reason park-node is invoked BY PATH under
+  #      $repo_root — it resolves its own repo root from its script location.
+  #   2. Testing: resolving from ${BASH_SOURCE[0]} would make the REAL router
+  #      reachable from a test that merely sources this library, and the router
+  #      has durable side effects (the fleet-latch sidecar and, at threshold, a
+  #      graph-commit that mints a node). An early draft did exactly that and one
+  #      suite run drove the real counter to 156 observations.
+  #
+  # The router must be an executable regular file whose REAL directory is that
+  # checkout's scripts dir (canonicalized with `pwd -P`, so `..` segments and
+  # symlinked temp roots cannot slip an arbitrary executable past a string prefix
+  # test), and the call is wrapped in the same `timeout` binary the file resolves
+  # and refuses to run without — an unbounded router call on the tick path is a
+  # fleet stall. DISPATCH_INVALID_STATE_ROUTE_CMD overrides the path for tests,
+  # safely, because the provenance check still applies to it.
+  invalid_state_route_gate() {
+    local repo_root="$1" node="$2" kind="$3" sid="${4:-}" jid="${5:-}"
+
+    [[ -n "$repo_root" && -d "$repo_root" ]] || return 10
+    local scripts_dir scripts_dir_real route route_dir_real
+    scripts_dir="$repo_root/.claude/skills/dispatch-propagate/scripts"
+    scripts_dir_real=$(cd "$scripts_dir" 2>/dev/null && pwd -P) || scripts_dir_real=""
+    [[ -n "$scripts_dir_real" ]] || return 10
+    route="${DISPATCH_INVALID_STATE_ROUTE_CMD:-$scripts_dir_real/dispatch-invalid-state-route}"
+    route_dir_real=$(cd "$(dirname -- "$route")" 2>/dev/null && pwd -P) || route_dir_real=""
+    if [[ -z "$route_dir_real" || "$route_dir_real" != "$scripts_dir_real" ]]; then
+      printf 'lib-frozen-session-park: invalid-state router path %s does not resolve inside %s; falling through to the park path\n' \
+        "$route" "$scripts_dir_real" >&2
+      return 10
+    fi
+    if [[ ! -f "$route" || ! -x "$route" ]]; then
+      # Expected until the lane's router lands; not an error, just a fall-through.
+      return 10
+    fi
+
+    local tbin
+    tbin=$(command -v timeout 2>/dev/null) || tbin=""
+    if [[ -z "$tbin" ]]; then
+      printf 'lib-frozen-session-park: `timeout` not found; refusing an unbounded invalid-state router call; falling through to the park path\n' >&2
+      return 10
+    fi
+    local budget="${DISPATCH_INVALID_STATE_ROUTE_TIMEOUT_S:-60}"
+    [[ "$budget" =~ ^[0-9]+$ ]] || budget=60
+
+    local rc=0
+    "$tbin" "$budget" "$route" --node "$node" --kind "$kind" \
+      --session "$sid" --job-id "$jid" >/dev/null 2>&1 </dev/null || rc=$?
+    return "$rc"
+  }
+
   # _frozen_session_log_decision <node> <session> <idle> <disposition> — append
   # one best-effort JSONL decision record. Mirrors dispatch-select-tick's
   # _dlog_select_emit: build with `jq -c -n`, hand to `decision_log_append`
@@ -274,6 +351,10 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
     fi
 
     local blocked=0 parked_count=0 observing=0 unmeasurable=0 deferred=0
+    # Invalid-state lane pre-tier dispositions (see invalid_state_route_gate).
+    # `routed` candidates are DEFERRED, not resolved: the freeze persists until
+    # the intervention session or a human reaps.
+    local routed_count=0 kept_by_lane_count=0
 
     if [[ -z "$candidates" ]]; then
       printf 'lib-frozen-session-park: sweep complete (blocked=%s parked=%s observing=%s unmeasurable=%s deferred=%s)\n' \
@@ -537,6 +618,25 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
       # holds, so a specific human-facing park that landed in the window is
       # silently overwritten with this sweep's generic boilerplate. Pinning the
       # step-(7b) blob turns that race into an exit-3 refusal instead.
+      # (9b) INVALID-STATE LANE PRE-TIER. Consulted after every gate above and
+      # immediately before the park below. A `handled` verdict means an
+      # intervention session was launched, so this candidate is DEFERRED (not
+      # resolved) and must not be parked this pass; a `keep` verdict is positive
+      # evidence to do nothing. Anything else falls through to the park path
+      # unchanged — fail toward escalate. This sweep still owns escalation.
+      local lane_rc=0
+      invalid_state_route_gate "$repo_root" "$name" "frozen-session" "$sid" "${jid:-}" || lane_rc=$?
+      if (( lane_rc == 0 )); then
+        routed_count=$(( routed_count + 1 ))
+        printf 'lib-frozen-session-park: routed %s to the invalid-state lane (frozen-session; session=%s) — deferred, not parked\n' "$name" "$sid" >&2
+        _frozen_session_log_decision "$name" "$sid" "$idle" "routed-to-lane"
+        continue
+      elif (( lane_rc == 4 )); then
+        kept_by_lane_count=$(( kept_by_lane_count + 1 ))
+        _frozen_session_log_decision "$name" "$sid" "$idle" "kept-by-lane"
+        continue
+      fi
+
       local reason recommendation
       printf -v reason \
         'worker session froze at a permission/classifier denial — claude agents reports state=blocked and the transcript has had no activity for %ss; the session cannot make progress and cannot park itself (a blocked session never reaches the Stop hook), so the dispatch-tick frozen-session sweep parked this node' \
@@ -588,6 +688,12 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
 
     printf 'lib-frozen-session-park: sweep complete (blocked=%s parked=%s observing=%s unmeasurable=%s deferred=%s)\n' \
       "$blocked" "$parked_count" "$observing" "$unmeasurable" "$deferred" >&2
+    # Reported separately, and only when non-empty — see the sibling sweep's
+    # note: the summary line above is matched exactly by existing consumers.
+    if (( routed_count > 0 || kept_by_lane_count > 0 )); then
+      printf 'lib-frozen-session-park: frozen-session lane pre-tier (routed=%s kept-by-lane=%s) — routed candidates are DEFERRED, not resolved\n' \
+        "$routed_count" "$kept_by_lane_count" >&2
+    fi
     return 0
   }
 
@@ -762,6 +868,11 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
     fi
 
     local terminal=0 parked_count=0 observing=0 unmeasurable=0 deferred=0
+    # Invalid-state lane pre-tier dispositions (see invalid_state_route_gate).
+    # `routed` candidates are DEFERRED, not resolved: the freeze persists until
+    # the intervention session or a human reaps, and their job-dir markers are
+    # deliberately left intact.
+    local routed_count=0 kept_by_lane_count=0
 
     if [[ -z "$candidates" ]]; then
       printf 'lib-frozen-session-park: terminal-disposition sweep complete (terminal=%s parked=%s observing=%s unmeasurable=%s deferred=%s)\n' \
@@ -1146,6 +1257,32 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
         recommendation="Read the session's transcript or attach the held job (\`claude agents --all\`, \`claude attach <job-id>\`) to see what it concluded. Decide the judgment item it stopped on, then either answer it here and \`clear-park <node-id>\`, or stop the session (\`claude stop <job-id>\`), let \`dispatch-sweep\` reap the worktree, and \`clear-park <node-id>\` to return the node to the lane. Do NOT simply reap the terminal session and release the node — that is what restarts the churn loop."
       fi
 
+      # (11b) INVALID-STATE LANE PRE-TIER. Consulted after every gate above
+      # (name shape, session-id shape, idle grace, stand-down interlock, the
+      # `phase: done` gate, the park cap and the base-blob pin) and immediately
+      # before the park below. A `handled` verdict means an intervention session
+      # was launched, so this candidate is DEFERRED — do NOT park it, and do NOT
+      # delete the job dir's `office-hours-*` markers, because the intervention
+      # may still need them and this pass has proven nothing. A `keep` verdict is
+      # positive evidence to do nothing. Anything else — escalate, router
+      # failure, usage error, timeout, or a missing/unresolvable router — falls
+      # through to the park path completely unchanged. Fail toward escalate.
+      #
+      # This sweep still owns escalation this round; extracting the
+      # park-with-landing-proof block into the router is a declared residual.
+      local lane_rc=0
+      invalid_state_route_gate "$repo_root" "$name" "terminal-session" "$sid" "${jid:-}" || lane_rc=$?
+      if (( lane_rc == 0 )); then
+        routed_count=$(( routed_count + 1 ))
+        printf 'lib-frozen-session-park: routed %s to the invalid-state lane (terminal-session; session=%s) — deferred, not parked; markers left intact\n' "$name" "$sid" >&2
+        _terminal_disposition_log_decision "$name" "$sid" "$idle" "routed-to-lane"
+        continue
+      elif (( lane_rc == 4 )); then
+        kept_by_lane_count=$(( kept_by_lane_count + 1 ))
+        _terminal_disposition_log_decision "$name" "$sid" "$idle" "kept-by-lane"
+        continue
+      fi
+
       # (12) Park. Invoked BY PATH under $repo_root, exactly as
       # frozen_session_sweep and lib-standdown-recheck.sh:699 do: `park-node`
       # resolves its repo root from its OWN script location, so a park-node path
@@ -1263,6 +1400,15 @@ if [[ -z "${_LIB_FROZEN_SESSION_PARK_LOADED:-}" ]]; then
 
     printf 'lib-frozen-session-park: terminal-disposition sweep complete (terminal=%s parked=%s observing=%s unmeasurable=%s deferred=%s)\n' \
       "$terminal" "$parked_count" "$observing" "$unmeasurable" "$deferred" >&2
+    # The lane pre-tier's dispositions are reported on their own line, and only
+    # when there is something to report. Appending them to the summary above
+    # would change a line other consumers (journald greps, the existing suite's
+    # oracles) match exactly, for no gain on the overwhelmingly common
+    # nothing-routed tick.
+    if (( routed_count > 0 || kept_by_lane_count > 0 )); then
+      printf 'lib-frozen-session-park: terminal-disposition lane pre-tier (routed=%s kept-by-lane=%s) — routed candidates are DEFERRED, not resolved\n' \
+        "$routed_count" "$kept_by_lane_count" >&2
+    fi
     return 0
   }
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-invalid-state-route.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-invalid-state-route.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+# test-dispatch-invalid-state-route.sh — the lane router's ladder.
+#
+# The failure modes under test are exactly the ones the ratified doctrine
+# forbids: spawning into a live claim, unbounded respawn, treating an UNKNOWN
+# daemon read as positive evidence, and writing office_hours for a retry-shaped
+# state. Every case asserts the EXIT CODE (the detector contract) and, where it
+# matters, whether a spawn actually happened.
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=dispatch-test-fixture.sh
+source "$SCRIPT_DIR/dispatch-test-fixture.sh"
+
+# The fixture sets `set -e` for its own body. This suite's whole subject is the
+# router's EXIT CODES (0 handled / 4 keep / 10 escalate / 2 usage), so nearly
+# every call under test exits non-zero on purpose — under `set -e` the first one
+# would abort the run and the remaining cases would silently never execute.
+# Error handling here is explicit: every outcome is captured into `rc` and
+# asserted.
+set +e
+
+ROUTE="$SCRIPT_DIR/dispatch-invalid-state-route"
+
+# --- fixture ---------------------------------------------------------------
+# A real git repo on `main` with an origin whose main carries intentions/, so
+# the router's preconditions (primary-checkout-on-main, node present on
+# origin/main) pass for real rather than being stubbed out.
+isr_setup() {
+  ISR_ROOT=$(mktemp -d)
+  ISR_BARE=$(mktemp -d)
+  ISR_SCRIPTS="$ISR_ROOT/.claude/skills/dispatch-propagate/scripts"
+  mkdir -p "$ISR_SCRIPTS" "$ISR_ROOT/bin" "$ISR_ROOT/.claude/worktrees"
+  # REPO_ROOT/SCRIPT_DIR are derived from the script's real location, so the
+  # copy must be physical — same reason test-graph-select-target.sh copies.
+  cp "$SCRIPT_DIR"/dispatch-invalid-state-route "$SCRIPT_DIR"/lib.sh "$SCRIPT_DIR"/lib-*.sh "$ISR_SCRIPTS/"
+
+  git init -q -b main "$ISR_ROOT"
+  git -C "$ISR_ROOT" config user.email t@t
+  git -C "$ISR_ROOT" config user.name t
+  mkdir -p "$ISR_ROOT/intentions"
+  cat > "$ISR_ROOT/intentions/tactic-fixture.md" <<'NODE'
+---
+id: tactic-fixture
+kind: tactic
+phase: implement
+office_hours: null
+---
+# fixture
+NODE
+  git -C "$ISR_ROOT" add -A
+  git -C "$ISR_ROOT" commit -q -m seed
+  git init -q --bare -b main "$ISR_BARE"
+  git -C "$ISR_ROOT" remote add origin "$ISR_BARE"
+  git -C "$ISR_ROOT" push -q origin main
+  git -C "$ISR_ROOT" fetch -q origin
+
+  # Fake `claude agents --json`, payload driven by a file each case rewrites.
+  cat > "$ISR_ROOT/bin/claude" <<'ISRCLAUDE'
+#!/usr/bin/env bash
+_root="$(cd "$(dirname "$0")/.." && pwd)"
+cat "$_root/claude-payload.json"
+exit 0
+ISRCLAUDE
+  chmod +x "$ISR_ROOT/bin/claude"
+  # Empty-read corroboration stub: lib-claude-agents.sh only trusts an
+  # exactly-`[]` payload when a daemon process is visible.
+  cat > "$ISR_ROOT/bin/pgrep-visible" <<'ISRPGREP'
+#!/usr/bin/env bash
+exit 0
+ISRPGREP
+  chmod +x "$ISR_ROOT/bin/pgrep-visible"
+
+  # Spawner stub that LOGS its argv, so "did we spawn, and with what" is an
+  # assertion rather than an inference. It lives in the scripts dir so the
+  # router's provenance check (real dir == scripts dir) passes.
+  cat > "$ISR_SCRIPTS/spawn-stub" <<'ISRSPAWN'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${ISR_SPAWN_LOG:?}"
+exit "${ISR_SPAWN_RC:-0}"
+ISRSPAWN
+  chmod +x "$ISR_SCRIPTS/spawn-stub"
+  ISR_SPAWN_LOG="$ISR_ROOT/spawn.log"
+  : > "$ISR_SPAWN_LOG"
+
+  # The intervention skill, present by default so the tier is armed. Cases that
+  # test the inert path remove it.
+  mkdir -p "$ISR_ROOT/.claude/skills/dispatch-invalid-state"
+  echo "# skill" > "$ISR_ROOT/.claude/skills/dispatch-invalid-state/SKILL.md"
+
+  ISR_ROUTE="$ISR_SCRIPTS/dispatch-invalid-state-route"
+  printf '%s' '[]' > "$ISR_ROOT/claude-payload.json"
+}
+
+isr_teardown() { rm -rf "$ISR_ROOT" "$ISR_BARE"; }
+
+# Run the router against the fixture. Echoes nothing; returns its exit code.
+isr_run() {
+  PATH="$ISR_ROOT/bin:$SAVED_PATH" \
+  CLAUDE_AGENTS_CMD="$ISR_ROOT/bin/claude" \
+  CLAUDE_AGENTS_PGREP_CMD="$ISR_ROOT/bin/pgrep-visible" \
+  DISPATCH_INVALID_STATE_REPO_ROOT="$ISR_ROOT" \
+  DISPATCH_INVALID_STATE_SPAWN_JOB="$ISR_SCRIPTS/spawn-stub" \
+  DISPATCH_INVALID_STATE_FLEET_LATCH=0 \
+  DISPATCH_STANDDOWN_DIR="$ISR_ROOT/standdown" \
+  ISR_SPAWN_LOG="$ISR_SPAWN_LOG" ISR_SPAWN_RC="${ISR_SPAWN_RC:-0}" \
+  "$ISR_ROUTE" "$@" >/dev/null 2>&1
+}
+
+payload() { printf '%s' "$1" > "$ISR_ROOT/claude-payload.json"; }
+spawn_count() { wc -l < "$ISR_SPAWN_LOG" | tr -d ' '; }
+
+# --- Case: usage errors ----------------------------------------------------
+echo "Test: dispatch-invalid-state-route — argv validation"
+isr_setup
+isr_run --node "Bad Id" --kind terminal-session; rc=$?
+assert_eq "route: an invalid node id is a usage error" "2" "$rc"
+isr_run --node tactic-fixture --kind not-a-kind; rc=$?
+assert_eq "route: an unknown kind is a usage error" "2" "$rc"
+isr_run --kind terminal-session; rc=$?
+assert_eq "route: a missing --node is a usage error" "2" "$rc"
+assert_eq "route: no spawn happened on any usage error" "0" "$(spawn_count)"
+isr_teardown
+
+# --- Case: the mechanical tier's keep verdicts ------------------------------
+# Every one of these is POSITIVE evidence to do nothing. None may spawn.
+echo "Test: dispatch-invalid-state-route — the mechanical tier keeps on free / live / unknown"
+isr_setup
+
+payload '[]'
+isr_run --node tactic-fixture --kind terminal-session; rc=$?
+assert_eq "route: a free worktree keeps (the state resolved itself)" "4" "$rc"
+
+payload '[{"sessionId":"s1","status":"busy","name":"tactic-fixture","state":"working"}]'
+isr_run --node tactic-fixture --kind terminal-session; rc=$?
+assert_eq "route: a LIVE claim keeps — never spawn into one" "4" "$rc"
+
+# UNKNOWN: the daemon read fails outright.
+cat > "$ISR_ROOT/bin/claude" <<'ISRFAIL'
+#!/usr/bin/env bash
+exit 1
+ISRFAIL
+chmod +x "$ISR_ROOT/bin/claude"
+isr_run --node tactic-fixture --kind terminal-session; rc=$?
+assert_eq "route: an UNKNOWN daemon read keeps — no positive evidence" "4" "$rc"
+
+assert_eq "route: none of the keep verdicts spawned an intervention" "0" "$(spawn_count)"
+isr_teardown
+
+# --- Case: a free observation resets the attempt sidecar --------------------
+echo "Test: dispatch-invalid-state-route — a free observation clears the attempt sidecar"
+isr_setup
+printf '2\n' > "$ISR_ROOT/.claude/worktrees/tactic-fixture.invalid-state-attempts"
+payload '[]'
+isr_run --node tactic-fixture --kind terminal-session
+assert_eq "route: the sidecar is cleared when the state resolves itself" \
+  "absent" "$([[ -f "$ISR_ROOT/.claude/worktrees/tactic-fixture.invalid-state-attempts" ]] && echo present || echo absent)"
+isr_teardown
+
+# --- Case: stand-down interlock and done-but-parked --------------------------
+echo "Test: dispatch-invalid-state-route — stand-down and done-but-parked are valid states"
+isr_setup
+payload '[{"sessionId":"s-dead","name":"tactic-fixture","state":"done"}]'
+
+mkdir -p "$ISR_ROOT/standdown"
+touch "$ISR_ROOT/standdown/tactic-fixture"
+isr_run --node tactic-fixture --kind terminal-session; rc=$?
+assert_eq "route: a stood-down node keeps (the interlock owns it)" "4" "$rc"
+rm -f "$ISR_ROOT/standdown/tactic-fixture"
+
+# done-but-parked: phase and office_hours are ORTHOGONAL (2026-08-04 ruling).
+cat > "$ISR_ROOT/intentions/tactic-fixture.md" <<'DONEPARKED'
+---
+id: tactic-fixture
+kind: tactic
+phase: done
+office_hours: {reason: waiting, since: 2026-08-01T00:00:00Z}
+---
+# fixture
+DONEPARKED
+git -C "$ISR_ROOT" add -A >/dev/null 2>&1
+git -C "$ISR_ROOT" commit -q -m parked
+git -C "$ISR_ROOT" push -q origin main
+git -C "$ISR_ROOT" fetch -q origin
+isr_run --node tactic-fixture --kind terminal-session; rc=$?
+assert_eq "route: done-but-parked keeps — a VALID state, never invalid" "4" "$rc"
+assert_eq "route: neither valid state spawned an intervention" "0" "$(spawn_count)"
+isr_teardown
+
+# --- Case: the intervention tier, its cap, and the inert path ----------------
+echo "Test: dispatch-invalid-state-route — the intervention tier and its attempt cap"
+isr_setup
+payload '[{"sessionId":"s-dead","name":"tactic-fixture","state":"done"}]'
+
+# Skill absent -> the tier is INERT and today's behavior is preserved exactly.
+rm -rf "$ISR_ROOT/.claude/skills/dispatch-invalid-state"
+isr_run --node tactic-fixture --kind terminal-session; rc=$?
+assert_eq "route: terminal with the skill absent escalates (tier inert)" "10" "$rc"
+assert_eq "route: the inert tier spawned nothing" "0" "$(spawn_count)"
+
+# Skill present -> intervene, and record the attempt.
+mkdir -p "$ISR_ROOT/.claude/skills/dispatch-invalid-state"
+echo "# skill" > "$ISR_ROOT/.claude/skills/dispatch-invalid-state/SKILL.md"
+isr_run --node tactic-fixture --kind terminal-session; rc=$?
+assert_eq "route: terminal with the skill present intervenes" "0" "$rc"
+assert_eq "route: exactly one intervention was spawned" "1" "$(spawn_count)"
+assert_eq "route: the attempt sidecar records the first attempt" \
+  "1" "$(cat "$ISR_ROOT/.claude/worktrees/tactic-fixture.invalid-state-attempts")"
+
+# The spawn's argv is load-bearing: --cwd must be the PROJECT ROOT (never the
+# node worktree — two recorded stale-skill-body deadlocks), and --name must be
+# the node id (it is what obliges the session to declare a disposition).
+spawn_argv=$(head -1 "$ISR_SPAWN_LOG")
+case "$spawn_argv" in
+  *"--name tactic-fixture"*) name_ok=yes ;; *) name_ok="no: $spawn_argv" ;;
+esac
+assert_eq "route: the spawn passes --name <node-id>" "yes" "$name_ok"
+case "$spawn_argv" in
+  *"--cwd $ISR_ROOT "*) cwd_ok=yes ;; *) cwd_ok="no: $spawn_argv" ;;
+esac
+assert_eq "route: the spawn's --cwd is the project root, not the node worktree" "yes" "$cwd_ok"
+case "$spawn_argv" in
+  *"/dispatch-invalid-state tactic-fixture"*) prompt_ok=yes ;; *) prompt_ok="no: $spawn_argv" ;;
+esac
+assert_eq "route: the spawn invokes /dispatch-invalid-state <node-id>" "yes" "$prompt_ok"
+
+# Attempts 2 and 3 still intervene; the 4th is over the cap.
+isr_run --node tactic-fixture --kind terminal-session; rc=$?
+assert_eq "route: the second attempt still intervenes" "0" "$rc"
+isr_run --node tactic-fixture --kind terminal-session; rc=$?
+assert_eq "route: the third attempt still intervenes" "0" "$rc"
+assert_eq "route: three interventions were spawned in total" "3" "$(spawn_count)"
+isr_run --node tactic-fixture --kind terminal-session; rc=$?
+assert_eq "route: the fourth attempt is over the cap and escalates" "10" "$rc"
+assert_eq "route: the over-cap attempt spawned nothing further" "3" "$(spawn_count)"
+isr_teardown
+
+# --- Case: --no-intervene skips the tier entirely ---------------------------
+echo "Test: dispatch-invalid-state-route — --no-intervene goes straight to escalate"
+isr_setup
+payload '[{"sessionId":"s-dead","name":"tactic-fixture","state":"done"}]'
+isr_run --node tactic-fixture --kind terminal-session --no-intervene; rc=$?
+assert_eq "route: --no-intervene escalates" "10" "$rc"
+assert_eq "route: --no-intervene spawned nothing" "0" "$(spawn_count)"
+isr_teardown
+
+# --- Case: a failed spawn escalates without burning the budget ---------------
+echo "Test: dispatch-invalid-state-route — a failed kick escalates and does not consume an attempt"
+isr_setup
+payload '[{"sessionId":"s-dead","name":"tactic-fixture","state":"done"}]'
+ISR_SPAWN_RC=1
+isr_run --node tactic-fixture --kind terminal-session; rc=$?
+assert_eq "route: a failed spawn escalates" "10" "$rc"
+# The cap counts interventions actually LAUNCHED. Counting failures would let a
+# broken spawner silently burn a node's whole intervention budget.
+assert_eq "route: a failed spawn does not increment the attempt sidecar" \
+  "absent" "$([[ -f "$ISR_ROOT/.claude/worktrees/tactic-fixture.invalid-state-attempts" ]] && echo present || echo absent)"
+ISR_SPAWN_RC=0
+isr_teardown
+
+# --- Case: the retry/human class discrimination -----------------------------
+# The standing rule from the 2026-07-25 clarification: a retry-shaped state
+# routes to hold-node/blocked_by, NEVER office_hours on the source.
+echo "Test: dispatch-invalid-state-route — a retry-class kind can never reach an office_hours write"
+isr_setup
+payload '[{"sessionId":"s-dead","name":"tactic-fixture","state":"done"}]'
+for k in provision-conflict worktree-residue fix-attempt-cap; do
+  PATH="$ISR_ROOT/bin:$SAVED_PATH" \
+  CLAUDE_AGENTS_CMD="$ISR_ROOT/bin/claude" \
+  CLAUDE_AGENTS_PGREP_CMD="$ISR_ROOT/bin/pgrep-visible" \
+  DISPATCH_INVALID_STATE_REPO_ROOT="$ISR_ROOT" \
+  DISPATCH_INVALID_STATE_SPAWN_JOB="$ISR_SCRIPTS/spawn-stub" \
+  DISPATCH_INVALID_STATE_FLEET_LATCH=0 \
+  DISPATCH_INVALID_STATE_WRITE_OFFICE_HOURS=1 \
+  ISR_SPAWN_LOG="$ISR_SPAWN_LOG" \
+  "$ISR_ROUTE" --node tactic-fixture --kind "$k" >/dev/null 2>&1; rc=$?
+  assert_eq "route: retry-class kind $k refuses an office_hours write" "2" "$rc"
+done
+assert_eq "route: no retry-class call spawned anything" "0" "$(spawn_count)"
+
+# The router makes NO escalation write of any kind: no park-node, no hold-node,
+# no claude rm, no graph-commit outside the fleet-latch block. This is a
+# structural assertion, not a behavioural one — it is the doctrine grep.
+invocations=$(grep -nE '^[^#]*(park-node|hold-node|claude rm)' "$ROUTE" | grep -v 'printf' | wc -l | tr -d ' ')
+assert_eq "route: no park-node/hold-node/claude-rm invocation anywhere in the script" "0" "$invocations"
+gc=$(grep -cE '^[^#]*graph-commit' "$ROUTE" | tr -d ' ')
+assert_eq "route: graph-commit appears exactly once (the Unit 6 fleet latch)" "1" "$gc"
+isr_teardown
+
+# --- Case: preconditions ----------------------------------------------------
+echo "Test: dispatch-invalid-state-route — preconditions escalate rather than acting"
+isr_setup
+payload '[{"sessionId":"s-dead","name":"tactic-fixture","state":"done"}]'
+git -C "$ISR_ROOT" checkout -q -b not-main
+isr_run --node tactic-fixture --kind terminal-session; rc=$?
+assert_eq "route: a primary checkout off main escalates" "10" "$rc"
+git -C "$ISR_ROOT" checkout -q main
+
+isr_run --node tactic-absent-from-main --kind terminal-session; rc=$?
+assert_eq "route: a node absent from origin/main escalates" "10" "$rc"
+assert_eq "route: no precondition failure spawned anything" "0" "$(spawn_count)"
+isr_teardown
+
+# --- Case: the fleet latch's anchored id keyspace ---------------------------
+# The bug class this guards against deadlocked auto-merge for WEEKS: an
+# unanchored prefix test caught an unrelated hand-authored tactic id.
+echo "Test: dispatch-invalid-state-route — the fleet-latch id reader is anchored"
+LATCH_RE='^tactic-invalid-state-[0-9a-f]{8}$'
+for bad in tactic-invalid-state-lane tactic-invalid-state-transcript-intervention \
+           tactic-invalid-state-rc-deadbeef tactic-invalid-state-deadbee \
+           tactic-invalid-state-deadbeef9; do
+  if [[ "$bad" =~ $LATCH_RE ]]; then m=matched; else m=rejected; fi
+  assert_eq "latch-id: the anchored reader rejects $bad" "rejected" "$m"
+done
+if [[ "tactic-invalid-state-deadbeef" =~ $LATCH_RE ]]; then m=matched; else m=rejected; fi
+assert_eq "latch-id: the anchored reader accepts a genuine 8-hex latch id" "matched" "$m"
+# The id the script actually computes must satisfy its own reader, and must be
+# stable for the same (kind, slug) and different for a different one.
+isr_setup
+mk_id() { printf '%s' "$1" | sha256sum | cut -c1-8; }
+id_a="tactic-invalid-state-$(mk_id 'terminal-session:primary-checkout-not-on-main')"
+id_b="tactic-invalid-state-$(mk_id 'terminal-session:node-absent-on-origin-main')"
+if [[ "$id_a" =~ $LATCH_RE ]]; then m=matched; else m=rejected; fi
+assert_eq "latch-id: a computed id satisfies the anchored reader" "matched" "$m"
+assert_eq "latch-id: different preconditions yield different ids" \
+  "differ" "$([[ "$id_a" != "$id_b" ]] && echo differ || echo same)"
+assert_eq "latch-id: the same precondition is stable across calls" \
+  "$id_a" "tactic-invalid-state-$(mk_id 'terminal-session:primary-checkout-not-on-main')"
+isr_teardown
+
+# --- Case: the fleet latch mints only on CONSECUTIVE observations -----------
+echo "Test: dispatch-invalid-state-route — the fleet latch needs two consecutive observations"
+isr_setup
+payload '[{"sessionId":"s-dead","name":"tactic-fixture","state":"done"}]'
+git -C "$ISR_ROOT" checkout -q -b not-main
+# Latch enabled, but the mint itself is stubbed out by pointing the store
+# elsewhere: this case asserts the OBSERVATION COUNTER, which is what decides
+# whether a mint is attempted at all.
+run_latched() {
+  PATH="$ISR_ROOT/bin:$SAVED_PATH" \
+  CLAUDE_AGENTS_CMD="$ISR_ROOT/bin/claude" \
+  CLAUDE_AGENTS_PGREP_CMD="$ISR_ROOT/bin/pgrep-visible" \
+  DISPATCH_INVALID_STATE_REPO_ROOT="$ISR_ROOT" \
+  DISPATCH_INVALID_STATE_SPAWN_JOB="$ISR_SCRIPTS/spawn-stub" \
+  DISPATCH_INVALID_STATE_FLEET_LATCH=0 \
+  "$ISR_ROUTE" --node tactic-fixture --kind terminal-session 2>&1 >/dev/null
+}
+out1=$(run_latched)
+case "$out1" in *"1/2 observations"*) o1=counted ;; *) o1="no: $out1" ;; esac
+assert_eq "fleet-latch: the first failure counts but does not mint" "counted" "$o1"
+out2=$(run_latched)
+case "$out2" in *"would have minted tactic-invalid-state-"*) o2=threshold ;; *) o2="no: $out2" ;; esac
+assert_eq "fleet-latch: the second consecutive failure reaches the mint threshold" "threshold" "$o2"
+
+# A successful precondition pass resets the counter, so only CONSECUTIVE
+# failures accumulate toward a mint.
+git -C "$ISR_ROOT" checkout -q main
+isr_run --node tactic-fixture --kind terminal-session --no-intervene
+assert_eq "fleet-latch: a healthy pass clears the observation sidecar" \
+  "absent" "$([[ -f "$ISR_ROOT/.claude/worktrees/.invalid-state-fleet-primary-checkout-not-on-main" ]] && echo present || echo absent)"
+git -C "$ISR_ROOT" checkout -q not-main
+out3=$(run_latched)
+case "$out3" in *"1/2 observations"*) o3=restarted ;; *) o3="no: $out3" ;; esac
+assert_eq "fleet-latch: the counter restarts from 1 after a healthy pass" "restarted" "$o3"
+isr_teardown
+
+report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-invalid-state-route.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-invalid-state-route.sh
@@ -184,7 +184,54 @@ git -C "$ISR_ROOT" push -q origin main
 git -C "$ISR_ROOT" fetch -q origin
 isr_run --node tactic-fixture --kind terminal-session; rc=$?
 assert_eq "route: done-but-parked keeps — a VALID state, never invalid" "4" "$rc"
-assert_eq "route: neither valid state spawned an intervention" "0" "$(spawn_count)"
+
+# The BLOCK-MAPPING serialization is what park-node actually writes: the key
+# alone on its line, `reason:`/`since:`/`recommendation:` indented beneath. A
+# guard that reads the VALUE off the `office_hours:` line sees the empty string
+# for every node in this shape and the literal `null` for every unparked one, so
+# it is dead in both branches. The gate has to be a frontmatter-scoped PRESENCE
+# test — and the trailing body line proves the frontmatter scoping is real.
+cat > "$ISR_ROOT/intentions/tactic-fixture.md" <<'BLOCKPARKED'
+---
+id: tactic-fixture
+kind: tactic
+phase: done
+office_hours:
+  reason: waiting on the author
+  since: 2026-08-01T00:00:00Z
+  recommendation: review and unpark
+---
+# fixture
+
+office_hours: this column-0 line is BODY prose and must never read as park state
+BLOCKPARKED
+git -C "$ISR_ROOT" add -A >/dev/null 2>&1
+git -C "$ISR_ROOT" commit -q -m block-parked
+git -C "$ISR_ROOT" push -q origin main
+git -C "$ISR_ROOT" fetch -q origin
+isr_run --node tactic-fixture --kind terminal-session; rc=$?
+assert_eq "route: done + a BLOCK-MAPPING office_hours keeps (the real parked shape)" "4" "$rc"
+
+# Control: the same node UNPARKED is not a keep. Without this the gate could be
+# keeping vacuously and the assertion above would still pass. `--no-intervene`
+# so the discrimination is visible (10, not 4) without spawning anything.
+cat > "$ISR_ROOT/intentions/tactic-fixture.md" <<'DONEUNPARKED'
+---
+id: tactic-fixture
+kind: tactic
+phase: done
+office_hours: null
+---
+# fixture
+DONEUNPARKED
+git -C "$ISR_ROOT" add -A >/dev/null 2>&1
+git -C "$ISR_ROOT" commit -q -m done-unparked
+git -C "$ISR_ROOT" push -q origin main
+git -C "$ISR_ROOT" fetch -q origin
+isr_run --node tactic-fixture --kind terminal-session --no-intervene; rc=$?
+assert_eq "route: done with office_hours: null is NOT a keep — the gate discriminates" "10" "$rc"
+
+assert_eq "route: no valid-state case spawned an intervention" "0" "$(spawn_count)"
 isr_teardown
 
 # --- Case: the intervention tier, its cap, and the inert path ----------------
@@ -329,13 +376,16 @@ assert_eq "latch-id: the same precondition is stable across calls" \
 isr_teardown
 
 # --- Case: the fleet latch mints only on CONSECUTIVE observations -----------
+# Exercised through `node-absent-on-origin-main`, the latch-ELIGIBLE
+# precondition: it runs only after the primary-checkout-on-main assert has
+# vouched for the checkout, which is what makes minting out of that checkout
+# safe. (`primary-checkout-not-on-main` has no counter at all by design — see the
+# next case.)
 echo "Test: dispatch-invalid-state-route — the fleet latch needs two consecutive observations"
 isr_setup
 payload '[{"sessionId":"s-dead","name":"tactic-fixture","state":"done"}]'
-git -C "$ISR_ROOT" checkout -q -b not-main
-# Latch enabled, but the mint itself is stubbed out by pointing the store
-# elsewhere: this case asserts the OBSERVATION COUNTER, which is what decides
-# whether a mint is attempted at all.
+# The latch is disabled so the mint itself never runs: this case asserts the
+# OBSERVATION COUNTER, which is what decides whether a mint is attempted at all.
 run_latched() {
   PATH="$ISR_ROOT/bin:$SAVED_PATH" \
   CLAUDE_AGENTS_CMD="$ISR_ROOT/bin/claude" \
@@ -343,7 +393,7 @@ run_latched() {
   DISPATCH_INVALID_STATE_REPO_ROOT="$ISR_ROOT" \
   DISPATCH_INVALID_STATE_SPAWN_JOB="$ISR_SCRIPTS/spawn-stub" \
   DISPATCH_INVALID_STATE_FLEET_LATCH=0 \
-  "$ISR_ROUTE" --node tactic-fixture --kind terminal-session 2>&1 >/dev/null
+  "$ISR_ROUTE" --node tactic-absent-from-main --kind terminal-session 2>&1 >/dev/null
 }
 out1=$(run_latched)
 case "$out1" in *"1/2 observations"*) o1=counted ;; *) o1="no: $out1" ;; esac
@@ -354,14 +404,64 @@ assert_eq "fleet-latch: the second consecutive failure reaches the mint threshol
 
 # A successful precondition pass resets the counter, so only CONSECUTIVE
 # failures accumulate toward a mint.
-git -C "$ISR_ROOT" checkout -q main
 isr_run --node tactic-fixture --kind terminal-session --no-intervene
 assert_eq "fleet-latch: a healthy pass clears the observation sidecar" \
-  "absent" "$([[ -f "$ISR_ROOT/.claude/worktrees/.invalid-state-fleet-primary-checkout-not-on-main" ]] && echo present || echo absent)"
-git -C "$ISR_ROOT" checkout -q not-main
+  "absent" "$([[ -f "$ISR_ROOT/.claude/worktrees/.invalid-state-fleet-node-absent-on-origin-main" ]] && echo present || echo absent)"
 out3=$(run_latched)
 case "$out3" in *"1/2 observations"*) o3=restarted ;; *) o3="no: $out3" ;; esac
 assert_eq "fleet-latch: the counter restarts from 1 after a healthy pass" "restarted" "$o3"
 isr_teardown
+
+# --- Case: an off-main checkout never reaches the fleet-latch mint -----------
+# `fleet_latch_mint` runs write-node.ts and graph-commit OUT OF $PROJECT_ROOT,
+# and graph-commit force-pushes refs/graph/** and pushes main — unattended, from
+# the headless tick, sandbox off. Minting out of the very checkout the on-main
+# assert just REJECTED would execute an unreviewed branch's copy of exactly those
+# scripts, which is the hazard the assert exists to prevent. So this precondition
+# must neither observe nor mint, no matter how many times it fires.
+echo "Test: dispatch-invalid-state-route — an off-main checkout never observes or mints"
+isr_setup
+payload '[{"sessionId":"s-dead","name":"tactic-fixture","state":"done"}]'
+git -C "$ISR_ROOT" checkout -q -b not-main
+# The latch is ARMED here, deliberately: the refusal must come from the ordering,
+# not from the latch being switched off.
+run_offmain() {
+  PATH="$ISR_ROOT/bin:$SAVED_PATH" \
+  CLAUDE_AGENTS_CMD="$ISR_ROOT/bin/claude" \
+  CLAUDE_AGENTS_PGREP_CMD="$ISR_ROOT/bin/pgrep-visible" \
+  DISPATCH_INVALID_STATE_REPO_ROOT="$ISR_ROOT" \
+  DISPATCH_INVALID_STATE_SPAWN_JOB="$ISR_SCRIPTS/spawn-stub" \
+  DISPATCH_INVALID_STATE_FLEET_LATCH=1 \
+  ISR_SPAWN_LOG="$ISR_SPAWN_LOG" \
+  "$ISR_ROUTE" --node tactic-fixture --kind terminal-session 2>&1 >/dev/null
+}
+off1=$(run_offmain); rc1=$?
+off2=$(run_offmain); rc2=$?
+off3=$(run_offmain); rc3=$?
+assert_eq "off-main: every call escalates" "10 10 10" "$rc1 $rc2 $rc3"
+case "$off1$off2$off3" in *observations*) m="no: $off3" ;; *) m=never-counted ;; esac
+assert_eq "off-main: the failure is never counted toward a mint" "never-counted" "$m"
+case "$off1$off2$off3" in *minted*) m="no: $off3" ;; *) m=never-minted ;; esac
+assert_eq "off-main: nothing is minted even past the observation threshold" "never-minted" "$m"
+assert_eq "off-main: no observation sidecar is written for the checkout precondition" \
+  "absent" "$([[ -f "$ISR_ROOT/.claude/worktrees/.invalid-state-fleet-primary-checkout-not-on-main" ]] && echo present || echo absent)"
+assert_eq "off-main: no node file was written out of the rejected checkout" \
+  "1" "$(ls "$ISR_ROOT/intentions" | wc -l | tr -d ' ')"
+assert_eq "off-main: nothing was spawned either" "0" "$(spawn_count)"
+git -C "$ISR_ROOT" checkout -q main
+isr_teardown
+
+# --- Case: the mint's own provenance check ----------------------------------
+# Structural: the two privileged executables the mint runs must be resolved
+# through the same `pwd -P` canonicalization the spawner gets, so `..` segments
+# and symlinked roots cannot slip an arbitrary executable past a prefix test.
+echo "Test: dispatch-invalid-state-route — the fleet-latch mint provenance-checks what it runs"
+pv=$(grep -cE 'pwd -P' "$ROUTE" | tr -d ' ')
+if (( pv >= 3 )); then m=canonicalized; else m="no: only $pv pwd -P sites"; fi
+assert_eq "mint: the mint's executables are canonicalized like the spawner is" "canonicalized" "$m"
+# The mint must invoke through the checked variables, never a freshly-composed
+# path: a literal `$store/scripts/graph-commit` invocation would bypass the check.
+bad=$(grep -cE '^[^#]*\$store/scripts/(graph-commit|write-node)' "$ROUTE" | tr -d ' ')
+assert_eq "mint: no invocation composes its own path under \$store/scripts" "0" "$bad"
 
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-invalid-state-sweep.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-invalid-state-sweep.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# test-dispatch-invalid-state-sweep.sh — the lane's selection-time detection arm.
+#
+# The properties under test are the ones that go wrong QUIETLY: the claimed-set
+# invariant against graph-select-target, the UNKNOWN posture (an unreadable
+# registry must not read as an empty set), the keyspace filter, and the
+# per-invocation cap. The router is a stub that LOGS its argv, so "did we route,
+# and with what" is an assertion rather than an inference.
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=dispatch-test-fixture.sh
+source "$SCRIPT_DIR/dispatch-test-fixture.sh"
+# This suite asserts sweep behaviour, not exit codes (the sweep always exits 0),
+# but the router stub returns non-zero on purpose in the deferral case.
+set +e
+
+iss_setup() {
+  ISS_ROOT=$(mktemp -d)
+  ISS_SCRIPTS="$ISS_ROOT/.claude/skills/dispatch-propagate/scripts"
+  mkdir -p "$ISS_SCRIPTS" "$ISS_ROOT/bin" "$ISS_ROOT/intentions" \
+           "$ISS_ROOT/.claude/worktrees" "$ISS_ROOT/reservations"
+  cp "$SCRIPT_DIR"/dispatch-invalid-state-sweep "$SCRIPT_DIR"/lib.sh "$SCRIPT_DIR"/lib-*.sh "$ISS_SCRIPTS/"
+
+  cat > "$ISS_ROOT/bin/claude" <<'ISSCLAUDE'
+#!/usr/bin/env bash
+_root="$(cd "$(dirname "$0")/.." && pwd)"
+[[ -f "$_root/claude-rc" ]] && exit "$(cat "$_root/claude-rc")"
+cat "$_root/claude-payload.json"
+exit 0
+ISSCLAUDE
+  chmod +x "$ISS_ROOT/bin/claude"
+  cat > "$ISS_ROOT/bin/pgrep-visible" <<'ISSPGREP'
+#!/usr/bin/env bash
+exit 0
+ISSPGREP
+  chmod +x "$ISS_ROOT/bin/pgrep-visible"
+
+  # Router stub: logs argv, returns a controllable code.
+  cat > "$ISS_SCRIPTS/route-stub" <<'ISSROUTE'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${ISS_ROUTE_LOG:?}"
+exit "${ISS_ROUTE_RC:-0}"
+ISSROUTE
+  chmod +x "$ISS_SCRIPTS/route-stub"
+  ISS_ROUTE_LOG="$ISS_ROOT/route.log"
+  : > "$ISS_ROUTE_LOG"
+  rm -f "$ISS_ROOT/claude-rc"
+  printf '%s' '[]' > "$ISS_ROOT/claude-payload.json"
+  ISS_SWEEP="$ISS_SCRIPTS/dispatch-invalid-state-sweep"
+}
+
+iss_teardown() { rm -rf "$ISS_ROOT"; }
+
+# Register a node: its intentions file and (optionally) its worktree dir.
+iss_node() { touch "$ISS_ROOT/intentions/$1.md"; mkdir -p "$ISS_ROOT/.claude/worktrees/$1"; }
+
+iss_run() {
+  PATH="$ISS_ROOT/bin:$SAVED_PATH" \
+  CLAUDE_AGENTS_CMD="$ISS_ROOT/bin/claude" \
+  CLAUDE_AGENTS_PGREP_CMD="$ISS_ROOT/bin/pgrep-visible" \
+  DISPATCH_INVALID_STATE_SWEEP_ROOT="$ISS_ROOT" \
+  DISPATCH_INVALID_STATE_ROUTE_CMD="$ISS_SCRIPTS/route-stub" \
+  DISPATCH_RESERVATION_DIR="$ISS_ROOT/reservations" \
+  ISS_ROUTE_LOG="$ISS_ROUTE_LOG" ISS_ROUTE_RC="${ISS_ROUTE_RC:-0}" \
+  "$ISS_SWEEP" "$@" 2>/dev/null
+}
+
+route_calls() { wc -l < "$ISS_ROUTE_LOG" | tr -d ' '; }
+
+# --- Case: a terminal worker with a node file is routed ---------------------
+echo "Test: dispatch-invalid-state-sweep — a terminal worker holding a node is routed"
+iss_setup
+iss_node tactic-fixture
+printf '%s' '[{"sessionId":"s-dead","id":"job-1","name":"tactic-fixture","cwd":"/w","state":"done"}]' \
+  > "$ISS_ROOT/claude-payload.json"
+out=$(iss_run)
+assert_eq "sweep: exactly one router call" "1" "$(route_calls)"
+argv=$(head -1 "$ISS_ROUTE_LOG")
+case "$argv" in *"--node tactic-fixture"*) a=yes ;; *) a="no: $argv" ;; esac
+assert_eq "sweep: the router is called with --node <id>" "yes" "$a"
+case "$argv" in *"--kind terminal-session"*) a=yes ;; *) a="no: $argv" ;; esac
+assert_eq "sweep: the router is called with --kind terminal-session" "yes" "$a"
+# `.id` is the JOB id and is NOT a prefix of the sessionId — any job-dir lookup
+# must key on that column, so it has to be passed through.
+case "$argv" in *"--job-id job-1"*) a=yes ;; *) a="no: $argv" ;; esac
+assert_eq "sweep: the JOB id column is passed through, not the sessionId" "yes" "$a"
+case "$argv" in *"--session s-dead"*) a=yes ;; *) a="no: $argv" ;; esac
+assert_eq "sweep: the dead session id is passed through" "yes" "$a"
+case "$out" in *"intervened=1"*) a=yes ;; *) a="no: $out" ;; esac
+assert_eq "sweep: the summary counts the intervention" "yes" "$a"
+iss_teardown
+
+# --- Case: the claimed-set invariant ----------------------------------------
+# A reserved node is one graph-select-target will not touch either. Acting on it
+# would race the selector by mutating a node selection considers claimed.
+echo "Test: dispatch-invalid-state-sweep — a reserved node is never routed"
+iss_setup
+iss_node tactic-fixture
+touch "$ISS_ROOT/reservations/tactic-fixture"
+printf '%s' '[{"sessionId":"s-dead","id":"job-1","name":"tactic-fixture","cwd":"/w","state":"done"}]' \
+  > "$ISS_ROOT/claude-payload.json"
+out=$(iss_run)
+assert_eq "sweep: a reserved node produces no router call" "0" "$(route_calls)"
+case "$out" in *"kept=1"*) a=yes ;; *) a="no: $out" ;; esac
+assert_eq "sweep: a reserved node is counted as kept" "yes" "$a"
+iss_teardown
+
+# --- Case: UNKNOWN is not an empty set --------------------------------------
+# The sensors rule: what does this check print when it cannot see? If the answer
+# is "healthy", it is broken.
+echo "Test: dispatch-invalid-state-sweep — an UNKNOWN registry aborts rather than reading as empty"
+iss_setup
+iss_node tactic-fixture
+printf '1' > "$ISS_ROOT/claude-rc"
+out=$(iss_run)
+assert_eq "sweep: an UNKNOWN registry produces no router call" "0" "$(route_calls)"
+case "$out" in *"UNKNOWN"*) a=yes ;; *) a="no: $out" ;; esac
+assert_eq "sweep: an UNKNOWN registry is reported, not silently swallowed" "yes" "$a"
+case "$out" in *"candidates=0"*) a=summary ;; *) a=aborted ;; esac
+assert_eq "sweep: an UNKNOWN read aborts before emitting a healthy-looking summary" "aborted" "$a"
+iss_teardown
+
+# --- Case: the keyspace filter ----------------------------------------------
+echo "Test: dispatch-invalid-state-sweep — names outside the node keyspace are ignored"
+iss_setup
+iss_node tactic-fixture
+# A legacy `<N>-slug` issue worktree is not this lane's to route, and a name with
+# no intentions/ file is not a graph node at all.
+printf '%s' '[{"sessionId":"s1","id":"j1","name":"1234-legacy-issue","cwd":"/w","state":"done"},
+              {"sessionId":"s2","id":"j2","name":"tactic-has-no-node-file","cwd":"/w","state":"done"}]' \
+  > "$ISS_ROOT/claude-payload.json"
+out=$(iss_run)
+assert_eq "sweep: a legacy issue name and a nodeless name produce no router calls" "0" "$(route_calls)"
+case "$out" in *"candidates=0"*) a=yes ;; *) a="no: $out" ;; esac
+assert_eq "sweep: neither name counts as a candidate" "yes" "$a"
+iss_teardown
+
+# --- Case: occupancy must independently confirm terminal --------------------
+# The registry row says a SESSION is terminal; the occupancy classifier says the
+# NODE is actually held by it. A row whose node worktree is not terminal-held
+# (e.g. the name matches nothing) must not be routed.
+echo "Test: dispatch-invalid-state-sweep — occupancy must independently confirm the hold"
+iss_setup
+iss_node tactic-fixture
+# The registry lists a terminal row under a DIFFERENT name than the node's own
+# worktree basename resolves to a live claim, so occupancy is not `terminal`.
+printf '%s' '[{"sessionId":"s-dead","id":"job-1","name":"tactic-fixture","cwd":"/w","state":"done"},
+              {"sessionId":"s-live","id":"job-2","name":"tactic-fixture","cwd":"/w","state":"working"}]' \
+  > "$ISS_ROOT/claude-payload.json"
+out=$(iss_run)
+# The FIRST matching row wins in the occupancy classifier; with a live row also
+# present the node must not be treated as a confirmed invalid state by both.
+# What matters is that the sweep never routes a node whose occupancy is not
+# `terminal` — assert on the router call count, not on which row matched.
+calls=$(route_calls)
+if [[ "$calls" == "0" || "$calls" == "1" ]]; then a=bounded; else a="no: $calls"; fi
+assert_eq "sweep: a contested node produces at most one route call" "bounded" "$a"
+iss_teardown
+
+# --- Case: the per-invocation cap, and it is never silent -------------------
+echo "Test: dispatch-invalid-state-sweep — the per-invocation cap is honored and logged"
+iss_setup
+for n in tactic-aaa tactic-bbb tactic-ccc; do iss_node "$n"; done
+printf '%s' '[{"sessionId":"s1","id":"j1","name":"tactic-aaa","cwd":"/w","state":"done"},
+              {"sessionId":"s2","id":"j2","name":"tactic-bbb","cwd":"/w","state":"done"},
+              {"sessionId":"s3","id":"j3","name":"tactic-ccc","cwd":"/w","state":"done"}]' \
+  > "$ISS_ROOT/claude-payload.json"
+out=$(DISPATCH_INVALID_STATE_SWEEP_MAX=2 \
+  PATH="$ISS_ROOT/bin:$SAVED_PATH" \
+  CLAUDE_AGENTS_CMD="$ISS_ROOT/bin/claude" \
+  CLAUDE_AGENTS_PGREP_CMD="$ISS_ROOT/bin/pgrep-visible" \
+  DISPATCH_INVALID_STATE_SWEEP_ROOT="$ISS_ROOT" \
+  DISPATCH_INVALID_STATE_ROUTE_CMD="$ISS_SCRIPTS/route-stub" \
+  DISPATCH_RESERVATION_DIR="$ISS_ROOT/reservations" \
+  ISS_ROUTE_LOG="$ISS_ROUTE_LOG" \
+  "$ISS_SWEEP" 2>/dev/null)
+assert_eq "sweep: the cap bounds router calls to 2" "2" "$(route_calls)"
+# A silent cap reads as "covered everything" — it must say what it dropped.
+case "$out" in *"cap"*"deferred"*) a=yes ;; *) a="no: $out" ;; esac
+assert_eq "sweep: the cap is logged, never silent" "yes" "$a"
+iss_teardown
+
+# --- Case: a router escalation is deferred, never parked here ---------------
+echo "Test: dispatch-invalid-state-sweep — a router escalation defers to the sweep tier"
+iss_setup
+iss_node tactic-fixture
+printf '%s' '[{"sessionId":"s-dead","id":"job-1","name":"tactic-fixture","cwd":"/w","state":"done"}]' \
+  > "$ISS_ROOT/claude-payload.json"
+ISS_ROUTE_RC=10
+out=$(iss_run)
+case "$out" in *"escalate-deferred=1"*) a=yes ;; *) a="no: $out" ;; esac
+assert_eq "sweep: a router exit 10 is counted as escalate-deferred" "yes" "$a"
+case "$out" in *"terminal_without_disposition_sweep owns the escalation"*) a=yes ;; *) a="no: $out" ;; esac
+assert_eq "sweep: the deferral names the escalation owner" "yes" "$a"
+ISS_ROUTE_RC=0
+iss_teardown
+
+# --- Case: this arm never parks, holds or reaps -----------------------------
+# Structural, not behavioural: the single escalation-owner rule.
+echo "Test: dispatch-invalid-state-sweep — the arm contains no park/hold/reap call"
+SWEEP_SRC="$SCRIPT_DIR/dispatch-invalid-state-sweep"
+n=$(grep -cE '^[^#]*(park-node|hold-node|claude rm|git worktree remove|graph-commit)' "$SWEEP_SRC" | tr -d ' ')
+assert_eq "sweep: no park/hold/reap/graph-write invocation in the sweep" "0" "$n"
+
+report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-invalid-state-sweep.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-invalid-state-sweep.sh
@@ -106,6 +106,84 @@ case "$out" in *"kept=1"*) a=yes ;; *) a="no: $out" ;; esac
 assert_eq "sweep: a reserved node is counted as kept" "yes" "$a"
 iss_teardown
 
+# --- Case: the doctrine gates this arm holds on its own ---------------------
+# This arm carries NO router-supplied discrimination: the router's own gates run
+# after it has already been called, and a call is what spawns an Opus session.
+# So `phase: done` (a completed node in the normal post-completion reap window —
+# session terminal, worktree not yet reaped) and an already-parked node must both
+# be filtered HERE, exactly as terminal_without_disposition_sweep steps (8) and
+# (9) do. `office_hours` is serialized as a BLOCK MAPPING, so the gate has to be
+# a frontmatter-scoped PRESENCE test, not a read of the key's own line.
+echo "Test: dispatch-invalid-state-sweep — phase: done and already-parked are never routed"
+iss_setup
+for n in tactic-done tactic-parked tactic-body-prose tactic-live-work; do iss_node "$n"; done
+cat > "$ISS_ROOT/intentions/tactic-done.md" <<'DONE'
+---
+id: tactic-done
+phase: done
+office_hours: null
+---
+# done
+DONE
+cat > "$ISS_ROOT/intentions/tactic-parked.md" <<'PARKED'
+---
+id: tactic-parked
+phase: implement
+office_hours:
+  reason: waiting on the author
+  since: 2026-08-01T00:00:00Z
+---
+# parked
+PARKED
+# The negative control for the frontmatter scoping: a column-0 `office_hours:`
+# line in the BODY is prose, not park state, and must NOT suppress routing.
+cat > "$ISS_ROOT/intentions/tactic-body-prose.md" <<'PROSE'
+---
+id: tactic-body-prose
+phase: implement
+office_hours: null
+---
+# body prose
+
+office_hours: this line is documentation about the field, not park state
+PROSE
+cat > "$ISS_ROOT/intentions/tactic-live-work.md" <<'LIVE'
+---
+id: tactic-live-work
+phase: implement
+office_hours: null
+---
+# live work
+LIVE
+printf '%s' '[{"sessionId":"s1","id":"j1","name":"tactic-done","cwd":"/w","state":"done"},
+              {"sessionId":"s2","id":"j2","name":"tactic-parked","cwd":"/w","state":"done"},
+              {"sessionId":"s3","id":"j3","name":"tactic-body-prose","cwd":"/w","state":"done"},
+              {"sessionId":"s4","id":"j4","name":"tactic-live-work","cwd":"/w","state":"done"}]' \
+  > "$ISS_ROOT/claude-payload.json"
+out=$(DISPATCH_INVALID_STATE_SWEEP_MAX=9 \
+  PATH="$ISS_ROOT/bin:$SAVED_PATH" \
+  CLAUDE_AGENTS_CMD="$ISS_ROOT/bin/claude" \
+  CLAUDE_AGENTS_PGREP_CMD="$ISS_ROOT/bin/pgrep-visible" \
+  DISPATCH_INVALID_STATE_SWEEP_ROOT="$ISS_ROOT" \
+  DISPATCH_INVALID_STATE_ROUTE_CMD="$ISS_SCRIPTS/route-stub" \
+  DISPATCH_RESERVATION_DIR="$ISS_ROOT/reservations" \
+  ISS_ROUTE_LOG="$ISS_ROUTE_LOG" \
+  "$ISS_SWEEP" 2>/dev/null)
+routed=$(cat "$ISS_ROUTE_LOG")
+case "$routed" in *tactic-done*) a="no: $routed" ;; *) a=filtered ;; esac
+assert_eq "sweep: a phase: done node is never routed" "filtered" "$a"
+case "$routed" in *tactic-parked*) a="no: $routed" ;; *) a=filtered ;; esac
+assert_eq "sweep: an already-parked node (block mapping) is never routed" "filtered" "$a"
+# Both controls must still route, or the gates would be suppressing everything.
+case "$routed" in *tactic-body-prose*) a=routed ;; *) a="no: $routed" ;; esac
+assert_eq "sweep: a column-0 office_hours line in the BODY does not suppress routing" "routed" "$a"
+case "$routed" in *tactic-live-work*) a=routed ;; *) a="no: $routed" ;; esac
+assert_eq "sweep: a working, unparked node still routes" "routed" "$a"
+assert_eq "sweep: exactly the two eligible nodes were routed" "2" "$(route_calls)"
+case "$out" in *"kept=2"*) a=yes ;; *) a="no: $out" ;; esac
+assert_eq "sweep: the two filtered nodes are counted as kept" "yes" "$a"
+iss_teardown
+
 # --- Case: UNKNOWN is not an empty set --------------------------------------
 # The sensors rule: what does this check print when it cannot see? If the answer
 # is "healthy", it is broken.
@@ -194,6 +272,87 @@ assert_eq "sweep: a router exit 10 is counted as escalate-deferred" "yes" "$a"
 case "$out" in *"terminal_without_disposition_sweep owns the escalation"*) a=yes ;; *) a="no: $out" ;; esac
 assert_eq "sweep: the deferral names the escalation owner" "yes" "$a"
 ISS_ROUTE_RC=0
+iss_teardown
+
+# --- Case: the evidence file has exactly one owner --------------------------
+# The sweep creates the evidence file, so it owns it until ownership transfers.
+# Ownership transfers only when the router reports a LAUNCHED intervention
+# (rc 0) — that session reads the path out of its own prompt after this loop has
+# moved on. On any other outcome nothing will ever read the file, and the
+# steady state today is exactly that outcome (the intervention skill has not
+# landed, so the router escalates every time), which without cleanup drops files
+# into the temp dir every tick, forever.
+echo "Test: dispatch-invalid-state-sweep — the evidence file has exactly one owner"
+iss_setup
+iss_node tactic-fixture
+printf '%s' '[{"sessionId":"s-dead","id":"job-1","name":"tactic-fixture","cwd":"/w","state":"done"}]' \
+  > "$ISS_ROOT/claude-payload.json"
+SAVED_TMPDIR="${TMPDIR:-}"
+mkdir -p "$ISS_ROOT/tmp"
+export TMPDIR="$ISS_ROOT/tmp"
+
+iss_evidence_path() {
+  awk '{for (i = 1; i < NF; i++) if ($i == "--evidence-file") print $(i + 1)}' \
+    "$ISS_ROUTE_LOG" | head -1
+}
+
+# rc 0: a session was launched and now owns the file — it must survive.
+ISS_ROUTE_RC=0
+iss_run >/dev/null
+evid=$(iss_evidence_path)
+case "$evid" in */invalid-state-evidence-*) a=yes ;; *) a="no: $evid" ;; esac
+assert_eq "sweep: an evidence file path is handed to the router" "yes" "$a"
+[[ -f "$evid" ]] && a=yes || a=no
+assert_eq "sweep: a launched intervention keeps its evidence file" "yes" "$a"
+
+# rc 10: no session was launched, so the sweep still owns the file.
+: > "$ISS_ROUTE_LOG"
+ISS_ROUTE_RC=10
+iss_run >/dev/null
+evid=$(iss_evidence_path)
+[[ -e "$evid" ]] && a="still present: $evid" || a=removed
+assert_eq "sweep: an escalated candidate leaves no evidence file behind" "removed" "$a"
+
+ISS_ROUTE_RC=0
+if [[ -n "$SAVED_TMPDIR" ]]; then export TMPDIR="$SAVED_TMPDIR"; else unset TMPDIR; fi
+iss_teardown
+
+# --- Case: the router call is bounded on the tick path ----------------------
+# This sweep runs inline between two of the tick's lock heartbeats, so a router
+# call that hangs (a contended graph landing lock is the easy way to induce one)
+# would stall the tick past its heartbeat and the fleet with it. Two bounds are
+# asserted: the wall-clock `timeout` around the call, and the short landing-lock
+# wait handed down so the router's own graph landing defers rather than waits.
+echo "Test: dispatch-invalid-state-sweep — the router call is time-bounded and gets a short lock wait"
+iss_setup
+iss_node tactic-fixture
+cat > "$ISS_SCRIPTS/route-slow" <<'ISSSLOW'
+#!/usr/bin/env bash
+printf 'LOCK=%s\n' "${GRAPH_COMMIT_LOCK_WAIT_SECONDS:-unset}" >> "${ISS_ROUTE_LOG:?}"
+sleep 30
+exit 0
+ISSSLOW
+chmod +x "$ISS_SCRIPTS/route-slow"
+printf '%s' '[{"sessionId":"s-dead","id":"job-1","name":"tactic-fixture","cwd":"/w","state":"done"}]' \
+  > "$ISS_ROOT/claude-payload.json"
+t0=$(date +%s)
+out=$(DISPATCH_INVALID_STATE_ROUTE_TIMEOUT_S=1 \
+  DISPATCH_INVALID_STATE_LOCK_WAIT_S=7 \
+  PATH="$ISS_ROOT/bin:$SAVED_PATH" \
+  CLAUDE_AGENTS_CMD="$ISS_ROOT/bin/claude" \
+  CLAUDE_AGENTS_PGREP_CMD="$ISS_ROOT/bin/pgrep-visible" \
+  DISPATCH_INVALID_STATE_SWEEP_ROOT="$ISS_ROOT" \
+  DISPATCH_INVALID_STATE_ROUTE_CMD="$ISS_SCRIPTS/route-slow" \
+  DISPATCH_RESERVATION_DIR="$ISS_ROOT/reservations" \
+  ISS_ROUTE_LOG="$ISS_ROUTE_LOG" \
+  "$ISS_SWEEP" 2>/dev/null)
+elapsed=$(( $(date +%s) - t0 ))
+if (( elapsed < 15 )); then a=bounded; else a="no: ${elapsed}s"; fi
+assert_eq "sweep: a hanging router is cut off well inside its sleep" "bounded" "$a"
+case "$out" in *"escalate-deferred=1"*) a=yes ;; *) a="no: $out" ;; esac
+assert_eq "sweep: a timed-out router call defers to the sweep tier" "yes" "$a"
+case "$(cat "$ISS_ROUTE_LOG")" in *"LOCK=7"*) a=yes ;; *) a="no: $(cat "$ISS_ROUTE_LOG")" ;; esac
+assert_eq "sweep: the router inherits the short landing-lock wait" "yes" "$a"
 iss_teardown
 
 # --- Case: this arm never parks, holds or reaps -----------------------------

--- a/.claude/skills/dispatch-propagate/scripts/test-graph-select-target.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-graph-select-target.sh
@@ -103,6 +103,48 @@ gsc_sel=$(PATH="$GSC_ROOT/bin:$SAVED_PATH" \
   DISPATCH_RESERVATION_DIR="$GSC_ROOT/reservations" \
   DISPATCH_SELECTION_LOG_DIR="$GSC_ROOT/seldir" "$GSC_GST" 2>/dev/null)
 assert_eq "graph-select-target: orphan node-id worktree (no session) is selected" "node tactic-fixture tactic implement" "$gsc_sel"
+
+# Case 3 — a TERMINAL session holds the worktree (tactic-invalid-state-lane
+# Unit 2). The node is still skipped, exactly as in Case 1 — but the skip is now
+# attributable: the decision log must carry `terminal-session`, not
+# `live-session`. Folding the two together is what made this invalid state
+# invisible at the moment the router noticed it.
+echo "Test: graph-select-target — a terminal-session holder is skipped as terminal-session, not live-session"
+printf '%s' '[{"sessionId":"s-dead","name":"tactic-fixture","state":"done","cwd":""}]' \
+  > "$GSC_ROOT/claude-payload.json"
+rm -rf "$GSC_ROOT/seldir"; mkdir -p "$GSC_ROOT/seldir"
+gsc_term=$(PATH="$GSC_ROOT/bin:$SAVED_PATH" \
+  CLAUDE_AGENTS_CMD="$GSC_ROOT/bin/claude" CLAUDE_AGENTS_PGREP_CMD="$GSC_ROOT/bin/pgrep-daemon-visible" \
+  DISPATCH_RESERVATION_DIR="$GSC_ROOT/reservations" \
+  DISPATCH_DECISION_LOG_DIR="$GSC_ROOT/seldir" \
+  DISPATCH_SELECTION_LOG_DIR="$GSC_ROOT/seldir" "$GSC_GST" 2>/dev/null)
+assert_eq "graph-select-target: a terminal-held node is still skipped" "empty" "$gsc_term"
+gsc_reason=$(cat "$GSC_ROOT/seldir"/*.jsonl 2>/dev/null \
+  | jq -r 'select(.site=="graph-select-target") | .skipped[]? | select(.id=="tactic-fixture") | .reason' \
+  2>/dev/null | tail -1)
+assert_eq "graph-select-target: the skip reason is attributable as terminal-session" \
+  "terminal-session" "$gsc_reason"
+
+# Case 4 — an UNKNOWN daemon read must keep reporting `live-session`. A blocked
+# read must never manufacture an invalid state out of a healthy node.
+echo "Test: graph-select-target — an UNKNOWN daemon read still reports live-session"
+cat > "$GSC_ROOT/bin/claude" <<'GSCCLAUDEFAIL'
+#!/usr/bin/env bash
+exit 1
+GSCCLAUDEFAIL
+chmod +x "$GSC_ROOT/bin/claude"
+rm -rf "$GSC_ROOT/seldir"; mkdir -p "$GSC_ROOT/seldir"
+gsc_unk=$(PATH="$GSC_ROOT/bin:$SAVED_PATH" \
+  CLAUDE_AGENTS_CMD="$GSC_ROOT/bin/claude" CLAUDE_AGENTS_PGREP_CMD="$GSC_ROOT/bin/pgrep-daemon-visible" \
+  DISPATCH_RESERVATION_DIR="$GSC_ROOT/reservations" \
+  DISPATCH_DECISION_LOG_DIR="$GSC_ROOT/seldir" \
+  DISPATCH_SELECTION_LOG_DIR="$GSC_ROOT/seldir" "$GSC_GST" 2>/dev/null)
+assert_eq "graph-select-target: an unknown read still skips the node" "empty" "$gsc_unk"
+gsc_ureason=$(cat "$GSC_ROOT/seldir"/*.jsonl 2>/dev/null \
+  | jq -r 'select(.site=="graph-select-target") | .skipped[]? | select(.id=="tactic-fixture") | .reason' \
+  2>/dev/null | tail -1)
+assert_eq "graph-select-target: an unknown read is NOT reported as terminal-session" \
+  "live-session" "$gsc_ureason"
 rm -rf "$GSC_ROOT" "$GSC_BARE"
 
 # ============================================================================

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-claude-agents.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-claude-agents.sh
@@ -1577,4 +1577,108 @@ if claude_agents_registry_reachable 2>/dev/null; then rc=0; else rc=$?; fi
 assert_eq "probe: a missing pgrep reports unreachable (no corroboration)" "127" "$rc"
 ca_teardown
 
+# --- Test 71: worktree_occupancy_state — the four-state occupancy verdict ----
+# The granular classifier behind worktree_has_live_session. The TOKEN on stdout
+# is the contract; the function ALWAYS returns 0 (same shape as
+# dispatch_pause_state). `terminal` is the state the invalid-state lane exists
+# to see: nothing is running, yet the claim survives.
+echo "Test: worktree_occupancy_state distinguishes free / live / terminal / unknown"
+ca_setup
+ca_basename=$(basename "$CA_DIR")
+
+# free — the daemon answered and nothing claims this worktree.
+write_fake_claude '[]' 0
+out=$(worktree_occupancy_state "$CA_DIR"); rc=$?
+assert_eq "occupancy: empty registry yields free" "free" "$out"
+assert_eq "occupancy: free still returns 0 (token is the contract)" "0" "$rc"
+# The evidence globals are observable only on a DIRECT call — a `$( )` call runs
+# in a subshell whose assignments cannot escape. Assert them the way a real
+# caller must read them.
+worktree_occupancy_state "$CA_DIR" >/dev/null
+assert_eq "occupancy: free publishes the state global" "free" "$WORKTREE_OCCUPANCY_STATE"
+assert_eq "occupancy: free carries no session id" "" "$WORKTREE_OCCUPANCY_SESSION_ID"
+
+# live — a working session is a VALID claim, never an invalid state.
+write_fake_claude "[{\"sessionId\":\"sess-live\",\"status\":\"busy\",\"name\":\"$ca_basename\",\"state\":\"working\"}]" 0
+out=$(worktree_occupancy_state "$CA_DIR"); rc=$?
+assert_eq "occupancy: a working session yields live" "live" "$out"
+assert_eq "occupancy: live returns 0" "0" "$rc"
+
+# terminal — at least `done` and `error`, both from the shared enumeration.
+write_fake_claude "[{\"sessionId\":\"sess-done\",\"name\":\"$ca_basename\",\"state\":\"done\"}]" 0
+out=$(worktree_occupancy_state "$CA_DIR" 2>/dev/null); rc=$?
+assert_eq "occupancy: a done session yields terminal" "terminal" "$out"
+assert_eq "occupancy: terminal returns 0" "0" "$rc"
+worktree_occupancy_state "$CA_DIR" >/dev/null 2>&1
+assert_eq "occupancy: terminal publishes the holder's session id" \
+  "sess-done" "$WORKTREE_OCCUPANCY_SESSION_ID"
+
+write_fake_claude "[{\"sessionId\":\"sess-err\",\"name\":\"$ca_basename\",\"state\":\"error\"}]" 0
+out=$(worktree_occupancy_state "$CA_DIR" 2>/dev/null)
+assert_eq "occupancy: an error session yields terminal" "terminal" "$out"
+
+# The operator diagnostic names whichever terminal state matched, not just `done`.
+diag=$(worktree_occupancy_state "$CA_DIR" 2>&1 >/dev/null)
+case "$diag" in
+  *"held by a error-but-not-removed session sess-err"*) diag_ok=yes ;;
+  *) diag_ok="no: $diag" ;;
+esac
+assert_eq "occupancy: the diagnostic names the matched terminal state" "yes" "$diag_ok"
+
+# unknown — a daemon failure and whitespace-only output. Never `terminal`:
+# a blocked read must not manufacture an invalid state.
+write_fake_claude '' 1
+out=$(worktree_occupancy_state "$CA_DIR" 2>/dev/null); rc=$?
+assert_eq "occupancy: a daemon-query failure yields unknown" "unknown" "$out"
+assert_eq "occupancy: unknown returns 0" "0" "$rc"
+
+write_fake_claude '   ' 0
+out=$(worktree_occupancy_state "$CA_DIR" 2>/dev/null)
+assert_eq "occupancy: whitespace-only output yields unknown" "unknown" "$out"
+
+# exclude_sid suppresses a self-match, leaving the worktree free.
+write_fake_claude "[{\"sessionId\":\"sess-self\",\"status\":\"busy\",\"name\":\"$ca_basename\",\"state\":\"working\"}]" 0
+out=$(worktree_occupancy_state "$CA_DIR" "sess-self")
+assert_eq "occupancy: exclude_sid suppresses the caller's own claim" "free" "$out"
+out=$(worktree_occupancy_state "$CA_DIR" "sess-other")
+assert_eq "occupancy: exclude_sid does not suppress another session's claim" "live" "$out"
+
+# A missing path argument is unknown (fail safe), never free.
+out=$(worktree_occupancy_state "" 2>/dev/null)
+assert_eq "occupancy: an empty path yields unknown, never free" "unknown" "$out"
+ca_teardown
+
+# --- Test 72: worktree_has_live_session's boolean contract is unchanged ------
+# The wrapper is the regression surface for every existing caller
+# (graph-select-target, dispatch-sweep, lib-graph-worktree.sh,
+# lib-standdown-recheck.sh, .claude/hooks/worktree-remove.sh): ONLY a definite
+# `free` releases the worktree. A terminal holder must still read as occupied —
+# promoting it to a first-class verdict must not un-block it.
+echo "Test: worktree_has_live_session still folds terminal and unknown to occupied"
+ca_setup
+ca_basename=$(basename "$CA_DIR")
+
+write_fake_claude "[{\"sessionId\":\"sess-done\",\"name\":\"$ca_basename\",\"state\":\"done\"}]" 0
+if worktree_has_live_session "$CA_DIR" 2>/dev/null; then live=occupied; else live=free; fi
+assert_eq "wrapper: a terminal row still reports occupied" "occupied" "$live"
+
+write_fake_claude '[]' 0
+if worktree_has_live_session "$CA_DIR"; then live=occupied; else live=free; fi
+assert_eq "wrapper: a free worktree still reports free" "free" "$live"
+
+write_fake_claude '' 1
+if worktree_has_live_session "$CA_DIR" 2>/dev/null; then live=occupied; else live=free; fi
+assert_eq "wrapper: an unknown read still folds to occupied" "occupied" "$live"
+
+# The done-holder stderr diagnostic must still reach existing callers through
+# the wrapper — the wrapper captures stdout, so stderr has to pass through.
+write_fake_claude "[{\"sessionId\":\"sess-done\",\"name\":\"$ca_basename\",\"state\":\"done\"}]" 0
+diag=$(worktree_has_live_session "$CA_DIR" 2>&1 >/dev/null || true)
+case "$diag" in
+  *"claude rm sess-done"*) diag_ok=yes ;;
+  *) diag_ok="no: $diag" ;;
+esac
+assert_eq "wrapper: the operator diagnostic still reaches stderr" "yes" "$diag_ok"
+ca_teardown
+
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-frozen-session-park.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-frozen-session-park.sh
@@ -249,6 +249,36 @@ fs_log_dispositions() {
   jq -r 'select(.site == "frozen-session-sweep") | .disposition' "$DECISION_LOG_FILE"
 }
 
+# fs_write_route_stub <exit-code> [sleep-seconds] — install a fake
+# dispatch-invalid-state-route for the lane pre-tier. The gate resolves the
+# router under the sweep's own $repo_root (NOT this library's location, so a
+# suite run can never reach the real router and its graph-minting side effects),
+# so the stub must live in the fixture repo's own scripts dir.
+FS_ROUTELOG=""
+# fs_write_route_stub <exit-code> [sleep-seconds] [repo-root] [log-dir] — the
+# repo root and log dir default to the frozen-session fixture's, and the
+# terminal-disposition fixture passes its own.
+fs_write_route_stub() {
+  local rc="$1" nap="${2:-0}" repo="${3:-$FS_REPO}" logdir="${4:-$FS_DIR}"
+  local dir="$repo/.claude/skills/dispatch-propagate/scripts"
+  mkdir -p "$dir"
+  FS_ROUTELOG="$logdir/route.log"
+  : > "$FS_ROUTELOG"
+  cat > "$dir/dispatch-invalid-state-route" <<ROUTESTUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$FS_ROUTELOG"
+[[ "$nap" != "0" ]] && sleep "$nap"
+exit $rc
+ROUTESTUB
+  chmod +x "$dir/dispatch-invalid-state-route"
+}
+
+fs_route_calls() {
+  local c=0
+  [[ -n "$FS_ROUTELOG" && -f "$FS_ROUTELOG" ]] && { c=$(wc -l < "$FS_ROUTELOG"); }
+  printf '%s' "${c// /}"
+}
+
 # --- Test 1: an aged blocked node worker is parked ---------------------------
 
 echo "Test: an aged blocked node worker with an unparked node is parked"
@@ -1819,6 +1849,165 @@ assert_eq "race: the escalation marker is retained" "present" \
 # park-node at all. Assert the race actually fired.
 assert_eq "race: non-vacuity — the fake park-node's CAS actually raced" "yes" \
   "$(grep -q '^RACED=1$' "$TD_PARKLOG" && printf 'yes' || printf 'no')"
+td_teardown
+
+# ============================================================================
+# Unit 5 — the invalid-state lane PRE-TIER in frozen_session_sweep
+# ============================================================================
+# The oracle for every fall-through case below is Test 1's own park assertion,
+# reused verbatim: with the pre-tier declining, the park path must run EXACTLY
+# as it does today. The failure mode this guards is the worst one in the change
+# set — deleting a session's only copy of its escalation text.
+
+echo "Test: lane pre-tier — a handled verdict defers the candidate instead of parking"
+fs_setup
+fs_write_route_stub 0
+fs_write_node "tactic-frozen-one" unparked
+fs_commit_nodes
+fs_write_transcript "0aa1-1111" $(( FS_NOW - 2000 ))
+fs_add_session "0aa1-1111" "tactic-frozen-one" "blocked"
+fs_install_claude 0
+fs_run
+assert_eq "lane: the router was consulted exactly once" "1" "$(fs_route_calls)"
+assert_eq "lane: a handled verdict parks NOTHING" "0" "$(fs_park_calls)"
+assert_eq "lane: the decision record says routed-to-lane" "routed-to-lane" "$(fs_log_dispositions)"
+assert_eq "lane: stderr says deferred, not parked" "yes" \
+  "$(fs_contains 'routed tactic-frozen-one to the invalid-state lane')"
+assert_eq "lane: the pre-tier line reports the routed count" "yes" \
+  "$(fs_contains 'frozen-session lane pre-tier (routed=1 kept-by-lane=0)')"
+# The router is called with the node id and the kind this sweep owns.
+route_argv=$(head -1 "$FS_ROUTELOG")
+case "$route_argv" in *"--node tactic-frozen-one"*) a=yes ;; *) a="no: $route_argv" ;; esac
+assert_eq "lane: the router call names the node" "yes" "$a"
+case "$route_argv" in *"--kind frozen-session"*) a=yes ;; *) a="no: $route_argv" ;; esac
+assert_eq "lane: frozen_session_sweep passes --kind frozen-session" "yes" "$a"
+fs_teardown
+
+echo "Test: lane pre-tier — a keep verdict parks nothing and is recorded"
+fs_setup
+fs_write_route_stub 4
+fs_write_node "tactic-frozen-one" unparked
+fs_commit_nodes
+fs_write_transcript "0aa1-1111" $(( FS_NOW - 2000 ))
+fs_add_session "0aa1-1111" "tactic-frozen-one" "blocked"
+fs_install_claude 0
+fs_run
+assert_eq "lane: a keep verdict parks nothing" "0" "$(fs_park_calls)"
+assert_eq "lane: the decision record says kept-by-lane" "kept-by-lane" "$(fs_log_dispositions)"
+fs_teardown
+
+echo "Test: lane pre-tier — an escalate verdict falls through to the park path unchanged"
+fs_setup
+fs_write_route_stub 10
+fs_write_node "tactic-frozen-one" unparked
+fs_commit_nodes
+fs_write_transcript "0aa1-1111" $(( FS_NOW - 2000 ))
+fs_add_session "0aa1-1111" "tactic-frozen-one" "blocked"
+fs_install_claude 0
+fs_run
+# Test 1's assertions, reused as the oracle: the park path must be untouched.
+assert_eq "lane/escalate: park-node invoked exactly once" "1" "$(fs_park_calls)"
+assert_eq "lane/escalate: node id is still \$3 (after --base <id>=<sha>)" \
+  "tactic-frozen-one" "$(fs_park_arg 3)"
+assert_eq "lane/escalate: the decision record says parked" "parked" "$(fs_log_dispositions)"
+assert_eq "lane/escalate: the summary is byte-identical to today's" "yes" \
+  "$(fs_contains 'sweep complete (blocked=1 parked=1 observing=0 unmeasurable=0 deferred=0)')"
+assert_eq "lane/escalate: no pre-tier line is printed when nothing was routed" "no" \
+  "$(fs_contains 'lane pre-tier')"
+fs_teardown
+
+echo "Test: lane pre-tier — an ABSENT router falls through to the park path (fail toward escalate)"
+fs_setup
+# No fs_write_route_stub at all: this is the state on landing, before the
+# router's own PR merges. Today's behavior must be preserved exactly.
+FS_ROUTELOG=""
+fs_write_node "tactic-frozen-one" unparked
+fs_commit_nodes
+fs_write_transcript "0aa1-1111" $(( FS_NOW - 2000 ))
+fs_add_session "0aa1-1111" "tactic-frozen-one" "blocked"
+fs_install_claude 0
+fs_run
+assert_eq "lane/absent: park-node invoked exactly once" "1" "$(fs_park_calls)"
+assert_eq "lane/absent: the summary is byte-identical to today's" "yes" \
+  "$(fs_contains 'sweep complete (blocked=1 parked=1 observing=0 unmeasurable=0 deferred=0)')"
+fs_teardown
+
+echo "Test: lane pre-tier — a router that hangs past its timeout falls through to the park path"
+fs_setup
+# 3s nap against a 1s budget: the gate must abandon it and park, not stall the
+# tick. An unbounded router call on the scheduling path is a fleet stall.
+fs_write_route_stub 0 3
+DISPATCH_INVALID_STATE_ROUTE_TIMEOUT_S=1
+fs_write_node "tactic-frozen-one" unparked
+fs_commit_nodes
+fs_write_transcript "0aa1-1111" $(( FS_NOW - 2000 ))
+fs_add_session "0aa1-1111" "tactic-frozen-one" "blocked"
+fs_install_claude 0
+fs_run
+assert_eq "lane/timeout: a hung router still parks" "1" "$(fs_park_calls)"
+assert_eq "lane/timeout: the park path ran unchanged" "parked" "$(fs_log_dispositions)"
+unset DISPATCH_INVALID_STATE_ROUTE_TIMEOUT_S
+fs_teardown
+
+echo "Test: lane pre-tier — a router outside the checkout's scripts dir is refused"
+fs_setup
+fs_write_route_stub 0
+# Provenance: an executable outside $repo_root's scripts dir must never be run,
+# even when named explicitly. This is what makes honouring the env override safe.
+ROGUE_ROUTE="$FS_DIR/rogue-route"
+cat > "$ROGUE_ROUTE" <<'ROGUE'
+#!/usr/bin/env bash
+exit 0
+ROGUE
+chmod +x "$ROGUE_ROUTE"
+DISPATCH_INVALID_STATE_ROUTE_CMD="$ROGUE_ROUTE"
+fs_write_node "tactic-frozen-one" unparked
+fs_commit_nodes
+fs_write_transcript "0aa1-1111" $(( FS_NOW - 2000 ))
+fs_add_session "0aa1-1111" "tactic-frozen-one" "blocked"
+fs_install_claude 0
+fs_run
+assert_eq "lane/provenance: a rogue router path is refused" "yes" \
+  "$(fs_contains 'does not resolve inside')"
+assert_eq "lane/provenance: the refusal falls through to the park path" "1" "$(fs_park_calls)"
+unset DISPATCH_INVALID_STATE_ROUTE_CMD
+fs_teardown
+
+# ============================================================================
+# Unit 5 — the invalid-state lane PRE-TIER in terminal_without_disposition_sweep
+# ============================================================================
+# This is the sweep whose park block deletes the job dir's office-hours-*
+# markers on landing proof. A routed candidate must keep them: the pass has
+# proven nothing and the intervention may still need them.
+
+echo "Test: lane pre-tier (terminal) — a handled verdict defers and leaves markers intact"
+td_setup
+fs_write_route_stub 0 0 "$TD_REPO" "$TD_DIR"
+td_write_node "tactic-terminal-one" unparked
+td_commit_nodes
+td_write_transcript "0cc3-3333" $(( TD_NOW - 2000 ))
+td_add_session "0cc3-3333" "tactic-terminal-one" "done" "job-td-1"
+td_install_claude 0
+td_run
+assert_eq "lane/td: the router was consulted" "1" "$(fs_route_calls)"
+assert_eq "lane/td: a handled verdict parks NOTHING" "0" "$(td_park_calls)"
+assert_eq "lane/td: stderr says deferred and markers intact" "yes" \
+  "$(td_contains 'routed tactic-terminal-one to the invalid-state lane')"
+route_argv=$(head -1 "$FS_ROUTELOG")
+case "$route_argv" in *"--kind terminal-session"*) a=yes ;; *) a="no: $route_argv" ;; esac
+assert_eq "lane/td: this sweep passes --kind terminal-session" "yes" "$a"
+td_teardown
+
+echo "Test: lane pre-tier (terminal) — an escalate verdict falls through to the park path unchanged"
+td_setup
+fs_write_route_stub 10 0 "$TD_REPO" "$TD_DIR"
+td_write_node "tactic-terminal-one" unparked
+td_commit_nodes
+td_write_transcript "0cc3-3333" $(( TD_NOW - 2000 ))
+td_add_session "0cc3-3333" "tactic-terminal-one" "done" "job-td-1"
+td_install_claude 0
+td_run
+assert_eq "lane/td-escalate: park-node invoked exactly once" "1" "$(td_park_calls)"
 td_teardown
 
 report_results


### PR DESCRIPTION
Implements `tactic-invalid-state-lane` — all six units of the plan in the node
body on `origin/main`.

A dispatch node can reach a state its phase ladder cannot progress from: a
session that ended without declaring a disposition but is still registered, a
session frozen at a permission/classifier denial, a reap that exited 0 while
declining. Each had its own ad-hoc handling, invented separately. This lands the
ratified generalization: **detect → mechanical tier → intervention session →
escalation**, with the escalation staying caller-owned this round.

## What each unit does

- **Unit 1** — `worktree_occupancy_state` in `lib-claude-agents.sh`: a four-state
  classifier (`free|live|terminal|unknown`) printing one token and always
  returning 0. `worktree_has_live_session` becomes a thin wrapper whose boolean
  contract, fail-safe UNKNOWN fold and operator diagnostic are unchanged for
  every existing caller. The nine-state terminal enumeration, previously
  duplicated in two jq programs, is now one constant shared by all three
  consumers.
- **Unit 2** — the selector's skip becomes attributable: `terminal-session`
  instead of folding an invalid state into `live-session`. The node is still
  skipped in all four cases; no routing, no spawn, no graph write.
- **Unit 3** — `dispatch-invalid-state-route`, the common ladder. Exit contract:
  `0` handled, `4` keep, `10` escalate, `1` failure, `2` usage.
- **Unit 4** — `dispatch-invalid-state-sweep`, the selection-time arm, wired into
  `dispatch-select-tick` beside the scope sweep.
- **Unit 5** — both defensive sweeps consult the router as a pre-tier before
  their park block.
- **Unit 6** — a find-or-create fleet latch for invalid states with no node to
  route.

## Doctrine this had to honor, and how it is enforced

- **The lane never reaps.** Verified by grep across every changed file: the only
  `claude rm` occurrences are inside operator-recommendation strings.
- **A live claim is never spawned into**, and **UNKNOWN is never positive
  evidence** — a daemon hiccup must not manufacture interventions.
- **done-but-parked is a VALID state** (2026-08-04 ruling): phase and
  `office_hours` are orthogonal.
- **A retry-shaped state never writes `office_hours` on the source** — refused at
  the edge, at the one place that knows the kind's class.
- **Nothing in the park machinery moved**: the base-blob pin and `--base` CAS,
  the landing-proof re-read, the marker deletion that only fires on proof, the
  decision-record vocabulary and the park cap are untouched. The existing 238
  assertions pass unmodified and are the regression oracle.

## Degradation while the sibling is unbuilt

The intervention tier is gated on `.claude/skills/dispatch-invalid-state/SKILL.md`
existing. It does not exist yet, so on landing the router exits `10` everywhere
and observable behavior is identical to today's: the sweeps park as before, the
selector still skips. The only new artifacts are the `terminal-session` skip
reason and the router's skill-absent log lines. The sibling
`tactic-invalid-state-transcript-intervention` (#2) arms it.

## Verification

All three of the node's `verify` blocks pass:

- `run-unit-tests.sh --pr-scripts` — all suites pass, zero failures.
- `run-lint.sh` — all lint checks pass.
- `npx vitest run --project packages/intentionsutil --root .` — 820/820.

Per-suite: `test-lib-claude-agents.sh` 238/238 (was 217),
`test-graph-select-target.sh` 81/81 (was 77),
`test-lib-frozen-session-park.sh` 263/263 (was 238),
plus new `test-dispatch-invalid-state-route.sh` 53/53 and
`test-dispatch-invalid-state-sweep.sh` 21/21.

**Revert-and-confirm-red performed** on Unit 5: neutralizing the pre-tier gate
turns 14 of the new cases red. The cases that stay green under neutralization are
the fall-through ones, which assert the park path is unchanged and so must pass
either way.

## Two findings worth reviewer attention

1. **The evidence globals are observable only on a direct call.** Command
   substitution sets them in a subshell that dies, so `st=$(worktree_occupancy_state …)`
   silently leaves them stale. Documented as a CAVEAT; both real callers use the
   direct-call idiom.
2. **A test harness was one working environment away from minting a graph node.**
   An early draft of the Unit 5 gate resolved the router from `${BASH_SOURCE[0]}`,
   which made the REAL router reachable from any suite that merely sources the
   library — and the router has durable side effects. One suite run drove the real
   fleet-latch counter to 156 observations before the mint failed harmlessly. The
   gate now resolves the router from the sweep's own `$repo_root`, which is both
   the correct production semantics and untestable-into-production by construction.

Declared residuals, deliberately not attempted: extracting the sweeps'
park-with-landing-proof block into the router, and rewiring
`dispatch-graph-execute` cases 11/14 onto it.
