### PR TITLE
graph: main-checkout session census + held alarm (tactic-blocked-session-invisible-to-census)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/dispatch-fleet-alarm
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-fleet-alarm
@@ -177,7 +177,7 @@ if ! source "$SCRIPT_DIR/lib.sh"; then
 fi
 
 # The closed enum of alarm kinds. Extending it is a deliberate edit here.
-KINDS=(tick-stale daemon-degraded busy-stall automerge-suppressed unclaimed-hold watch-unknown heal-fired heal-unknown)
+KINDS=(tick-stale daemon-degraded busy-stall automerge-suppressed unclaimed-hold main-checkout-held watch-unknown heal-fired heal-unknown)
 
 usage() {
   cat <<'USAGE'
@@ -186,7 +186,7 @@ usage: dispatch-fleet-alarm --kind <kind> --statement <text> --body-file <path>
        dispatch-fleet-alarm -h|--help
 
 kinds: tick-stale daemon-degraded busy-stall automerge-suppressed
-       unclaimed-hold watch-unknown heal-fired heal-unknown
+       unclaimed-hold main-checkout-held watch-unknown heal-fired heal-unknown
 
 Records an out-of-band fleet-health reading as the graph node
 tactic-fleet-alarm-<kind> (find-or-create; body refreshed on re-detection).

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-fleet-watch
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-fleet-watch
@@ -2,7 +2,7 @@
 #
 # dispatch-fleet-watch — ONE-SHOT fleet-health watcher pass.
 #
-# Reads five independent fleet-health predicates, reports each one, and turns
+# Reads six independent fleet-health predicates, reports each one, and turns
 # every finding (and every unreadable input) into a graph node through
 # dispatch-fleet-alarm. Then it exits. It does NOT loop and it takes no deadline
 # argument: cadence belongs to the systemd timer that invokes it, not to the
@@ -30,6 +30,8 @@
 #   4. automerge-suppressed  open tactic-main-red-* latch held too long
 #   5. unclaimed-hold        a tracked hold blocking top-ranked work that no
 #                            session and no reservation claims
+#   6. main-checkout-held    the shared main checkout is dirty/unpushed AND a
+#                            stuck (non-working) session is sitting in it
 #
 # WHY TWO SNAPSHOTS, BOTH CAPTURED AT THE INPUT BOUNDARY:
 #   Predicate 3 reads the live session array through
@@ -59,7 +61,8 @@
 #   predicate 5 below. Each snapshot's READABILITY is therefore recorded at its
 #   capture site (SNAPSHOT_OK for the active view, SNAPSHOT_ALL_OK for the
 #   registered one), and predicate 5 gates on SNAPSHOT_ALL_OK — the bit for the
-#   view its claim ladder actually reads.
+#   view its claim ladder actually reads. Predicate 6 gates on the same bit, for
+#   the same reason: its session read is the REGISTERED view too.
 #
 # TWO DETAIL STRINGS PER PREDICATE, ON PURPOSE:
 #   D_<P>  the READING — carries the live numbers (elapsed spans, ages, counts,
@@ -115,7 +118,12 @@
 #              manual-only dispatch is a supported STANDING operating mode, and
 #              a top-ranked node blocked by a hold nobody is holding is exactly
 #              what the human driving that paused fleet needs told.
-#   unknown  — ALL FIVE predicates evaluate and emit as normal, each tagged
+#              Predicate 6 evaluates under pause for the sharpest version of the
+#              same reason: the incident it watches for HAPPENED during a
+#              correct pause. A dirty shared main checkout is not a consequence
+#              of pausing, and it blocks every graph write the human still makes
+#              by hand.
+#   unknown  — ALL SIX predicates evaluate and emit as normal, each tagged
 #              `pause=unknown`, AND the pass emits a watch-unknown finding
 #              naming the unreadable pause state. Silencing on an unreadable
 #              input is exactly the failure class this rewrite exists to close.
@@ -142,6 +150,12 @@
 #   DISPATCH_FLEET_WATCH_HOLD_TOP_K        default 10 (a COUNT, not seconds) —
 #       how many top-ranked live nodes count as "important" for predicate 5's
 #       blocked-source gate. Both are passed straight through to the enumerator.
+#   DISPATCH_FLEET_WATCH_MAIN_HELD_GRACE_S default 1800 (30m) — how long a
+#       non-working session sitting in the main checkout must have been idle
+#       before predicate 6 will call it stuck. Below the grace it is merely
+#       OBSERVED, never alarmed (the convention at lib-frozen-session-park.sh
+#       :495-529, including its deliberate treatment of a negative,
+#       future-stamped idle as `< grace`).
 #
 # Paths:
 #   DISPATCH_DECISION_LOG_FILE / DISPATCH_DECISION_LOG_DIR
@@ -197,10 +211,10 @@ usage() {
 usage: dispatch-fleet-watch [--json]
        dispatch-fleet-watch -h|--help
 
-One-shot fleet-health watcher pass. Evaluates five predicates (tick-stale,
-daemon-degraded, busy-stall, automerge-suppressed, unclaimed-hold), ALWAYS all
-five, and records findings / unreadable inputs as graph nodes via
-dispatch-fleet-alarm.
+One-shot fleet-health watcher pass. Evaluates six predicates (tick-stale,
+daemon-degraded, busy-stall, automerge-suppressed, unclaimed-hold,
+main-checkout-held), ALWAYS all six, and records findings / unreadable inputs as
+graph nodes via dispatch-fleet-alarm.
 
 exit: 0 all clear, 1 finding, 2 unknown, 64 usage, 69 environment.
 USAGE
@@ -230,7 +244,8 @@ IDLE_LIMIT="${DISPATCH_FLEET_WATCH_IDLE_LIMIT:-2700}"
 SUPPRESSION_LIMIT="${DISPATCH_FLEET_WATCH_SUPPRESSION_LIMIT:-21600}"
 HOLD_MIN_AGE="${DISPATCH_FLEET_WATCH_HOLD_MIN_AGE:-86400}"
 HOLD_TOP_K="${DISPATCH_FLEET_WATCH_HOLD_TOP_K:-10}"
-for t in "$TICK_MAX_AGE" "$IDLE_LIMIT" "$SUPPRESSION_LIMIT" "$HOLD_MIN_AGE" "$HOLD_TOP_K"; do
+MAIN_HELD_GRACE="${DISPATCH_FLEET_WATCH_MAIN_HELD_GRACE_S:-1800}"
+for t in "$TICK_MAX_AGE" "$IDLE_LIMIT" "$SUPPRESSION_LIMIT" "$HOLD_MIN_AGE" "$HOLD_TOP_K" "$MAIN_HELD_GRACE"; do
   [[ "$t" =~ ^[0-9]+$ ]] || { log "threshold must be a non-negative integer, got '$t'"; exit 64; }
 done
 
@@ -688,6 +703,166 @@ else
   fi
 fi
 
+# --- 6. a stuck session holding the shared main checkout ---------------------
+# The incident, observed in production: a background session (`sync-repair`, cwd
+# = the main checkout, name outside the worker keyspace) sat in a non-`working`
+# state for three days after an API error, leaving the shared main checkout's
+# tree dirty. That tree is a fleet-wide resource — dispatch-select-tick's
+# `--ff-only` sync and every graph write through the main checkout refuse to run
+# against a dirty tree — so the whole fleet stalled while every health probe
+# read green. Nothing watched it, because every probe classified sessions on
+# `state: done` alone and this session was in neither `done` nor `working`.
+#
+# A CONJUNCTION, DELIBERATELY:
+#   finding  <=>  (the main checkout's tree is dirty OR has unpushed commits)
+#                 AND (>=1 registered session whose cwd IS the main checkout is
+#                      not working/busy and has been idle >= the grace)
+# Why not the session alone: an interactive human session started in the repo
+# root registers with cwd == the main checkout and sits idle for hours as a
+# matter of course. Alarming on that would mint a graph node against ordinary
+# human use and train the reader to ignore this kind. The HARM is the shared
+# tree being unusable; the session is the ATTRIBUTION. Together they are exactly
+# the incident and nothing else.
+#
+# THIS PREDICATE ACTS ON NOTHING. It does not reap, kill, park or otherwise
+# touch the session — `state: done` is the discriminator for REAPING, and this
+# predicate deliberately does not extend that set. It surfaces, and a human
+# decides. The recommended first act is READING THE SESSION'S TRANSCRIPT: a
+# session stopped on an error holds the only record of why it died, and a blind
+# removal destroys it.
+#
+# FAIL DIRECTION, same as predicate 5 and for the same reason: an unreadable
+# daemon or an unreadable tree is `unknown`, NEVER `clear`. A `clear` here does
+# not merely stay silent — dispatch_predicate sends `--resolve --kind
+# main-checkout-held`, closing an already-open alarm node. So the tree is read
+# THREE-WAY (clean / dirty / unreadable), each git command's status captured
+# separately, mirroring lib-worktree-residue.sh:185. worktree_in_sync
+# (lib-worktree-in-sync.sh:38-78) is the canonical definition of "clean AND zero
+# unpushed" and is the precedent for WHAT to check, but it is deliberately not
+# CALLED here: it collapses "git failed" into the same non-zero return as
+# "dirty", which is the wrong fail direction for an alarm.
+#
+# WHICH SESSION VIEW: claude_agents_list_sessions_in_cwd_all reads the
+# REGISTERED view (`claude agents --json --all`), so the readability gate is
+# SNAPSHOT_ALL_OK, not SNAPSHOT_OK — see predicate 5's FAIL DIRECTION note. That
+# function queries `--all` DIRECTLY rather than through the pre-captured
+# DISPATCH_AGENTS_SNAPSHOT_ALL variable, but SNAPSHOT_ALL_OK is still the
+# correct gate: it certifies that the same underlying view answered this pass,
+# which is the bit that decides whether a "no sessions here" read can be
+# trusted.
+#
+# Idle age comes from _standdown_session_idle_s (lib-standdown-recheck.sh:321).
+# That helper's own comment records that it is already triplicated (copies at
+# lib-frozen-session-park.sh:495-529 and :1069-1094) and that extraction is a
+# follow-up — so this predicate CALLS it rather than writing a fourth copy. It
+# returns rc 1 with no output on no match, which is UNKNOWN: such a row can be
+# judged neither way, so it contributes to neither the finding nor the clear,
+# and if it is the ONLY candidate the verdict is `unknown`.
+#
+# Not quiet under pause — see the PAUSE block in the header.
+V_MAIN="unknown"; D_MAIN=""; B_MAIN=""
+MAIN_HELD_COUNT=0
+MAIN_HELD_IDENTS=""   # identity: one `<name>:<state>` per line
+MAIN_HELD_READINGS="" # reading: the same sessions with ids and idle ages
+MAIN_ROOT="$HOLD_ROOT"
+# Guarded source, dispatch-tick's idiom (dispatch-tick:354, 388, 406, 531, 578):
+# source only when the function is absent, verify it arrived, and on failure log
+# loudly and degrade THIS predicate to `unknown`. Nothing here aborts the pass.
+if ! declare -f _standdown_session_idle_s >/dev/null 2>&1; then
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/lib-standdown-recheck.sh" 2>/dev/null
+fi
+if [[ -z "$MAIN_ROOT" ]]; then
+  D_MAIN="repo root unresolvable (no worktree has main checked out and DISPATCH_GRAPH_MAIN_WORKTREE is unset) — the shared main checkout could not be inspected"
+elif ! declare -f _standdown_session_idle_s >/dev/null 2>&1; then
+  log "lib-standdown-recheck.sh failed to load; main-checkout-held session idle age is unmeasurable this pass"
+  D_MAIN="lib-standdown-recheck.sh failed to load, so _standdown_session_idle_s is unavailable — how long a session has been sitting in the main checkout is unmeasurable this pass"
+  B_MAIN="lib-standdown-recheck.sh failed to load, so session idle age in the main checkout is unmeasurable"
+elif [[ "$SNAPSHOT_ALL_OK" -ne 1 ]]; then
+  # Same gate and same reasoning as predicate 5: the lister reads the REGISTERED
+  # view, and an unreadable registered view would emit zero rows — which reads
+  # identically to "nobody is sitting in the main checkout" and would RESOLVE an
+  # open alarm node.
+  D_MAIN="the machine-wide claude agents daemon snapshot (registered view, 'claude agents --json --all') could not be captured this pass — whether a stuck session is sitting in the main checkout is unreadable, and an unreadable session view must NOT be folded into 'nobody is there' here (that would suppress this alarm)"
+else
+  # THREE-WAY tree read. Each git command's status is captured separately; a
+  # FAILED command is `unknown`, never `clear` and never `finding`.
+  MAIN_TREE_OK=1
+  MAIN_TREE_FAIL=""
+  MAIN_PORCELAIN=""
+  MAIN_UNPUSHED=""
+  if ! MAIN_PORCELAIN=$(git -C "$MAIN_ROOT" status --porcelain --untracked-files=no 2>/dev/null); then
+    MAIN_TREE_OK=0
+    MAIN_TREE_FAIL="git status --porcelain --untracked-files=no failed"
+  elif ! MAIN_UNPUSHED=$(git -C "$MAIN_ROOT" rev-list --count HEAD --not --remotes 2>/dev/null) \
+       || [[ ! "$MAIN_UNPUSHED" =~ ^[0-9]+$ ]]; then
+    MAIN_TREE_OK=0
+    MAIN_TREE_FAIL="git rev-list --count HEAD --not --remotes failed or returned a non-numeric count"
+  fi
+  MAIN_DIRTY_COUNT=0
+  [[ -n "${MAIN_PORCELAIN//[[:space:]]/}" ]] && MAIN_DIRTY_COUNT=$(grep -c . <<<"$MAIN_PORCELAIN")
+  if [[ "$MAIN_TREE_OK" -ne 1 ]]; then
+    D_MAIN="the shared main checkout's tree state could not be read at $MAIN_ROOT ($MAIN_TREE_FAIL) — whether the tree is being held is unreadable, and an unreadable tree is NOT a clean tree"
+    B_MAIN="the shared main checkout's tree state could not be read at $MAIN_ROOT ($MAIN_TREE_FAIL)"
+  elif (( MAIN_DIRTY_COUNT == 0 && MAIN_UNPUSHED == 0 )); then
+    # THE FALSE-POSITIVE GUARD. An idle human session in the repo root is
+    # ordinary and must never alarm: with the shared tree clean and fully
+    # pushed, nothing is being held, whoever is sitting there.
+    V_MAIN="clear"
+    D_MAIN="the shared main checkout at $MAIN_ROOT is clean and fully pushed (0 modified tracked file(s), 0 unpushed commit(s)) — nothing is holding it"
+  else
+    MAIN_SESSIONS=""
+    if ! MAIN_SESSIONS=$(claude_agents_list_sessions_in_cwd_all "$MAIN_ROOT" 2>/dev/null); then
+      D_MAIN="the shared main checkout at $MAIN_ROOT is dirty/unpushed, but the registered session list for that cwd is UNREADABLE (claude_agents_list_sessions_in_cwd_all returned UNKNOWN) — a dirty tree with no attributable session is not a clear"
+      B_MAIN="the shared main checkout at $MAIN_ROOT is dirty/unpushed and the registered session list for that cwd is unreadable"
+    else
+      MAIN_IDLE_UNKNOWN=0
+      while IFS=$'\t' read -r M_SID M_JOBID M_NAME M_STATE M_STATUS; do
+        [[ -n "${M_SID}${M_NAME}${M_STATE}" ]] || continue
+        # Someone is ACTIVELY WORKING here — that is the normal way the shared
+        # tree goes dirty, and it is not an incident. `state` is the granular
+        # field the `--all` listing carries; `status` is the coarse sibling.
+        # Either saying "working" exonerates the row.
+        [[ "$M_STATE" == "working" || "$M_STATUS" == "busy" ]] && continue
+        if ! M_IDLE=$(_standdown_session_idle_s "$M_SID" "$NOW" 2>/dev/null) \
+           || [[ ! "$M_IDLE" =~ ^-?[0-9]+$ ]]; then
+          # UNKNOWN idle: this row can be judged neither way. It contributes to
+          # neither the finding nor the clear.
+          MAIN_IDLE_UNKNOWN=$(( MAIN_IDLE_UNKNOWN + 1 ))
+          continue
+        fi
+        # Grace, following lib-frozen-session-park.sh:495-529 exactly, INCLUDING
+        # its deliberate treatment of a negative (future-stamped) idle as
+        # `< grace`: observe, never act.
+        (( M_IDLE < MAIN_HELD_GRACE )) && continue
+        MAIN_HELD_COUNT=$(( MAIN_HELD_COUNT + 1 ))
+        MAIN_HELD_IDENTS+="${M_NAME:-<unnamed>}:${M_STATE:-<state?>}"$'\n'
+        MAIN_HELD_READINGS+="${M_NAME:-<unnamed>} (session ${M_SID:-<sid?>}, job ${M_JOBID:-<id?>}, state ${M_STATE:-<state?>}/${M_STATUS:-<status?>}, idle ${M_IDLE}s); "
+      done <<<"$MAIN_SESSIONS"
+      if (( MAIN_HELD_COUNT > 0 )); then
+        V_MAIN="finding"
+        D_MAIN="$MAIN_HELD_COUNT stuck session(s) sitting in the shared main checkout $MAIN_ROOT while it holds $MAIN_DIRTY_COUNT modified tracked file(s) and $MAIN_UNPUSHED unpushed commit(s): ${MAIN_HELD_READINGS%; }"
+        # IDENTITY ONLY. Session ids, idle ages and the porcelain/unpushed
+        # counts are READINGS — they move on every pass while the condition
+        # merely persists, and a body carrying them would push to origin/main
+        # once per 5-minute pass. Sorted so the same set of sessions always
+        # renders the same bytes regardless of registry ordering.
+        B_MAIN="a stuck session is holding the shared main checkout $MAIN_ROOT dirty or unpushed. Offending session(s) as <name>:<state>: $(printf '%s' "$MAIN_HELD_IDENTS" | sort | tr '\n' ';' | sed 's/;$//' | sed 's/;/; /g')"
+      elif (( MAIN_IDLE_UNKNOWN > 0 )); then
+        # Every candidate row's idle age was unmeasurable (no transcript, or an
+        # unreadable mtime). "I could not measure it" is not evidence the
+        # session is fine — and reporting clear here would resolve the alarm.
+        V_MAIN="unknown"
+        D_MAIN="the shared main checkout at $MAIN_ROOT is dirty/unpushed and $MAIN_IDLE_UNKNOWN candidate session(s) sit in it whose transcript idle age is UNMEASURABLE — no verdict is possible"
+        B_MAIN="the shared main checkout at $MAIN_ROOT is dirty/unpushed and the idle age of the session(s) sitting in it is unmeasurable"
+      else
+        V_MAIN="clear"
+        D_MAIN="the shared main checkout at $MAIN_ROOT is dirty/unpushed ($MAIN_DIRTY_COUNT modified tracked file(s), $MAIN_UNPUSHED unpushed commit(s)) but no session sitting in it is stuck past the ${MAIN_HELD_GRACE}s grace"
+      fi
+    fi
+  fi
+fi
+
 # =============================================================================
 # Reporting — runs ONCE, over the complete verdict set.
 # =============================================================================
@@ -703,6 +878,7 @@ B_DAEMON="${B_DAEMON:-$D_DAEMON}"
 B_BUSY="${B_BUSY:-$D_BUSY}"
 B_AUTOMERGE="${B_AUTOMERGE:-$D_AUTOMERGE}"
 B_HOLD="${B_HOLD:-$D_HOLD}"
+B_MAIN="${B_MAIN:-$D_MAIN}"
 
 FINDING_COUNT=0
 UNKNOWN_COUNT=0
@@ -721,6 +897,7 @@ note_verdict "$V_DAEMON"    "daemon-degraded: $B_DAEMON"
 note_verdict "$V_BUSY"      "busy-stall: $B_BUSY"
 note_verdict "$V_AUTOMERGE" "automerge-suppressed: $B_AUTOMERGE"
 note_verdict "$V_HOLD"      "unclaimed-hold: $B_HOLD"
+note_verdict "$V_MAIN"      "main-checkout-held: $B_MAIN"
 
 # An unreadable PAUSE state is itself an unreadable input — it must raise
 # watch-unknown even when all five predicates happened to read cleanly.
@@ -833,6 +1010,36 @@ Thresholds: DISPATCH_FLEET_WATCH_HOLD_MIN_AGE=${HOLD_MIN_AGE}s,
 DISPATCH_FLEET_WATCH_HOLD_TOP_K=${HOLD_TOP_K}
 Pause state: $PAUSE_STATE (unclaimed holds are evaluated regardless of pause)"
 
+# Identity only: the offending `<name>:<state>` session pairs, the main checkout
+# path, and the threshold NAME. NOT the sessionIds, NOT the idle ages, NOT the
+# porcelain or unpushed counts — those change on every pass while the condition
+# merely persists, and each change is a push to origin/main. The operator needs
+# the sessionId to act, so the body says where to find it, exactly as the
+# daemon-degraded body does for its raw liveness JSON.
+dispatch_predicate "$V_MAIN" main-checkout-held \
+  "A stuck session is holding the shared main checkout dirty" \
+  "$B_MAIN
+
+Blast radius: the main checkout's tree is shared fleet-wide. While it is dirty
+or carries unpushed commits, dispatch-select-tick's 'git merge --ff-only
+origin/main' sync refuses to run and every graph write committed through that
+checkout fails — so the fleet stalls on work that has nothing to do with the
+stuck session.
+
+RECOMMENDED FIRST ACT: READ THE SESSION'S TRANSCRIPT. A session sitting in a
+non-working state may hold the only record of why it stopped (an API error, a
+denial, a crash mid-write) and may hold uncommitted work in that tree. Do not
+remove it blind. This alarm surfaces the condition and takes no action on the
+session itself: it does not reap, kill or park anything.
+
+The offending session ids and their idle ages are in this pass's journald
+output, not here: they change every pass and would push a commit per pass.
+
+Threshold: DISPATCH_FLEET_WATCH_MAIN_HELD_GRACE_S=${MAIN_HELD_GRACE}s
+Pause state: $PAUSE_STATE (a held main checkout is evaluated regardless of
+pause — the incident that motivated this predicate happened during a correct
+pause)"
+
 # THE most important single behavior in this script: any unknown, for any
 # reason, is announced. A watcher that cannot read its inputs must say so
 # loudly rather than emit a false all-clear.
@@ -864,6 +1071,8 @@ if [[ "$JSON" -eq 1 ]]; then
     --arg v_automerge "$V_AUTOMERGE" --arg d_automerge "$D_AUTOMERGE" \
     --arg v_hold "$V_HOLD" --arg d_hold "$D_HOLD" \
     --argjson hold_count "$HOLD_COUNT" \
+    --arg v_main "$V_MAIN" --arg d_main "$D_MAIN" \
+    --argjson main_held_count "$MAIN_HELD_COUNT" \
     --arg busy_count "${BUSY_COUNT:-}" \
     --arg busy_zero_since "${BUSY_SINCE_AFTER:-}" \
     --arg suppression_since "${SUPPRESSION_SINCE_AFTER:-}" \
@@ -888,7 +1097,9 @@ if [[ "$JSON" -eq 1 ]]; then
                                    suppression_since: ($suppression_since | blank_null | if . == null then null else tonumber end),
                                    open_main_red_nodes: ($red_nodes | blank_null | if . == null then [] else split("\n") end) },
         "unclaimed-hold":        { verdict: $v_hold,      detail: $d_hold,
-                                   candidate_count: $hold_count }
+                                   candidate_count: $hold_count },
+        "main-checkout-held":    { verdict: $v_main,      detail: $d_main,
+                                   held_session_count: $main_held_count }
       },
       unknown_reasons: ($unknown_reasons | blank_null)
     }'
@@ -901,6 +1112,7 @@ printf '  daemon-degraded:      %-8s %s%s\n' "$V_DAEMON"    "$D_DAEMON"    "$PAU
 printf '  busy-stall:           %-8s %s%s\n' "$V_BUSY"      "$D_BUSY"      "$PAUSE_TAG"
 printf '  automerge-suppressed: %-8s %s%s\n' "$V_AUTOMERGE" "$D_AUTOMERGE" "$PAUSE_TAG"
 printf '  unclaimed-hold:       %-8s %s%s\n' "$V_HOLD"      "$D_HOLD"      "$PAUSE_TAG"
+printf '  main-checkout-held:   %-8s %s%s\n' "$V_MAIN"      "$D_MAIN"      "$PAUSE_TAG"
 
 # Never print a bare `ok` when anything is unknown — that is the false
 # all-clear this watcher exists to prevent.

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-select-tick
@@ -27,8 +27,12 @@
 #   sync-failed      git fetch / merge --ff-only failed on `main` and the repair
 #                    attempt-cap is not yet hit; lock released, reseed armed.
 #                    dispatch-tick reads this to spawn the deduped repair job.
-#   sync-repair-pending   a live sync-repair job is mutating the main worktree;
-#                    deferred. lock released; reseed armed.
+#   sync-repair-pending   a session is genuinely holding the main worktree —
+#                    actively working there, or sitting there for less than
+#                    DISPATCH_MAIN_CHECKOUT_STUCK_GRACE_S (default 1800s) —
+#                    so the tick defers. BOUNDED: past that grace the tick
+#                    stops deferring and falls through to the fetch/merge
+#                    probe (see Decision A). lock released; reseed armed.
 #   sync-broken      local main cannot ff-merge origin/main and the repair
 #                    attempt-cap is hit (or the latch is already open); the
 #                    repo-health durable record is the latch. lock released;
@@ -71,6 +75,13 @@
 # releases before it emits; nothing holds the lock past select-tick. The graph
 # release is safe because the per-node reservation markers (written before the
 # emit) are the durable claim a concurrent tick's graph selector already skips on.
+#
+# Env: DISPATCH_MAIN_CHECKOUT_STUCK_GRACE_S (default 1800) — how long a
+# non-working session may sit in the shared main checkout before Decision A
+# stops deferring to it. 1800s is 2x DISPATCH_FROZEN_SESSION_GRACE_S's 900
+# (lib-frozen-session-park.sh): a legitimate /commit-merge-push run in the main
+# checkout can idle on a slow push or a CI wait, and the cost of waiting an
+# extra 30 minutes is far below the cost of a spurious `sync-broken` latch.
 #
 # Requires `dangerouslyDisableSandbox: true` — sub-scripts write tmp state, call
 # `gh`, and query the local Claude daemon over a Unix socket. The `--wait` lock
@@ -299,7 +310,7 @@ if [[ "$BRANCH" == "main" ]]; then
   # shellcheck source=/dev/null
   source "$SCRIPT_DIR/lib.sh"            # sync_repair_* + resolve_project_root
   # shellcheck source=/dev/null
-  source "$SCRIPT_DIR/lib-claude-agents.sh"   # claude_sessions_under
+  source "$SCRIPT_DIR/lib-claude-agents.sh"   # claude_agents_list_sessions_in_cwd_all
 
   # Resolve the main worktree the same way dispatch-tick does: an explicit
   # DISPATCH_TICK_MAIN_WORKTREE override is authoritative and bypasses the git
@@ -325,22 +336,111 @@ if [[ "$BRANCH" == "main" ]]; then
     exit 2
   }
 
-  # Decision A — defer while a live sync-repair session is mutating the main
-  # worktree, but fail OPEN on a daemon UNKNOWN (rc 1). claude_sessions_under
-  # returns rc 0 only on a definite list; a row whose name is `sync-repair` and
-  # whose status is not `stopped` means a repair is live: release, arm the
-  # reseed, and defer without bumping the counter or touching the tree. On rc 1
-  # (daemon down) we fall through to the merge — matching the concurrency gate's
-  # fail-open philosophy; the dispatch-spawn-job dedup itself fails closed on
-  # UNKNOWN, so no duplicate repair is spawned and git's index.lock contains the
-  # rare race.
-  if sessions=$(claude_sessions_under "$MAIN_WORKTREE"); then
-    if awk -F'\t' '$4=="sync-repair" && $3!="stopped"{f=1} END{exit !f}' <<<"$sessions"; then
+  # Decision A — defer while a session is genuinely holding the main worktree,
+  # but BOUNDED, and fail OPEN on a daemon UNKNOWN (rc 1).
+  #
+  # WHY THIS IS NOT THE OLD NAME-AND-STATUS TEST. The former rule deferred
+  # whenever a row named `sync-repair` had a status other than `stopped`. That
+  # defer was UNBOUNDED in two independent ways, and a 3-day incident rode both:
+  #   1. It read the ACTIVE view (claude_sessions_under), so a `stopped`/`done`
+  #      session still sitting in the main checkout was INVISIBLE to it.
+  #   2. A `blocked` session projects its coarse status as `idle`, never
+  #      `stopped` — so `$3!="stopped"` read it as "still live" FOREVER.
+  # Either way the tick emitted `sync-repair-pending` on every tick, never
+  # reached the merge probe, and never bumped sync_repair_*, which made the
+  # 3-attempt `sync-broken` escalation cap structurally unreachable.
+  #
+  # The rule now reads the REGISTERED view
+  # (claude_agents_list_sessions_in_cwd_all, exact-cwd match, no keyspace
+  # filter — a strict superset of the ACTIVE view, so a stopped/done holder is
+  # visible) and defers only while a session is genuinely holding the tree:
+  #   - state `working` (or coarse status `busy`) → actively mutating: defer.
+  #   - otherwise, transcript idle age below the grace → still plausibly alive:
+  #     defer. An UNMEASURABLE idle (rc 1: no transcript, or the helper failed
+  #     to load) folds to DEFER — fail-safe, per _standdown_session_idle_s's
+  #     documented "caller must keep" contract.
+  #   - beyond the grace → STOP DEFERRING. Fall through to the fetch/merge
+  #     probe below, unchanged.
+  #
+  # WHY FALLING THROUGH IS THE CORRECT ESCALATION, NOT A HAZARD:
+  #   - `git merge --ff-only` on a dirty tree FAILS; it corrupts nothing.
+  #   - A failed merge bumps sync_repair_bump_attempts (the existing failure
+  #     branch below) and emits `sync-failed`.
+  #   - dispatch-tick reads `sync-failed` and calls `dispatch-spawn-job --name
+  #     sync-repair`, whose dedup sees the existing live `sync-repair` name and
+  #     returns `deduped` — no duplicate repair session is spawned.
+  #   - After 3 such ticks the existing attempt cap below fires: `repo-health
+  #     --set-sync-broken --reason merge-failed` latches durably and the tick
+  #     emits `sync-broken`. That is the escalation the old rule could never
+  #     reach, and reaching it is the whole point of this bound.
+  # This decides only whether the TICK WAITS on the session. It never reaps,
+  # kills or parks it — `state: done` is the discriminator for REAPING, not for
+  # HEALTH, and the stuck session's own disposition belongs to the sweeps.
+  #
+  # FAIL OPEN on rc 1 (daemon unqueryable): fall through to the merge, matching
+  # the concurrency gate's fail-open philosophy — dispatch-spawn-job's own dedup
+  # fails CLOSED on UNKNOWN, so no duplicate repair is spawned, and git's
+  # index.lock contains the rare race.
+  MAIN_STUCK_GRACE_S="${DISPATCH_MAIN_CHECKOUT_STUCK_GRACE_S:-1800}"
+  [[ "$MAIN_STUCK_GRACE_S" =~ ^[0-9]+$ ]] || MAIN_STUCK_GRACE_S=1800
+  # Guarded source, dispatch-tick's idiom: source only when the function is
+  # absent, verify it arrived, and on failure degrade loudly (here: to the
+  # fail-safe defer) rather than aborting the script.
+  if ! declare -f _standdown_session_idle_s >/dev/null 2>&1; then
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/lib-standdown-recheck.sh" 2>/dev/null
+  fi
+  MAIN_NOW=$(date +%s)
+  if MAIN_SESSIONS=$(claude_agents_list_sessions_in_cwd_all "$MAIN_WORKTREE"); then
+    MAIN_DEFER_REASON=""
+    MAIN_STUCK_ATTR=""
+    while IFS=$'\t' read -r M_SID M_JOBID M_NAME M_STATE M_STATUS; do
+      [[ -n "${M_SID}${M_NAME}${M_STATE}" ]] || continue
+      # `state` is the granular field the registered listing carries; `status`
+      # is the coarse busy/idle/stopped sibling. Either saying "working"/"busy"
+      # means the session is legitimately mutating the tree — wait for it.
+      if [[ "$M_STATE" == "working" || "$M_STATUS" == "busy" ]]; then
+        MAIN_DEFER_REASON="main-checkout-active:${M_NAME:-<unnamed>}:${M_STATE:-<state?>}"
+        break
+      fi
+      if ! declare -f _standdown_session_idle_s >/dev/null 2>&1; then
+        echo "dispatch-select-tick: lib-standdown-recheck.sh failed to load; idle age of the session in the main checkout is unmeasurable — deferring (fail-safe)" >&2
+        MAIN_DEFER_REASON="main-checkout-idle-unmeasurable:${M_NAME:-<unnamed>}:${M_STATE:-<state?>}"
+        break
+      fi
+      if ! M_IDLE=$(_standdown_session_idle_s "$M_SID" "$MAIN_NOW" 2>/dev/null) \
+         || [[ ! "$M_IDLE" =~ ^-?[0-9]+$ ]]; then
+        # UNKNOWN idle (no transcript / unreadable mtime): the helper's
+        # contract is "caller must keep". Defer.
+        MAIN_DEFER_REASON="main-checkout-idle-unknown:${M_NAME:-<unnamed>}:${M_STATE:-<state?>}"
+        break
+      fi
+      # Grace, following lib-frozen-session-park.sh:495-529 exactly, INCLUDING
+      # its deliberate treatment of a negative (future-stamped) idle as
+      # `< grace`: observe, never act.
+      if (( M_IDLE < MAIN_STUCK_GRACE_S )); then
+        MAIN_DEFER_REASON="main-checkout-within-grace:${M_NAME:-<unnamed>}:${M_STATE:-<state?>}"
+        break
+      fi
+      # Beyond the grace: record the attribution and DO NOT defer for this row.
+      MAIN_STUCK_ATTR="${MAIN_STUCK_ATTR:+$MAIN_STUCK_ATTR,}${M_NAME:-<unnamed>}:${M_STATE:-<state?>}"
+      # stderr names the sessionId deliberately: the graph-node body the
+      # main-checkout-held alarm writes omits it (it is a reading, not an
+      # identity), so this line is where a debugger recovers it.
+      echo "dispatch-select-tick: ${M_NAME:-<unnamed>} (session ${M_SID:-<sid?>}, job ${M_JOBID:-<id?>}, state ${M_STATE:-<state?>}/${M_STATUS:-<status?>}) has sat in the main checkout $MAIN_WORKTREE for ${M_IDLE}s >= grace ${MAIN_STUCK_GRACE_S}s; declining to defer and falling through to the fetch/merge probe" >&2
+    done <<<"$MAIN_SESSIONS"
+    if [[ -n "$MAIN_DEFER_REASON" ]]; then
       release_lock
       "$SCRIPT_DIR/dispatch-schedule-reseed" 1>&2 || true
       DLOG_DISPOSITION="sync-repair-pending"
+      DLOG_SKIP_REASON="$MAIN_DEFER_REASON"
       echo "sync-repair-pending"
       exit 0
+    fi
+    # Attribute the DECLINED defer in the routing decision log, so the record
+    # says WHICH session the tick stopped waiting on and in what state.
+    if [[ -n "$MAIN_STUCK_ATTR" ]]; then
+      DLOG_SKIP_REASON="main-checkout-stuck:$MAIN_STUCK_ATTR"
     fi
   fi
 

--- a/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
+++ b/.claude/skills/dispatch-propagate/scripts/dispatch-sweep
@@ -589,4 +589,48 @@ else
   log "HELD_FOR_DEBUG_COUNT: n=UNKNOWN (daemon unqueryable)"
 fi
 
+# ---- Session state census (hygiene/observability metric) --------------------
+# Log every registered session's state via claude_agents_count_by_state, so a
+# session parked in a non-terminal, non-`working` state (e.g. `blocked`) is
+# visible in this log instead of silently falling into an unemitted remainder
+# — see tactic-blocked-session-invisible-to-census. This is not a
+# control-flow signal — nothing downstream acts on it. UNKNOWN is logged
+# distinctly from an empty census, same convention as HELD_FOR_DEBUG_COUNT
+# above: "daemon unqueryable" and "zero sessions" are different facts and
+# must not be conflated.
+#
+# The sandbox caveat above HELD_FOR_DEBUG_COUNT applies here too: under a
+# sandboxed Bash call the daemon's Unix socket is unreachable and `claude
+# agents --json` returns `[]` with exit 0, which reads here as a definite
+# empty census — the UNKNOWN branch cannot catch it because nothing failed.
+# Read an empty census from a sandboxed run as "not measured".
+#
+# claude_agents_count_by_state emits two interleaved views, distinguished by
+# column count: 2-column `state<TAB>count` (overall, no keyspace filter) and
+# 3-column `keyspace<TAB>state<TAB>count` (per-keyspace, plus a `terminal`
+# roll-up row per keyspace). Reading 3 fields off a 2-column line leaves the
+# third variable empty, which is exactly what distinguishes the two shapes
+# below — no upfront column-counting needed.
+if census_out=$(claude_agents_count_by_state); then
+  census_rc=0
+else
+  census_rc=$?
+fi
+if [[ "$census_rc" -eq 0 ]]; then
+  if [[ -z "$census_out" ]]; then
+    log "SESSION_STATE_CENSUS: none (empty registry)"
+  else
+    while IFS=$'\t' read -r census_c1 census_c2 census_c3; do
+      [[ -z "$census_c1" ]] && continue
+      if [[ -n "$census_c3" ]]; then
+        log "SESSION_STATE_CENSUS: keyspace=$census_c1 state=$census_c2 n=$census_c3"
+      else
+        log "SESSION_STATE_CENSUS: state=$census_c1 n=$census_c2"
+      fi
+    done <<<"$census_out"
+  fi
+else
+  log "SESSION_STATE_CENSUS: UNKNOWN (daemon unqueryable)"
+fi
+
 exit 0

--- a/.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh
+++ b/.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh
@@ -1565,6 +1565,188 @@ if [[ -z "${_LIB_CLAUDE_AGENTS_LOADED:-}" ]]; then
     return 0
   }
 
+  # claude_agents_list_sessions_in_cwd_all <path> — emit EVERY registered
+  # session whose cwd is exactly <path>, as
+  # sessionId<TAB>id<TAB>name<TAB>state<TAB>status TSV.
+  #
+  # NO KEYSPACE FILTER, deliberately. Every other lister in this file narrows to
+  # the worker keyspace (`^[0-9]+-|^tactic-|^strategy-`), which makes whole
+  # classes of session invisible: `sync-repair` matches none of those three
+  # prefixes, and neither do `diagnose-main`, jit job names, `dispatch-*`
+  # routers, or an unnamed human interactive session. A `sync-repair` session
+  # sitting in the main checkout is exactly the case that motivated this
+  # function, so it must not be filtered out. Callers that want only workers
+  # filter the emitted rows themselves.
+  #
+  # The cwd match is EXACT string equality, never a prefix or substring test: a
+  # prefix test rooted at the project root would match every worktree under
+  # `.claude/worktrees/`, i.e. the entire fleet, instead of the one checkout the
+  # caller asked about.
+  #
+  # `.id` is the registry's own job id, and it is a DISTINCT value from the
+  # sessionId — not a prefix of it. The managed-job dir (`~/.claude/jobs/<id>`)
+  # is named by `.id`, while the transcript file is named by `.sessionId`; a
+  # RESUMED session keeps its original `.id` while its `.sessionId` changes.
+  # Consumers that need the job dir MUST key on that column, never on
+  # `${sessionId%%-*}`. A row with no `.id` (or no `.state` / no `.status`)
+  # emits an empty column (`@tsv` renders null as ""), which callers must treat
+  # as "absent", never as a match.
+  #
+  # Both `state` and `status` are projected raw and unresolved — this function
+  # classifies nothing. `state` is the granular field the `--all` listing
+  # carries (working/blocked/done/…); `status` is the coarse busy/idle/stopped.
+  # A terminal row is `{"state":"done"}` with NO `.status` key at all.
+  #
+  # Queries `claude agents --json --all` DIRECTLY, bypassing
+  # `_claude_agents_raw` and the `--cwd` server-side filter — the tick snapshot
+  # (DISPATCH_AGENTS_SNAPSHOT) is captured without `--all` and so lacks the
+  # terminal-state rows this function exists to find; reading the snapshot would
+  # silently hide them. `claude_agents_count_held_for_debug` and
+  # `claude_agents_list_terminal_workers` already carry this same note.
+  #     return 0 — daemon queried successfully. Stdout carries zero or more TSV
+  #               lines. Zero matches (or a `[]` registry) → return 0 with empty
+  #               stdout: a definite "no sessions in that cwd", NOT a failure.
+  #     return 1 — UNKNOWN. `claude` missing, non-zero exit, whitespace-only
+  #               stdout, non-array JSON, or a missing <path> argument. Stdout
+  #               is empty. Callers MUST treat UNKNOWN as "cannot reconcile",
+  #               never as "none".
+  #
+  # Sandbox: reaches the local Claude daemon over a Unix socket. Callers MUST
+  # run this with `dangerouslyDisableSandbox: true` — a sandboxed call yields
+  # `[]`, which reads here as a definite "no sessions". See
+  # `.claude/rules/sandbox.md`.
+  claude_agents_list_sessions_in_cwd_all() {
+    local pth="${1:-}"
+    if [[ -z "$pth" ]]; then
+      printf 'lib-claude-agents: claude_agents_list_sessions_in_cwd_all requires a <path> argument\n' >&2
+      return 1
+    fi
+
+    # --all so terminal (done/error/etc) rows are visible; queried DIRECTLY
+    # (not via _claude_agents_raw) because the snapshot lacks --all and
+    # therefore lacks the very rows this function lists. 2>/dev/null drops
+    # daemon noise; only the exit code and well-formed JSON on stdout are
+    # trusted.
+    local out
+    if ! out=$("${CLAUDE_AGENTS_CMD:-claude}" agents --json --all 2>/dev/null); then
+      return 1
+    fi
+    if [[ -z "${out//[[:space:]]/}" ]]; then
+      return 1
+    fi
+
+    # One jq pass validates the array shape, filters on an EXACT .cwd match,
+    # and projects the TSV. Non-array input errors out and the result is
+    # UNKNOWN.
+    local lines
+    if ! lines=$(jq -r --arg cwd "$pth" '
+      if type == "array"
+      then .[]
+        | select(.cwd == $cwd)
+        | [.sessionId, .id, .name, .state, .status] | @tsv
+      else error("claude agents --json output is not a JSON array")
+      end' <<<"$out" 2>/dev/null); then
+      return 1
+    fi
+    # `[]` or no matches → empty $lines → emit nothing, still return 0.
+    if [[ -n "$lines" ]]; then
+      printf '%s\n' "$lines"
+    fi
+    return 0
+  }
+
+  # claude_agents_count_by_state — census EVERY registered session by state, so
+  # a session parked in a non-terminal, non-`working` state (the `blocked` case
+  # that motivated this) is visible to health probes instead of falling into an
+  # unemitted remainder. Two views are emitted, in this order:
+  #
+  #   1. Overall — one `state<TAB>count` line per distinct state, over every
+  #      registered session with NO keyspace filter, sorted by state.
+  #   2. Keyspace-partitioned — one `<keyspace><TAB><state><TAB><count>` line,
+  #      where <keyspace> is `worker` (name matches
+  #      `^[0-9]+-|^tactic-|^strategy-`) or `other` (EVERYTHING else: `dispatch-*`
+  #      routers, `sync-repair`, jit/diagnose jobs, unnamed and human sessions),
+  #      plus one `<keyspace><TAB>terminal<TAB><count>` roll-up line per
+  #      keyspace present. Sorted as text, so a keyspace's rows are contiguous.
+  #
+  # The two views are distinguishable by column count (2 vs 3). The partition is
+  # total: every session lands in `worker` or `other`, so the keyspace counts
+  # always sum to the overall counts.
+  #
+  # The `terminal` roll-up uses the single shared `terminal_states` jq `def`
+  # (CLAUDE_AGENTS_TERMINAL_STATES_JQ, defined once at the top of this file) —
+  # the nine states are deliberately NOT re-listed here, since a second copy
+  # could drift from the one the counter, lister, and occupancy classifier
+  # share. Note that `blocked` is NOT in that enumeration and must not be added:
+  # two other consumers depend on `blocked` reading as a LIVE claim. A blocked
+  # session therefore shows up in its own `blocked` state row, never in the
+  # `terminal` roll-up. (A future daemon state literally named `terminal` would
+  # collide with the roll-up key; none exists today.)
+  #
+  # State key is `(.state // .status) // "<none>"` — the same resolution
+  # `claude_agents_count_held_for_debug` uses (the granular `.state` the `--all`
+  # listing carries, falling back to the coarse `.status`), with a literal
+  # `<none>` bucket for a row carrying neither, so such a row is still counted
+  # somewhere rather than vanishing.
+  #
+  # Queries `claude agents --json --all` DIRECTLY, bypassing
+  # `_claude_agents_raw`, for the same reason as
+  # `claude_agents_list_sessions_in_cwd_all` above: the snapshot lacks `--all`
+  # and therefore lacks the terminal rows. Exactly ONE daemon round-trip per
+  # call.
+  #     return 0 — daemon queried successfully. Stdout carries the census lines;
+  #               a `[]` registry → return 0 with empty stdout (a definite "no
+  #               sessions", NOT a failure).
+  #     return 1 — UNKNOWN. `claude` missing, non-zero exit, whitespace-only
+  #               stdout, or non-array JSON. Stdout is empty. Callers MUST treat
+  #               UNKNOWN as "cannot reconcile", never as "none".
+  #
+  # Sandbox: same Unix-socket caveat as above — run with
+  # `dangerouslyDisableSandbox: true`.
+  claude_agents_count_by_state() {
+    # --all so terminal (done/error/etc) rows are visible; queried DIRECTLY
+    # (not via _claude_agents_raw) because the snapshot lacks --all and
+    # therefore lacks the very rows this census must include.
+    local out
+    if ! out=$("${CLAUDE_AGENTS_CMD:-claude}" agents --json --all 2>/dev/null); then
+      return 1
+    fi
+    if [[ -z "${out//[[:space:]]/}" ]]; then
+      return 1
+    fi
+
+    local lines
+    if ! lines=$(jq -r "$CLAUDE_AGENTS_TERMINAL_STATES_JQ"'
+      if type == "array"
+      then
+        [ .[]
+          | { ks: (if (.name | type == "string"
+                       and test("^[0-9]+-|^tactic-|^strategy-"))
+                   then "worker" else "other" end),
+              st: ((((.state // .status) // "<none>") | tostring)) } ] as $rows
+        | ( $rows | group_by(.st)
+            | map([ .[0].st, (length | tostring) ] | join("\t")) )
+          + ( $rows | group_by(.ks)
+              | map( . as $g
+                     | ( $g | group_by(.st)
+                         | map([ $g[0].ks, .[0].st, (length | tostring) ] | join("\t")) )
+                       + [ [ $g[0].ks, "terminal",
+                             ( $g
+                               | map(select(.st as $s | terminal_states | index($s)))
+                               | length | tostring ) ] | join("\t") ] )
+              | (add // []) | sort )
+        | .[]
+      else error("claude agents --json output is not a JSON array")
+      end' <<<"$out" 2>/dev/null); then
+      return 1
+    fi
+    # `[]` → no rows → emit nothing, still return 0.
+    if [[ -n "$lines" ]]; then
+      printf '%s\n' "$lines"
+    fi
+    return 0
+  }
+
   # verify_agent_registered_under <agent-name> <cwd> — bounded-retry verify
   # that closes the async-registration race after `claude --bg` returns.
   # See the header comment for the return-code contract.

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-fleet-alarm.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-fleet-alarm.sh
@@ -589,6 +589,66 @@ git -C "$FR" update-ref refs/remotes/origin/main "$SAVED_ORIGIN_MAIN"
 BARE_RESTORE_HITS=$(grep -cE '^[[:space:]]*restore_from_blob ' "$SUT" || true)
 assert_eq "(20) no unchecked restore_from_blob call in $SUT" "0" "${BARE_RESTORE_HITS:-0}"
 
+# --- (21) kind acceptance: main-checkout-held --------------------------------
+# The KINDS enum is closed and the anchored id regex is BUILT from it, so a new
+# kind is only genuinely accepted if it survives the whole round trip: mint,
+# refresh with a differing body, resolve. Case (1) already pins that an unknown
+# kind exits 64; the near-miss below pins that the new entry did not widen the
+# enum into a prefix match.
+git -C "$FR" checkout -- intentions
+git -C "$FR" update-ref refs/remotes/origin/main HEAD
+BODY21="$WORK/body21.md"
+printf 'A stuck session is holding the shared main checkout.\n' > "$BODY21"
+run_alarm STUB_STATE=absent STUB_GC_LAND=1 -- \
+  --kind main-checkout-held --statement 'A stuck session is holding the shared main checkout dirty' \
+  --body-file "$BODY21"
+assert_eq "(21) mint exits 0" "0" "$RC"
+MINT21="$FR/intentions/tactic-fleet-alarm-main-checkout-held.md"
+assert_contains "(21) graph-commit got the alarm id" "tactic-fleet-alarm-main-checkout-held" \
+  "$(log_lines graph-commit.log)"
+assert_eq "(21) node id" "tactic-fleet-alarm-main-checkout-held" \
+  "$(jq -r .id "$LOG/write-node-input.json")"
+assert_eq "(21) body spliced over the placeholder" \
+  "A stuck session is holding the shared main checkout." \
+  "$(awk 'p; /^---$/{c++; if(c==2) p=1}' "$MINT21")"
+
+# Re-detection with an IDENTICAL body must not churn a commit...
+run_alarm STUB_STATE=open STUB_GC_LAND=1 -- \
+  --kind main-checkout-held --statement 'A stuck session is holding the shared main checkout dirty' \
+  --body-file "$BODY21"
+assert_eq "(21) identical-body re-detection exits 0" "0" "$RC"
+assert_eq "(21) NO graph-commit on an identical body" "" "$(log_lines graph-commit.log)"
+
+# ...and a DIFFERING body refreshes through the --base path.
+BODY21B="$WORK/body21b.md"
+printf 'A different set of offending sessions.\n' > "$BODY21B"
+run_alarm STUB_STATE=open STUB_GC_LAND=1 -- \
+  --kind main-checkout-held --statement 'A stuck session is holding the shared main checkout dirty' \
+  --body-file "$BODY21B"
+assert_eq "(21) differing-body refresh exits 0" "0" "$RC"
+assert_contains "(21) refresh ran with --base" "--base" "$(log_lines graph-commit.log)"
+assert_eq "(21) refreshed body landed on disk" "A different set of offending sessions." \
+  "$(awk 'p; /^---$/{c++; if(c==2) p=1}' "$MINT21")"
+
+# ...and the condition resolves to phase done.
+git -C "$FR" checkout -- intentions
+git -C "$FR" update-ref refs/remotes/origin/main HEAD
+run_alarm STUB_STATE=open STUB_GC_LAND=1 \
+  STUB_NODE_JSON='{"id":"tactic-fleet-alarm-main-checkout-held","phase":"implement","execution":null}' -- \
+  --resolve --kind main-checkout-held
+assert_eq "(21) resolve exits 0" "0" "$RC"
+assert_eq "(21) write-node got phase done" "done" "$(jq -r .phase "$LOG/write-node-input.json")"
+assert_contains "(21) resolve message" "graph: resolve fleet alarm main-checkout-held" \
+  "$(log_lines graph-commit.log)"
+assert_eq "(21) tree left clean" "" "$(git -C "$FR" status --porcelain)"
+
+# The enum is still CLOSED: a near-miss of the new kind is rejected, and no
+# unknown kind reaches a write.
+run_alarm -- --kind main-checkout --statement 'x' --body-file "$BODY21"
+assert_eq "(21) a near-miss kind still exits 64" "64" "$RC"
+assert_eq "(21) near-miss made no write-node"   "" "$(log_lines write-node.log)"
+assert_eq "(21) near-miss made no graph-commit" "" "$(log_lines graph-commit.log)"
+
 # --- results -----------------------------------------------------------------
 echo ""
 echo "================================"

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-fleet-watch.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-fleet-watch.sh
@@ -26,6 +26,18 @@
 #                                       the real repo (and predicate 5's
 #                                       worktree probes stay inside $WORK)
 #   DISPATCH_RESERVATION_DIR            lib-reservation-ledger.sh's ledger dir
+#   DISPATCH_STANDDOWN_PROJECTS_ROOT    lib-standdown-recheck.sh's transcript
+#                                       root, so predicate 6's idle measurement
+#                                       reads fixture mtimes instead of
+#                                       ~/.claude/projects
+#
+# Predicate 6 additionally needs its subject to BE a git repository:
+# DISPATCH_GRAPH_MAIN_WORKTREE points resolve_main_worktree at $CASEDIR, and the
+# predicate reads that checkout's tree with `git status --porcelain` and
+# `git rev-list --count HEAD --not --remotes`. new_env therefore initialises
+# $CASEDIR as a real repo with a bare origin and one pushed commit, so its
+# DEFAULT state is clean-and-fully-pushed (predicate 6 clear); dirty_main()
+# makes it dirty.
 #
 # No systemd, no real `claude` daemon, no git remote, no graph write — only bash
 # + jq. Run under bash, never zsh.
@@ -173,6 +185,8 @@ run_case() {
     DISPATCH_FLEET_WATCH_HOLDALERT_CMD="$BIN/holdalert" \
     DISPATCH_GRAPH_MAIN_WORKTREE="$CASEDIR" \
     DISPATCH_RESERVATION_DIR="$RESVDIR" \
+    DISPATCH_STANDDOWN_PROJECTS_ROOT="$PROJROOT" \
+    DISPATCH_FLEET_WATCH_MAIN_HELD_GRACE_S="${MAIN_HELD_GRACE_S:-1800}" \
     STUB_HOLDALERT_OUT="${STUB_HOLDALERT_OUT:-}" \
     STUB_HOLDALERT_RC="${STUB_HOLDALERT_RC:-0}" \
     STUB_LIVENESS_RC="${STUB_LIVENESS_RC:-0}" \
@@ -196,6 +210,7 @@ reset_stubs() {
   unset STUB_LIVENESS_RC STUB_LIVENESS_VERDICT STUB_LIVENESS_REASON STUB_LIVENESS_NOJSON
   unset STUB_REDSYNC_OUT STUB_AGENTS_JSON STUB_AGENTS_FAIL STUB_AGENTS_ALL_FAIL STUB_ALARM_RC
   unset STUB_HOLDALERT_OUT STUB_HOLDALERT_RC
+  unset MAIN_HELD_GRACE_S
 }
 
 # new_env <case-name> — fresh log/pause/state paths for an isolated case.
@@ -210,18 +225,63 @@ new_env() {
   # claimed) and the worktrees root under the faked main worktree ($CASEDIR).
   RESVDIR="$CASEDIR/reservations"; mkdir -p "$RESVDIR"
   mkdir -p "$CASEDIR/.claude/worktrees"
+  # Predicate 6's transcript root (idle measurement) and its subject repo.
+  PROJROOT="$CASEDIR/projects"; mkdir -p "$PROJROOT/proj"
+  # A real repo with a bare origin and one pushed commit: clean tracked tree,
+  # zero unpushed commits — predicate 6's `clear` baseline. The identity is
+  # passed with -c so the harness never depends on a global git identity (which
+  # CI does not have).
+  git -C "$CASEDIR" init -q -b main >/dev/null 2>&1
+  printf 'seed\n' > "$CASEDIR/seed.txt"
+  git -C "$CASEDIR" add seed.txt >/dev/null 2>&1
+  git -C "$CASEDIR" -c user.email=harness@example.invalid -c user.name=harness \
+    commit -q -m seed >/dev/null 2>&1
+  git init -q --bare "$WORK/$c-origin.git" >/dev/null 2>&1
+  git -C "$CASEDIR" remote add origin "$WORK/$c-origin.git" >/dev/null 2>&1
+  git -C "$CASEDIR" push -q origin main >/dev/null 2>&1
+}
+
+# dirty_main — modify a TRACKED file in the faked main checkout, so
+# `git status --porcelain --untracked-files=no` is non-empty. That is the harm
+# half of predicate 6's conjunction: a dirty shared tree blocks the tick's
+# --ff-only sync and every graph-commit through that checkout.
+dirty_main() { printf 'held\n' >> "$CASEDIR/seed.txt"; }
+
+# main_session_json <name> <state> <status> <sid> — the session array of
+# `agents_json 1`, plus one session whose cwd IS the faked main checkout. The
+# name is deliberately OUTSIDE the worker keyspace (`sync-repair` is the real
+# incident's session name), so predicate 3's keyspace-filtered busy count is
+# unaffected and only predicate 6 sees it.
+main_session_json() {
+  jq -c --arg nm "$1" --arg st "$2" --arg su "$3" --arg sid "$4" --arg cwd "$CASEDIR" \
+    '. + [{sessionId:$sid, id:"job-1", name:$nm, state:$st, status:$su, cwd:$cwd}]' \
+    <<<"$(agents_json 1)"
+}
+
+# make_transcript <sid> <idle-seconds> — a transcript file at
+# <projects-root>/<project>/<sid>.jsonl whose mtime is <idle-seconds> old, which
+# is exactly what _standdown_session_idle_s measures. Omit it entirely and that
+# helper returns UNKNOWN.
+#
+# The fixture sids are hex-and-dash shaped on purpose: _standdown_session_idle_s
+# validates the sid against `^[0-9a-fA-F-]+$` before feeding it to a `find -name`
+# glob, and a sid failing that edge check reads as UNKNOWN idle regardless of
+# any transcript on disk.
+make_transcript() {
+  : > "$PROJROOT/proj/$1.jsonl"
+  touch -d "@$((NOW - $2))" "$PROJROOT/proj/$1.jsonl"
 }
 
 fresh_log() { printf '{"ts":"%s","site":"select-tick"}\n' "$(iso $((NOW - 60)))" > "$LOGFILE"; }
 stale_log() { printf '{"ts":"%s","site":"select-tick"}\n' "$(iso $((NOW - 99999)))" > "$LOGFILE"; }
 
 # ===========================================================================
-# Case 1: all five clear -> exit 0, five --resolve calls, zero finding calls.
+# Case 1: all six clear -> exit 0, six --resolve calls, zero finding calls.
 reset_stubs; new_env case1
 fresh_log
 STUB_LIVENESS_RC=0 STUB_AGENTS_JSON="$(agents_json 2)" STUB_REDSYNC_OUT="" run_case
 assert_eq "case1 exit code" 0 "$RUN_RC"
-assert_eq "case1 resolve count" 5 "$(grep -c -- '--resolve' <<<"$ALARMS")"
+assert_eq "case1 resolve count" 6 "$(grep -c -- '--resolve' <<<"$ALARMS")"
 assert_eq "case1 finding-alarm count" 0 "$(grep -c -- '--statement' <<<"$ALARMS")"
 assert_contains "case1 reports ok" "result: ok" "$RUN_OUT"
 # The latch is READ, never completed: completing it re-arms the auto-merge gate
@@ -282,8 +342,8 @@ assert_contains "case4 pause reported unknown" "pause=unknown" "$RUN_OUT"
 assert_eq "case4 watch-unknown alarm fired" 1 "$(grep -c -- '--kind watch-unknown --statement' <<<"$ALARMS")"
 assert_not_contains "case4 does NOT report bare ok" "result: ok" "$RUN_OUT"
 if [[ "$RUN_RC" -ne 0 ]]; then ok "case4 exit is not 0"; else no "case4 exited 0 despite pause-unknown"; fi
-# All five still evaluated (each read cleanly, so each resolved).
-assert_eq "case4 all five predicates still evaluated" 5 "$(grep -c -- '--resolve' <<<"$ALARMS")"
+# All six still evaluated (each read cleanly, so each resolved).
+assert_eq "case4 all six predicates still evaluated" 6 "$(grep -c -- '--resolve' <<<"$ALARMS")"
 
 # ===========================================================================
 # Case 5: busy-worker count UNKNOWN (the daemon query fails) with a pre-set
@@ -647,6 +707,203 @@ assert_eq "case24 exit code (unknown)" 2 "$RUN_RC"
 # The ACTIVE view really was healthy, or the case proves nothing about WHICH
 # view the gate consults: predicate 3 read it and produced a definite verdict.
 assert_not_contains "case24 busy-stall still read the active view" "busy-stall:           unknown" "$RUN_OUT"
+
+# ===========================================================================
+# Predicate 6 (main-checkout-held). The subject is $CASEDIR — a real repo with a
+# bare origin, clean and fully pushed by default (see new_env). The session view
+# is the `claude` stub's `--all` answer, and idle age comes from a fixture
+# transcript whose mtime make_transcript sets.
+#
+# Case 25 (THE INCIDENT): dirty shared tree + a non-working session sitting in
+# it, idle past the grace -> finding, one main-checkout-held alarm, exit 1.
+reset_stubs; new_env case25
+fresh_log
+dirty_main
+make_transcript dead1234-beef-5678-90ab-cdef01234567 9000
+STUB_LIVENESS_RC=0 STUB_REDSYNC_OUT="" \
+  STUB_AGENTS_JSON="$(main_session_json sync-repair blocked idle dead1234-beef-5678-90ab-cdef01234567)" run_case
+assert_contains "case25 verdict is finding" "main-checkout-held:   finding" "$RUN_OUT"
+assert_eq "case25 exactly one main-checkout-held finding" 1 \
+  "$(grep -c -- '--kind main-checkout-held --statement' <<<"$ALARMS")"
+assert_not_contains "case25 no main-checkout-held resolve" "--resolve --kind main-checkout-held" "$ALARMS"
+assert_eq "case25 exit code (finding)" 1 "$RUN_RC"
+
+# ===========================================================================
+# Case 26: the same dirty tree and the same session, but idle WITHIN the grace.
+# It is being observed, not acted on — verdict clear (the grace convention at
+# lib-frozen-session-park.sh:495-529).
+reset_stubs; new_env case26
+fresh_log
+dirty_main
+make_transcript dead1234-beef-5678-90ab-cdef01234567 60
+STUB_LIVENESS_RC=0 STUB_REDSYNC_OUT="" \
+  STUB_AGENTS_JSON="$(main_session_json sync-repair blocked idle dead1234-beef-5678-90ab-cdef01234567)" run_case
+assert_contains "case26 verdict clear (within grace)" "main-checkout-held:   clear" "$RUN_OUT"
+assert_eq "case26 main-checkout-held resolved" 1 "$(grep -c -- '--resolve --kind main-checkout-held' <<<"$ALARMS")"
+assert_not_contains "case26 no finding" "--kind main-checkout-held --statement" "$ALARMS"
+assert_eq "case26 exit code (clear)" 0 "$RUN_RC"
+
+# ===========================================================================
+# Case 27: dirty tree, but the session sitting in it is WORKING. That is the
+# ordinary way the shared tree goes dirty and it is not an incident.
+reset_stubs; new_env case27
+fresh_log
+dirty_main
+make_transcript dead1234-beef-5678-90ab-cdef01234567 9000
+STUB_LIVENESS_RC=0 STUB_REDSYNC_OUT="" \
+  STUB_AGENTS_JSON="$(main_session_json 999-some-node working busy dead1234-beef-5678-90ab-cdef01234567)" run_case
+assert_contains "case27 verdict clear (someone is working)" "main-checkout-held:   clear" "$RUN_OUT"
+assert_not_contains "case27 no finding" "--kind main-checkout-held --statement" "$ALARMS"
+assert_eq "case27 exit code (clear)" 0 "$RUN_RC"
+
+# ===========================================================================
+# Case 28 (THE CRITICAL FALSE-POSITIVE GUARD): a CLEAN, fully-pushed tree with a
+# long-idle non-working session sitting in it. An interactive human session
+# started in the repo root registers with cwd == the main checkout and sits idle
+# for hours as a matter of course; alarming on the session alone would mint a
+# graph node against ordinary human use. The harm is the tree, not the session.
+reset_stubs; new_env case28
+fresh_log
+make_transcript dead1234-beef-5678-90ab-cdef01234567 999999
+STUB_LIVENESS_RC=0 STUB_REDSYNC_OUT="" \
+  STUB_AGENTS_JSON="$(main_session_json my-scratch blocked idle dead1234-beef-5678-90ab-cdef01234567)" run_case
+assert_contains "case28 verdict clear (clean tree, idle human session)" "main-checkout-held:   clear" "$RUN_OUT"
+assert_not_contains "case28 no finding on an idle session alone" "--kind main-checkout-held --statement" "$ALARMS"
+assert_eq "case28 main-checkout-held resolved" 1 "$(grep -c -- '--resolve --kind main-checkout-held' <<<"$ALARMS")"
+assert_eq "case28 exit code (clear)" 0 "$RUN_RC"
+
+# ===========================================================================
+# Case 29 (FAIL DIRECTION, session view): the registered view (`--all`) is
+# unreadable with a dirty tree. An unreadable session list would emit zero rows,
+# which reads identically to "nobody is there" and would send
+# `--resolve --kind main-checkout-held`, closing an already-open alarm node.
+# Verdict must be unknown: no finding, no resolve, watch-unknown raised.
+reset_stubs; new_env case29
+fresh_log
+dirty_main
+STUB_LIVENESS_RC=0 STUB_REDSYNC_OUT="" STUB_AGENTS_ALL_FAIL=1 \
+  STUB_AGENTS_JSON="$(agents_json 1)" run_case
+assert_contains "case29 verdict unknown (registered view unreadable)" "main-checkout-held:   unknown" "$RUN_OUT"
+assert_not_contains "case29 verdict is NOT a false clear" "main-checkout-held:   clear" "$RUN_OUT"
+assert_not_contains "case29 no main-checkout-held resolve" "--resolve --kind main-checkout-held" "$ALARMS"
+assert_not_contains "case29 no main-checkout-held finding" "--kind main-checkout-held --statement" "$ALARMS"
+assert_eq "case29 watch-unknown alarm fired" 1 "$(grep -c -- '--kind watch-unknown --statement' <<<"$ALARMS")"
+assert_eq "case29 exit code (unknown)" 2 "$RUN_RC"
+# The ACTIVE view really was healthy, or the case proves nothing about WHICH
+# view this predicate's gate consults.
+assert_not_contains "case29 busy-stall still read the active view" "busy-stall:           unknown" "$RUN_OUT"
+
+# ===========================================================================
+# Case 30 (FAIL DIRECTION, tree read): the git read FAILS — $CASEDIR's repo is
+# gone, so `git status` cannot run. A failed git command is unknown, never
+# clear: worktree_in_sync collapses "git failed" into the same non-zero return
+# as "dirty", which is why this predicate does its own three-way read.
+reset_stubs; new_env case30
+fresh_log
+rm -rf "$CASEDIR/.git"
+STUB_LIVENESS_RC=0 STUB_REDSYNC_OUT="" STUB_AGENTS_JSON="$(agents_json 1)" run_case
+assert_contains "case30 verdict unknown (git read failed)" "main-checkout-held:   unknown" "$RUN_OUT"
+assert_not_contains "case30 verdict is NOT a false clear" "main-checkout-held:   clear" "$RUN_OUT"
+assert_not_contains "case30 no main-checkout-held resolve" "--resolve --kind main-checkout-held" "$ALARMS"
+assert_not_contains "case30 no main-checkout-held finding" "--kind main-checkout-held --statement" "$ALARMS"
+assert_eq "case30 watch-unknown alarm fired" 1 "$(grep -c -- '--kind watch-unknown --statement' <<<"$ALARMS")"
+assert_not_contains "case30 does NOT report bare ok" "result: ok" "$RUN_OUT"
+assert_eq "case30 exit code (unknown)" 2 "$RUN_RC"
+
+# ===========================================================================
+# Case 31 (BODY-STABILITY RATCHET for predicate 6): two passes over the SAME
+# offending session whose readings differ — a different idle age and a different
+# number of modified tracked files — must emit a byte-identical body. A body
+# carrying either would fetch/rebase/push to origin/main once per 5-minute pass.
+reset_stubs; new_env case31
+fresh_log
+dirty_main
+make_transcript dead1234-beef-5678-90ab-cdef01234567 9000
+ALARM_BODY_DIR="$CASEDIR/bodies-1"
+STUB_LIVENESS_RC=0 STUB_REDSYNC_OUT="" \
+  STUB_AGENTS_JSON="$(main_session_json sync-repair blocked idle dead1234-beef-5678-90ab-cdef01234567)" run_case
+assert_eq "case31 pass 1 raised the main-checkout-held finding" 1 \
+  "$(grep -c -- '--kind main-checkout-held --statement' <<<"$ALARMS")"
+CASE31_OUT_1="$RUN_OUT"
+# Move BOTH readings: a second modified tracked file, and a much older idle age.
+printf 'second\n' > "$CASEDIR/second.txt"
+git -C "$CASEDIR" add second.txt >/dev/null 2>&1
+git -C "$CASEDIR" -c user.email=harness@example.invalid -c user.name=harness \
+  commit -q -m second >/dev/null 2>&1
+git -C "$CASEDIR" push -q origin main >/dev/null 2>&1
+printf 'held too\n' >> "$CASEDIR/second.txt"
+make_transcript dead1234-beef-5678-90ab-cdef01234567 77777
+ALARM_BODY_DIR="$CASEDIR/bodies-2"
+reset_stubs
+STUB_LIVENESS_RC=0 STUB_REDSYNC_OUT="" \
+  STUB_AGENTS_JSON="$(main_session_json sync-repair blocked idle dead1234-beef-5678-90ab-cdef01234567)" run_case
+ALARM_BODY_DIR=""
+if [[ ! -s "$CASEDIR/bodies-1/main-checkout-held.body" || ! -s "$CASEDIR/bodies-2/main-checkout-held.body" ]]; then
+  no "case31 main-checkout-held body missing from one of the passes (the ratchet would be vacuous)"
+elif cmp -s "$CASEDIR/bodies-1/main-checkout-held.body" "$CASEDIR/bodies-2/main-checkout-held.body"; then
+  ok "case31 main-checkout-held body is identical across passes"
+else
+  no "case31 main-checkout-held body CHURNS across passes: $(diff "$CASEDIR/bodies-1/main-checkout-held.body" "$CASEDIR/bodies-2/main-checkout-held.body" | tr '\n' ' ')"
+fi
+# The readings really did differ, or the byte-comparison above proves nothing.
+if [[ "$(grep -F 'main-checkout-held:' <<<"$CASE31_OUT_1")" != "$(grep -F 'main-checkout-held:' <<<"$RUN_OUT")" ]]; then
+  ok "case31 main-checkout-held reading DID change between passes (stdout keeps the live numbers)"
+else
+  no "case31 main-checkout-held reading did not change between passes — the body comparison above is vacuous"
+fi
+CASE31_BODY="$(cat "$CASEDIR/bodies-2/main-checkout-held.body")"
+assert_not_contains "case31 body carries no idle age" "77777" "$CASE31_BODY"
+assert_not_contains "case31 body carries no sessionId" "dead1234-beef-5678-90ab-cdef01234567" "$CASE31_BODY"
+# ...but the offending session's name/state IS the condition's identity.
+assert_contains "case31 body names the offending session" "sync-repair:blocked" "$CASE31_BODY"
+assert_contains "case31 body names the main checkout" "$CASEDIR" "$CASE31_BODY"
+# The operator still needs the sessionId, so the body says where to find it —
+# and says plainly that the first act is reading the transcript, never a blind
+# removal: a stopped session may hold the only record of why it died.
+assert_contains "case31 body points at journald for the volatile reading" \
+  "journald" "$CASE31_BODY"
+assert_contains "case31 body recommends reading the transcript first" \
+  "READ THE SESSION'S TRANSCRIPT" "$CASE31_BODY"
+
+# ===========================================================================
+# Case 32: PAUSED. Predicate 6 still evaluates — a dirty shared main checkout is
+# not a consequence of pausing, and the incident that motivated this predicate
+# happened DURING a correct pause.
+reset_stubs; new_env case32
+fresh_log
+touch "$PAUSEFLAG"
+dirty_main
+make_transcript dead1234-beef-5678-90ab-cdef01234567 9000
+STUB_LIVENESS_RC=0 STUB_REDSYNC_OUT="" \
+  STUB_AGENTS_JSON="$(main_session_json sync-repair blocked idle dead1234-beef-5678-90ab-cdef01234567)" run_case
+assert_contains "case32 predicate 6 evaluated under pause" "main-checkout-held:   finding" "$RUN_OUT"
+assert_not_contains "case32 predicate 6 is NOT quiet under pause" "main-checkout-held:   quiet" "$RUN_OUT"
+assert_eq "case32 main-checkout-held finding raised under pause" 1 \
+  "$(grep -c -- '--kind main-checkout-held --statement' <<<"$ALARMS")"
+
+# ===========================================================================
+# Case 33: a candidate session whose transcript is MISSING — its idle age is
+# unmeasurable, so it can be judged neither way. It is the only candidate, so
+# the verdict is unknown, never clear.
+reset_stubs; new_env case33
+fresh_log
+dirty_main
+STUB_LIVENESS_RC=0 STUB_REDSYNC_OUT="" \
+  STUB_AGENTS_JSON="$(main_session_json sync-repair blocked idle dead1234-beef-5678-90ab-cdef01234567)" run_case
+assert_contains "case33 verdict unknown (idle unmeasurable)" "main-checkout-held:   unknown" "$RUN_OUT"
+assert_not_contains "case33 no main-checkout-held resolve" "--resolve --kind main-checkout-held" "$ALARMS"
+assert_not_contains "case33 no main-checkout-held finding" "--kind main-checkout-held --statement" "$ALARMS"
+assert_eq "case33 exit code (unknown)" 2 "$RUN_RC"
+
+# ===========================================================================
+# Case 34 (I22 RATCHET): predicate 6 SURFACES, it never acts. `state: done` is
+# the discriminator for REAPING, not for HEALTH, and this predicate must not
+# grow into a reaper — no session removal, no kill, no park.
+if grep -Eq 'claude[[:space:]]+rm|kill[[:space:]]+-|pkill' "$SCRIPT"; then
+  no "ratchet: script removes or kills a session (predicate 6 surfaces, it never acts)"
+else
+  ok "ratchet: no session removal/kill (predicate 6 surfaces, it never acts)"
+fi
 
 # ===========================================================================
 # Case 17 (DOCTRINE RATCHET): the watcher must never fleet-halt. Grep the

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-select-tick.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-select-tick.sh
@@ -44,8 +44,21 @@ sel_tick_setup() {
   # SCRIPT_DIR (= TMPDIR_TEST). Copy the real script so the wiring test can
   # assert reconcile-produced `ready:` lines appear in the tick output.
   cp "$SCRIPT_DIR/dispatch-reconcile-ready" "$TMPDIR_TEST/dispatch-reconcile-ready"
+  # dispatch-select-tick's Decision A sources lib-standdown-recheck.sh via its
+  # SCRIPT_DIR (= TMPDIR_TEST) for _standdown_session_idle_s, the transcript-mtime
+  # idle probe that bounds the main-checkout defer. Stage the REAL lib (its idle
+  # math is under test) plus the sibling it sources that is not already staged
+  # (lib-worktree-in-sync.sh; lib.sh / lib-claude-agents.sh / lib-decision-log.sh
+  # are). A test drives idle age by writing a transcript under
+  # DISPATCH_STANDDOWN_PROJECTS_ROOT with a chosen mtime — see sel_tick_transcript.
+  cp "$SCRIPT_DIR/lib-standdown-recheck.sh" "$TMPDIR_TEST/lib-standdown-recheck.sh"
+  cp "$SCRIPT_DIR/lib-worktree-in-sync.sh" "$TMPDIR_TEST/lib-worktree-in-sync.sh"
   chmod +x "$TMPDIR_TEST/dispatch-select-tick" "$TMPDIR_TEST/dispatch-acquire-lock" \
            "$TMPDIR_TEST/dispatch-reconcile-ready"
+  # Transcript store the idle probe reads; empty by default, so a session with no
+  # staged transcript reads as UNKNOWN idle (the fail-safe defer case).
+  export DISPATCH_STANDDOWN_PROJECTS_ROOT="$TMPDIR_TEST/projects"
+  mkdir -p "$DISPATCH_STANDDOWN_PROJECTS_ROOT/proj"
 
   export DISPATCH_LOCK_FILE="$STUB_DIR/dispatch.lock"
   # #1495: sync-repair attempt-counter file override (consumed by lib.sh's
@@ -251,6 +264,17 @@ claude_sessions_under() {
   [[ -n "${SEL_SESSIONS_UNDER_TSV:-}" ]] && printf '%s\n' "${SEL_SESSIONS_UNDER_TSV}"
   return 0
 }
+claude_agents_list_sessions_in_cwd_all() {
+  # The REGISTERED (--all) cwd-keyed view Decision A reads. Default UNKNOWN
+  # (rc 1) preserves the fall-through in every pre-existing main-branch test. A
+  # test sets SEL_MAIN_SESSIONS_RC=0 and SEL_MAIN_SESSIONS_TSV (rows of
+  # sessionId<TAB>id<TAB>name<TAB>state<TAB>status) to drive a definite list;
+  # SEL_MAIN_SESSIONS_RC=0 with no TSV models a definite "nobody is there".
+  local rc="${SEL_MAIN_SESSIONS_RC:-1}"
+  [[ "$rc" != 0 ]] && return "$rc"
+  [[ -n "${SEL_MAIN_SESSIONS_TSV:-}" ]] && printf '%s\n' "${SEL_MAIN_SESSIONS_TSV}"
+  return 0
+}
 FAKE
   # Default empty reservation ledger: the sweep no-ops, reservation_count is 0,
   # and the gap is unchanged from the pre-ledger gate (behavior-preserving).
@@ -400,6 +424,8 @@ sel_tick_teardown() {
     DISPATCH_RESERVATION_DIR SEL_AGENTS_TSV SEL_AGENTS_LIST_FAIL \
     DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE SEL_GIT_MERGE_LOG \
     SEL_SESSIONS_UNDER_RC SEL_SESSIONS_UNDER_TSV \
+    SEL_MAIN_SESSIONS_RC SEL_MAIN_SESSIONS_TSV \
+    DISPATCH_STANDDOWN_PROJECTS_ROOT DISPATCH_MAIN_CHECKOUT_STUCK_GRACE_S \
     DISPATCH_LOCK_PROBE_TIMEOUT DISPATCH_LOCK_FLOCK_TIMEOUT \
     SEL_AUTO_MERGE_OUT SEL_GRAPH_AUTO_MERGE_OUT SEL_RETRIAGE_OUT \
     SEL_MAIN_BROKEN_SHA SEL_MAIN_RED_NODES SEL_SYNC_BROKEN_LATCHED SEL_JIT_SCAN \
@@ -420,6 +446,18 @@ run_sel_tick() {
 run_sel_tick_err() {
   local errfile="$1"; shift
   "$TMPDIR_TEST/dispatch-select-tick" "$@" 2>"$errfile"
+}
+
+# sel_tick_transcript <sid> <age-seconds> — stage a transcript for <sid> whose
+# mtime is <age-seconds> in the past, which is exactly what
+# _standdown_session_idle_s measures (newest mtime of
+# <projects-root>/<project>/<sid>.jsonl). Omit the call entirely and the session
+# reads as UNKNOWN idle.
+sel_tick_transcript() {
+  local sid="$1" age="$2" f
+  f="$DISPATCH_STANDDOWN_PROJECTS_ROOT/proj/${sid}.jsonl"
+  : > "$f"
+  touch -d "@$(( $(date +%s) - age ))" "$f"
 }
 
 # --- empty queue → release + empty ------------------------------------------
@@ -887,11 +925,17 @@ assert_eq "sync-failed: escalate NOT called" "absent" \
   "$([ -f "$TMPDIR_TEST/logs/escalate-sync-broken.log" ] && echo present || echo absent)"
 sel_tick_teardown
 
+# --- Decision A (bounded main-checkout defer) --------------------------------
+# The rows below are the REGISTERED (--all) cwd-keyed view:
+# sessionId<TAB>id<TAB>name<TAB>state<TAB>status. Session ids are hex-and-dash
+# shaped on purpose — _standdown_session_idle_s validates that shape before it
+# globs for the transcript.
+
 # --- #1495: live sync-repair session → defer (sync-repair-pending), merge NOT run ---
-echo "Test: select-tick live sync-repair session → sync-repair-pending, merge deferred"
+echo "Test: select-tick working session in main → sync-repair-pending, merge deferred"
 sel_tick_setup
-export SEL_SESSIONS_UNDER_RC=0
-export SEL_SESSIONS_UNDER_TSV=$'sid1\t100\tbusy\tsync-repair'
+export SEL_MAIN_SESSIONS_RC=0
+export SEL_MAIN_SESSIONS_TSV=$'aaa1-bbb2\tjob1\tsync-repair\tworking\tbusy'
 out=$(run_sel_tick) || true
 assert_eq "defer: decision line" "sync-repair-pending" \
   "$(printf '%s\n' "$out" | tail -n 1)"
@@ -904,16 +948,114 @@ assert_eq "defer: counter untouched" "absent" \
   "$([ -f "$DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE" ] && echo present || echo absent)"
 sel_tick_teardown
 
-# --- #1495: stopped sync-repair session does NOT defer → falls through to merge ---
-echo "Test: select-tick stopped sync-repair session → no defer, failing merge → sync-failed"
+# A `blocked` session INSIDE the grace still defers: it may yet come back.
+echo "Test: select-tick blocked session in main, idle < grace → sync-repair-pending"
 sel_tick_setup
-export SEL_SESSIONS_UNDER_RC=0
-export SEL_SESSIONS_UNDER_TSV=$'sid1\t100\tstopped\tsync-repair'
+export SEL_MAIN_SESSIONS_RC=0
+export SEL_MAIN_SESSIONS_TSV=$'aaa1-bbb2\tjob1\tsync-repair\tblocked\tidle'
+sel_tick_transcript aaa1-bbb2 60
+export DISPATCH_MAIN_CHECKOUT_STUCK_GRACE_S=1800
+out=$(run_sel_tick) || true
+assert_eq "grace-defer: decision line" "sync-repair-pending" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "grace-defer: merge NOT attempted" "absent" \
+  "$([ -f "$STUB_DIR/git-merge.log" ] && echo present || echo absent)"
+assert_eq "grace-defer: counter untouched" "absent" \
+  "$([ -f "$DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE" ] && echo present || echo absent)"
+sel_tick_teardown
+
+# THE INCIDENT REGRESSION RATCHET. A `blocked` session past the grace must NOT
+# hold the tick any longer: the old name-and-status rule read its coarse status
+# as `idle` (never `stopped`), deferred forever, and so never bumped the
+# counter — making the 3-attempt sync-broken cap structurally unreachable.
+echo "Test: select-tick blocked session in main, idle >= grace → falls through, sync-failed"
+sel_tick_setup
+export SEL_MAIN_SESSIONS_RC=0
+export SEL_MAIN_SESSIONS_TSV=$'aaa1-bbb2\tjob1\tsync-repair\tblocked\tidle'
+sel_tick_transcript aaa1-bbb2 7200
+export DISPATCH_MAIN_CHECKOUT_STUCK_GRACE_S=1800
+export FAKE_GIT_MERGE_FAIL=1
+out=$(run_sel_tick) || true
+assert_eq "stuck-fallthrough: decision line" "sync-failed" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "stuck-fallthrough: merge attempted" "present" \
+  "$([ -f "$STUB_DIR/git-merge.log" ] && echo present || echo absent)"
+assert_eq "stuck-fallthrough: counter bumped to 1" "1" \
+  "$(cat "$DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE")"
+DLOG_FILE="$DISPATCH_DECISION_LOG_DIR/routing-decisions.jsonl"
+assert_eq "stuck-fallthrough: decision log attributes the declined defer" \
+  "main-checkout-stuck:sync-repair:blocked" \
+  "$(tail -n 1 "$DLOG_FILE" | jq -r .skip_reason)"
+sel_tick_teardown
+
+# ... and on the 3rd attempt the cap is REACHED — the escalation the unbounded
+# defer could never get to.
+echo "Test: select-tick blocked session past grace at the cap → sync-broken, latch set"
+sel_tick_setup
+export SEL_MAIN_SESSIONS_RC=0
+export SEL_MAIN_SESSIONS_TSV=$'aaa1-bbb2\tjob1\tsync-repair\tblocked\tidle'
+sel_tick_transcript aaa1-bbb2 7200
+export DISPATCH_MAIN_CHECKOUT_STUCK_GRACE_S=1800
+export FAKE_GIT_MERGE_FAIL=1
+printf '3\n' > "$DISPATCH_SYNC_REPAIR_ATTEMPTS_FILE"   # two prior ticks bumped it
+out=$(run_sel_tick) || true
+assert_eq "stuck-cap: decision line" "sync-broken" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "stuck-cap: repo-health --set-sync-broken invoked" "1" \
+  "$(grep -cF -- '--reason merge-failed' "$TMPDIR_TEST/logs/repo-health-set-sync-broken.log")"
+sel_tick_teardown
+
+# The REGISTERED-view-only case: a `stopped`/`done` row is INVISIBLE to the
+# ACTIVE view the old rule read, so the old code could not see this holder at
+# all. A second, distinct regression ratchet.
+echo "Test: select-tick stopped session in main past grace → falls through to merge"
+sel_tick_setup
+export SEL_MAIN_SESSIONS_RC=0
+export SEL_MAIN_SESSIONS_TSV=$'aaa1-bbb2\tjob1\tsync-repair\tdone\t'
+sel_tick_transcript aaa1-bbb2 7200
+export DISPATCH_MAIN_CHECKOUT_STUCK_GRACE_S=1800
 export FAKE_GIT_MERGE_FAIL=1
 out=$(run_sel_tick) || true
 assert_eq "stopped-defer: decision line" "sync-failed" \
   "$(printf '%s\n' "$out" | tail -n 1)"
 assert_eq "stopped-defer: merge attempted" "present" \
+  "$([ -f "$STUB_DIR/git-merge.log" ] && echo present || echo absent)"
+sel_tick_teardown
+
+# UNKNOWN idle (no transcript staged) is fail-SAFE: defer, never fall through.
+echo "Test: select-tick session in main with no transcript → sync-repair-pending"
+sel_tick_setup
+export SEL_MAIN_SESSIONS_RC=0
+export SEL_MAIN_SESSIONS_TSV=$'aaa1-bbb2\tjob1\tsync-repair\tblocked\tidle'
+export FAKE_GIT_MERGE_FAIL=1
+out=$(run_sel_tick) || true
+assert_eq "idle-unknown: decision line" "sync-repair-pending" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "idle-unknown: merge NOT attempted" "absent" \
+  "$([ -f "$STUB_DIR/git-merge.log" ] && echo present || echo absent)"
+sel_tick_teardown
+
+# Daemon UNKNOWN (rc 1) is fail-OPEN, unchanged: the tick proceeds to the merge.
+echo "Test: select-tick registered session view UNKNOWN → falls through to merge"
+sel_tick_setup
+export SEL_MAIN_SESSIONS_RC=1
+export FAKE_GIT_MERGE_FAIL=1
+out=$(run_sel_tick) || true
+assert_eq "daemon-unknown: decision line" "sync-failed" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "daemon-unknown: merge attempted" "present" \
+  "$([ -f "$STUB_DIR/git-merge.log" ] && echo present || echo absent)"
+sel_tick_teardown
+
+# A definite EMPTY main-checkout session list is not a defer either.
+echo "Test: select-tick no sessions in main → falls through to merge"
+sel_tick_setup
+export SEL_MAIN_SESSIONS_RC=0
+export FAKE_GIT_MERGE_FAIL=1
+out=$(run_sel_tick) || true
+assert_eq "no-sessions: decision line" "sync-failed" \
+  "$(printf '%s\n' "$out" | tail -n 1)"
+assert_eq "no-sessions: merge attempted" "present" \
   "$([ -f "$STUB_DIR/git-merge.log" ] && echo present || echo absent)"
 sel_tick_teardown
 

--- a/.claude/skills/dispatch-propagate/scripts/test-dispatch-sweep.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-dispatch-sweep.sh
@@ -2080,4 +2080,115 @@ else
 fi
 sweep_teardown
 
+# --- Test N10a: SESSION_STATE_CENSUS logs one line per row ------------------
+# claude_agents_count_by_state (tactic-blocked-session-invisible-to-census
+# Unit 1) emits two interleaved views: 2-column `state<TAB>count` (overall)
+# and 3-column `keyspace<TAB>state<TAB>count` (per-keyspace, plus a
+# `terminal` roll-up). A single blocked tactic-* session should produce both
+# an overall `state=blocked n=1` line and a keyspace-partitioned
+# `keyspace=worker state=blocked n=1` line.
+echo "Test: N10a SESSION_STATE_CENSUS logs one line per emitted row"
+sweep_setup
+WT_PATH="$TMPDIR_TEST/project/worktrees/66-census-rows"
+sweep_register_wt "$WT_PATH" "66-census-rows"
+echo "OPEN" > "$STUB_DIR/issue-state-66.txt"
+key=$(sweep_path_key "$WT_PATH")
+: > "$STUB_DIR/status${key}.txt"
+echo "0" > "$STUB_DIR/revlist${key}.txt"
+
+fake="$TMPDIR_TEST/fake/claude"
+cat > "$fake" <<'FAKE'
+#!/usr/bin/env bash
+# Ignore all args; always return the fixed payload regardless of --json/--all/--cwd.
+cat <<'JSON'
+[
+  {"sessionId":"s1","state":"blocked","name":"66-census-rows","cwd":""}
+]
+JSON
+FAKE
+chmod +x "$fake"
+export CLAUDE_AGENTS_CMD="$fake"
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "N10a sweep exits 0" "0" "$rc"
+
+TOTAL=$((TOTAL + 1))
+if grep -q "SESSION_STATE_CENSUS: state=blocked n=1" "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: N10a logs the overall state=blocked n=1 row"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: N10a logs the overall state=blocked n=1 row"
+  echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
+fi
+
+TOTAL=$((TOTAL + 1))
+if grep -q "SESSION_STATE_CENSUS: keyspace=worker state=blocked n=1" "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: N10a logs the keyspace=worker state=blocked n=1 row"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: N10a logs the keyspace=worker state=blocked n=1 row"
+  echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
+fi
+sweep_teardown
+
+# --- Test N10b: SESSION_STATE_CENSUS logs "none" on an empty registry -------
+echo "Test: N10b SESSION_STATE_CENSUS logs none on an empty registry"
+sweep_setup
+WT_PATH="$TMPDIR_TEST/project/worktrees/67-census-empty"
+sweep_register_wt "$WT_PATH" "67-census-empty"
+echo "OPEN" > "$STUB_DIR/issue-state-67.txt"
+key=$(sweep_path_key "$WT_PATH")
+: > "$STUB_DIR/status${key}.txt"
+echo "0" > "$STUB_DIR/revlist${key}.txt"
+
+fake="$TMPDIR_TEST/fake/claude"
+cat > "$fake" <<'FAKE'
+#!/usr/bin/env bash
+# Ignore all args; always return an empty registry.
+echo '[]'
+FAKE
+chmod +x "$fake"
+export CLAUDE_AGENTS_CMD="$fake"
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "N10b sweep exits 0" "0" "$rc"
+
+TOTAL=$((TOTAL + 1))
+if grep -q "SESSION_STATE_CENSUS: none (empty registry)" "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: N10b logs none on an empty registry"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: N10b logs none on an empty registry"
+  echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
+fi
+sweep_teardown
+
+# --- Test N10c: SESSION_STATE_CENSUS logs UNKNOWN when daemon unqueryable ---
+echo "Test: N10c SESSION_STATE_CENSUS logs UNKNOWN when the daemon is unqueryable"
+sweep_setup
+WT_PATH="$TMPDIR_TEST/project/worktrees/68-census-unknown"
+sweep_register_wt "$WT_PATH" "68-census-unknown"
+echo "OPEN" > "$STUB_DIR/issue-state-68.txt"
+key=$(sweep_path_key "$WT_PATH")
+: > "$STUB_DIR/status${key}.txt"
+echo "0" > "$STUB_DIR/revlist${key}.txt"
+
+fake="$TMPDIR_TEST/fake/claude"
+cat > "$fake" <<'FAKE'
+#!/usr/bin/env bash
+# Simulate a down/unqueryable daemon: nonzero exit, no stdout.
+exit 1
+FAKE
+chmod +x "$fake"
+export CLAUDE_AGENTS_CMD="$fake"
+
+out=$("$TMPDIR_TEST/scripts/dispatch-sweep" 2>/dev/null); rc=$?
+assert_eq "N10c sweep exits 0" "0" "$rc"
+
+TOTAL=$((TOTAL + 1))
+if grep -q "SESSION_STATE_CENSUS: UNKNOWN (daemon unqueryable)" "$DISPATCH_SWEEP_LOG_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: N10c logs UNKNOWN, never a literal none"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: N10c logs UNKNOWN, never a literal none"
+  echo "    log:"; sed 's/^/      /' "$DISPATCH_SWEEP_LOG_FILE" 2>/dev/null
+fi
+sweep_teardown
+
 report_results

--- a/.claude/skills/dispatch-propagate/scripts/test-lib-claude-agents.sh
+++ b/.claude/skills/dispatch-propagate/scripts/test-lib-claude-agents.sh
@@ -1681,4 +1681,185 @@ esac
 assert_eq "wrapper: the operator diagnostic still reaches stderr" "yes" "$diag_ok"
 ca_teardown
 
+# --- claude_agents_list_sessions_in_cwd_all -----------------------------------
+# The cwd-exact, keyspace-UNFILTERED registered-view lister. Emits
+# sessionId<TAB>id<TAB>name<TAB>state<TAB>status for every session whose .cwd
+# equals the argument exactly — routers, sync-repair, jit jobs and human
+# sessions included, since the worker keyspace filter is what made the
+# main-checkout `sync-repair` incident invisible.
+
+# --- Test 73: exact-cwd match emits only the matching rows -------------------
+echo "Test: claude_agents_list_sessions_in_cwd_all emits only rows whose cwd matches exactly"
+ca_setup
+write_fake_claude '[
+  {"sessionId":"s-here","id":"job-here","state":"working","status":"busy","name":"tactic-a","cwd":"/main"},
+  {"sessionId":"s-elsewhere","id":"job-else","state":"working","status":"busy","name":"tactic-b","cwd":"/other"}
+]' 0
+if out=$(claude_agents_list_sessions_in_cwd_all /main); then rc=0; else rc=$?; fi
+assert_eq "cwd-all-exact: exits 0" "0" "$rc"
+assert_eq "cwd-all-exact: only the /main row" \
+  "$(printf 's-here\tjob-here\ttactic-a\tworking\tbusy')" "$out"
+ca_teardown
+
+# --- Test 74: a prefix-extended cwd is NOT matched ---------------------------
+# A prefix/substring test rooted at the project root would match every worktree
+# under .claude/worktrees/, i.e. the whole fleet. Only exact equality counts.
+echo "Test: claude_agents_list_sessions_in_cwd_all does not match a prefix-extended cwd"
+ca_setup
+write_fake_claude '[
+  {"sessionId":"s-wt","id":"job-wt","state":"working","status":"busy","name":"tactic-x","cwd":"/main/.claude/worktrees/x"}
+]' 0
+if out=$(claude_agents_list_sessions_in_cwd_all /main); then rc=0; else rc=$?; fi
+assert_eq "cwd-all-prefix: exits 0" "0" "$rc"
+assert_eq "cwd-all-prefix: the worktree row under /main is not matched" "" "$out"
+ca_teardown
+
+# --- Test 75: a sync-repair row IS emitted (keyspace-filter-free ratchet) ----
+# `sync-repair` matches none of ^[0-9]+- / ^tactic- / ^strategy-, so every
+# keyspace-filtered lister hides it. This function must not.
+echo "Test: claude_agents_list_sessions_in_cwd_all emits a non-worker-keyspace sync-repair row"
+ca_setup
+write_fake_claude '[
+  {"sessionId":"s-sync","id":"job-sync","state":"blocked","status":"idle","name":"sync-repair","cwd":"/main"},
+  {"sessionId":"s-router","id":"job-router","state":"working","status":"busy","name":"dispatch-abc123","cwd":"/main"}
+]' 0
+if out=$(claude_agents_list_sessions_in_cwd_all /main); then rc=0; else rc=$?; fi
+assert_eq "cwd-all-keyspace: exits 0" "0" "$rc"
+assert_eq "cwd-all-keyspace: sync-repair and the router are both emitted" \
+  "$(printf 's-sync\tjob-sync\tsync-repair\tblocked\tidle\ns-router\tjob-router\tdispatch-abc123\tworking\tbusy')" \
+  "$out"
+ca_teardown
+
+# --- Test 76: a blocked row keeps `blocked` in the state column --------------
+# state (blocked) and status (idle) are projected RAW and unresolved; a probe
+# keying on status alone would read this session as merely idle.
+echo "Test: claude_agents_list_sessions_in_cwd_all projects state=blocked alongside status=idle"
+ca_setup
+write_fake_claude '[
+  {"sessionId":"s-b","id":"job-b","state":"blocked","status":"idle","name":"sync-repair","cwd":"/main"}
+]' 0
+if out=$(claude_agents_list_sessions_in_cwd_all /main); then rc=0; else rc=$?; fi
+assert_eq "cwd-all-blocked: exits 0" "0" "$rc"
+assert_eq "cwd-all-blocked: state column reads blocked" \
+  "$(printf 's-b\tjob-b\tsync-repair\tblocked\tidle')" "$out"
+ca_teardown
+
+# --- Test 77: a terminal row with no .status key is emitted ------------------
+echo "Test: claude_agents_list_sessions_in_cwd_all emits a done row that carries no .status"
+ca_setup
+write_fake_claude '[
+  {"sessionId":"s-done","id":"job-done","state":"done","name":"tactic-done","cwd":"/main"}
+]' 0
+if out=$(claude_agents_list_sessions_in_cwd_all /main); then rc=0; else rc=$?; fi
+assert_eq "cwd-all-done: exits 0" "0" "$rc"
+assert_eq "cwd-all-done: the absent status renders as an empty column" \
+  "$(printf 's-done\tjob-done\ttactic-done\tdone\t')" "$out"
+ca_teardown
+
+# --- Test 78: empty [] registry → rc 0, empty stdout (definite none) ---------
+echo "Test: claude_agents_list_sessions_in_cwd_all returns 0 with empty stdout for an empty registry"
+ca_setup
+write_fake_claude '[]' 0
+if out=$(claude_agents_list_sessions_in_cwd_all /main); then rc=0; else rc=$?; fi
+assert_eq "cwd-all-empty: exits 0 (definite zero, not UNKNOWN)" "0" "$rc"
+assert_eq "cwd-all-empty: prints nothing" "" "$out"
+ca_teardown
+
+# --- Test 79: daemon failure → rc 1, empty stdout ----------------------------
+echo "Test: claude_agents_list_sessions_in_cwd_all returns rc 1 on daemon failure"
+ca_setup
+write_fake_claude '' 1
+if out=$(claude_agents_list_sessions_in_cwd_all /main); then rc=0; else rc=$?; fi
+assert_eq "cwd-all-daemon-fail: exits non-zero (UNKNOWN)" "1" "$rc"
+assert_eq "cwd-all-daemon-fail: prints nothing" "" "$out"
+ca_teardown
+
+# --- Test 80: non-array JSON → rc 1 ------------------------------------------
+echo "Test: claude_agents_list_sessions_in_cwd_all returns rc 1 on non-array JSON output"
+ca_setup
+write_fake_claude '{}' 0
+if out=$(claude_agents_list_sessions_in_cwd_all /main); then rc=0; else rc=$?; fi
+assert_eq "cwd-all-non-array: exits non-zero (UNKNOWN)" "1" "$rc"
+assert_eq "cwd-all-non-array: prints nothing" "" "$out"
+ca_teardown
+
+# --- Test 81: a missing <path> argument → rc 1 -------------------------------
+echo "Test: claude_agents_list_sessions_in_cwd_all returns rc 1 when <path> is missing"
+ca_setup
+write_fake_claude '[{"sessionId":"s","id":"j","state":"working","status":"busy","name":"tactic-a","cwd":"/main"}]' 0
+if out=$(claude_agents_list_sessions_in_cwd_all 2>/dev/null); then rc=0; else rc=$?; fi
+assert_eq "cwd-all-no-arg: exits non-zero (UNKNOWN)" "1" "$rc"
+assert_eq "cwd-all-no-arg: prints nothing" "" "$out"
+ca_teardown
+
+# --- claude_agents_count_by_state ---------------------------------------------
+# The full-state census: `state<TAB>count` lines over every registered session
+# (no keyspace filter), plus `<keyspace><TAB><state><TAB><count>` lines over the
+# total worker/other partition and a per-keyspace `terminal` roll-up drawn from
+# the shared terminal_states enumeration (which excludes `blocked`).
+
+# --- Test 82: a mixed registry produces the expected census lines ------------
+# The `other  blocked  1` line is the regression ratchet for the incident: a
+# `sync-repair` session parked in state `blocked` was invisible to every probe.
+echo "Test: claude_agents_count_by_state censuses a mixed registry, sync-repair included"
+ca_setup
+write_fake_claude '[
+  {"sessionId":"s1","name":"tactic-a","state":"working","status":"busy","cwd":"/wt/a"},
+  {"sessionId":"s2","name":"sync-repair","state":"blocked","status":"idle","cwd":"/main"},
+  {"sessionId":"s3","name":"tactic-b","state":"done","cwd":"/wt/b"},
+  {"sessionId":"s4","name":"dispatch-abc123","state":"working","status":"busy","cwd":"/main"}
+]' 0
+if out=$(claude_agents_count_by_state); then rc=0; else rc=$?; fi
+assert_eq "census-mixed: exits 0" "0" "$rc"
+assert_eq "census-mixed: overall + keyspace census lines" \
+  "$(printf 'blocked\t1\ndone\t1\nworking\t2\nother\tblocked\t1\nother\tterminal\t0\nother\tworking\t1\nworker\tdone\t1\nworker\tterminal\t1\nworker\tworking\t1')" \
+  "$out"
+ca_teardown
+
+# --- Test 83: a stateless row lands in the <none> bucket ---------------------
+echo "Test: claude_agents_count_by_state buckets a row with neither state nor status as <none>"
+ca_setup
+write_fake_claude '[{"sessionId":"s-bare","cwd":"/main"}]' 0
+if out=$(claude_agents_count_by_state); then rc=0; else rc=$?; fi
+assert_eq "census-none: exits 0" "0" "$rc"
+assert_eq "census-none: the stateless row is counted under <none>, not dropped" \
+  "$(printf '<none>\t1\nother\t<none>\t1\nother\tterminal\t0')" "$out"
+ca_teardown
+
+# --- Test 84: the terminal roll-up counts done+errored but NOT blocked -------
+# `blocked` is deliberately absent from CLAUDE_AGENTS_TERMINAL_STATES_JQ (two
+# other consumers depend on it reading as a live claim), so it must show only in
+# its own state row, never in the roll-up.
+echo "Test: claude_agents_count_by_state rolls up done and errored as terminal, excluding blocked"
+ca_setup
+write_fake_claude '[
+  {"sessionId":"s1","name":"tactic-a","state":"done","cwd":"/wt/a"},
+  {"sessionId":"s2","name":"tactic-b","state":"errored","cwd":"/wt/b"},
+  {"sessionId":"s3","name":"tactic-c","state":"blocked","status":"idle","cwd":"/wt/c"}
+]' 0
+if out=$(claude_agents_count_by_state); then rc=0; else rc=$?; fi
+assert_eq "census-terminal: exits 0" "0" "$rc"
+assert_eq "census-terminal: roll-up is 2 (done+errored), blocked stands alone" \
+  "$(printf 'blocked\t1\ndone\t1\nerrored\t1\nworker\tblocked\t1\nworker\tdone\t1\nworker\terrored\t1\nworker\tterminal\t2')" \
+  "$out"
+ca_teardown
+
+# --- Test 85: empty [] registry → rc 0, empty stdout ------------------------
+echo "Test: claude_agents_count_by_state returns 0 with empty stdout for an empty registry"
+ca_setup
+write_fake_claude '[]' 0
+if out=$(claude_agents_count_by_state); then rc=0; else rc=$?; fi
+assert_eq "census-empty: exits 0 (definite zero, not UNKNOWN)" "0" "$rc"
+assert_eq "census-empty: prints nothing" "" "$out"
+ca_teardown
+
+# --- Test 86: daemon failure → rc 1, empty stdout ---------------------------
+echo "Test: claude_agents_count_by_state returns rc 1 on daemon failure"
+ca_setup
+write_fake_claude '' 1
+if out=$(claude_agents_count_by_state); then rc=0; else rc=$?; fi
+assert_eq "census-daemon-fail: exits non-zero (UNKNOWN)" "1" "$rc"
+assert_eq "census-daemon-fail: prints nothing" "" "$out"
+ca_teardown
+
 report_results


### PR DESCRIPTION
Implements the intention node `tactic-blocked-session-invisible-to-census`
(graph-native tactic; no GitHub issue).

## Summary

The reap/health census classified sessions on `state: done` alone, so a
session in any other non-`working` state (`blocked`, `stopped`) was invisible
to every health probe. When such a session sat in the **main checkout**, it
held the shared tree dirty indefinitely — blocking `dispatch-select-tick`'s
`--ff-only` sync and every `graph-commit`. This is exactly what happened
2026-08-06: background session `f2416fda` (`name: sync-repair`, `cwd` = main
checkout) went `state: blocked` after an API error and sat there for 3 days,
stalling the whole fleet, while `HELD_FOR_DEBUG_COUNT` read `n=0` the entire
time because `blocked` isn't a terminal state, and because `sync-repair`
doesn't match the existing worker-keyspace name filter either. This PR closes
both blind spots — state and keyspace — and adds a bounded escalation path so
a future incident like this self-resolves instead of stalling forever.

Invariant preserved throughout: `state: done` is the discriminator for
REAPING, not for HEALTH (I22). No unit here reaps, kills, or parks a `blocked`
session — reaping policy for `blocked` is deliberately out of scope.

## Unit 1 — Registered-view, cwd-keyed session lister + full-state census

Adds `claude_agents_list_sessions_in_cwd_all <path>` and
`claude_agents_count_by_state` to `lib-claude-agents.sh`. Both query
`claude agents --json --all` directly (the REGISTERED view, not the ACTIVE
`--cwd` snapshot) with **no keyspace filter**, closing the blind spot that
hid `sync-repair` (it matches none of `^[0-9]+-|^tactic-|^strategy-`). The
cwd filter is exact-string equality, never a prefix/substring test. The
by-state census emits both an overall and a keyspace-partitioned
(`worker`/`other`) breakdown, plus a `terminal` roll-up reusing the existing
shared `CLAUDE_AGENTS_TERMINAL_STATES_JQ` enum (never re-listed, and
`blocked` is deliberately never added to it). 28 new test cases in
`test-lib-claude-agents.sh`.

## Unit 2 — Surface the by-state breakdown in the sweep census

Wires `claude_agents_count_by_state` into `dispatch-sweep`'s existing
`HELD_FOR_DEBUG_COUNT` log block: one `SESSION_STATE_CENSUS` log line per
row, `none (empty registry)` on an empty census, `UNKNOWN (daemon
unqueryable)` on rc 1 — logged distinctly from zero, same convention as the
existing metric. Observability only; nothing downstream branches on it.

## Unit 3 — `main-checkout-held` alarm

Adds a `main-checkout-held` kind to `dispatch-fleet-alarm`'s closed `KINDS`
enum, and a sixth predicate to `dispatch-fleet-watch` that fires only on the
**conjunction**: the main checkout tree is dirty/ahead of `origin/main` AND
at least one registered session with `cwd` == the main checkout is
non-`working` and idle past a grace period (default 1800s, via the existing
`_standdown_session_idle_s` helper — not re-implemented). The conjunction is
deliberate: an ordinary interactive human session sitting idle in the repo
root must never alarm on its own — only a dirty/stuck tree does. Fail
direction: an unreadable daemon or unreadable tree yields `unknown`, never
`clear` (a false `clear` would `--resolve` an already-open alarm). The alarm
body is identity-only (sorted `name:state` pairs + the checkout path — never
session ids, ages, or counts, which stay in the live reading); it recommends
inspecting the session's transcript first, never a blind `claude rm`.

## Unit 4 — Bound Decision A's defer in `dispatch-select-tick`

The tick's "Decision A" deferred while a `sync-repair` session was "live" in
the main checkout, but the check was unbounded: it read the ACTIVE-only view
(invisible to a `stopped`/`done` holder) and treated any non-`"stopped"`
status — which includes `blocked`, since a blocked session's `.status`
projects as `idle` — as "still live," forever. This made the existing
3-attempt `sync-broken` escalation cap structurally unreachable. Now the
tick reads the REGISTERED view via Unit 1's lister, defers only while a
session is genuinely `working`/`busy` or non-working-but-within-grace, and
otherwise falls through to the existing fetch/merge probe — letting a failed
merge bump the attempt counter and eventually reach `sync-broken`, the
correct escalation the incident could never reach. `DLOG_SKIP_REASON` names
the stuck session and state for the decision log. Daemon UNKNOWN still fails
open (unchanged); idle-UNKNOWN still fails safe (defers).

## Verification

```verify
.claude/skills/dispatch-propagate/scripts/test-lib-claude-agents.sh
.claude/skills/dispatch-propagate/scripts/test-dispatch-sweep.sh
.claude/skills/dispatch-propagate/scripts/test-dispatch-fleet-alarm.sh
.claude/skills/dispatch-propagate/scripts/test-dispatch-fleet-watch.sh
.claude/skills/dispatch-propagate/scripts/test-dispatch-select-tick.sh
.claude/skills/dispatch-propagate/scripts/run-lint.sh
```

All six passed locally (922 total assertions across the five suites, plus a
clean lint pass).

### Manual / observe-in-production checks (not run this session — require
`dangerouslyDisableSandbox: true` on a live daemon)

1. Census breadth, live: run `dispatch-sweep` and confirm `SESSION_STATE_CENSUS`
   lines sum to `claude agents --json --all | jq length`.
2. Keyspace ratchet, live: confirm a non-worker-named session (e.g. a router)
   appears under `keyspace=other`.
3. Alarm precision, negative case: an ordinary interactive session + clean
   main checkout → `main-checkout-held: clear`.
4. Alarm, positive case: dirty tree + stuck session past grace → `finding`,
   `tactic-fleet-alarm-main-checkout-held` minted; a second pass with a
   different idle age pushes no second commit (body-identity gate holds).
5. Decision A end to end: the next real stuck main-checkout session should
   log the attributed skip reason, bump the attempt counter across ticks,
   and latch `sync-broken` on the third.
6. I22 preserved: no `blocked` session reaped/killed/parked by any of this.
