### PR TITLE
graph: arm strategy-graph-native-dispatch's success_signal (tactic-graph-native-signal-instrument-arm)

### DIFF
--- a/packages/intentionsutil/scripts/align-tactics-census.ts
+++ b/packages/intentionsutil/scripts/align-tactics-census.ts
@@ -18,16 +18,8 @@
 // propagate as thrown errors — no fallback, no silent default.
 
 import { listNodes, readNodeBody } from "../src/store.js";
-import type { IntentionNode } from "../src/schema.js";
-
-type Classification = "draft" | "born-parked" | "open" | "done";
-
-function classify(node: IntentionNode): Classification {
-  if (node.phase === "done") return "done";
-  if (node.phase !== null) return "open";
-  // phase is null/absent here
-  return node.office_hours === null ? "draft" : "born-parked";
-}
+import { classifyTactic } from "../src/census.js";
+import type { TacticClassification } from "../src/census.js";
 
 function headings(body: string): string[] {
   const matches = body.matchAll(/^##\s+(.+)$/gm);
@@ -55,7 +47,7 @@ function main(): void {
   const tactics = nodes.filter((n) => n.kind === "tactic" && n.serves.includes(strategyId));
 
   for (const tactic of tactics) {
-    const classification = classify(tactic);
+    const classification: TacticClassification = classifyTactic(tactic);
     const body = readNodeBody(intentionsDir, tactic.id);
     const lines: string[] = [];
     lines.push(`id: ${tactic.id}`);

--- a/packages/intentionsutil/scripts/read-sensors.ts
+++ b/packages/intentionsutil/scripts/read-sensors.ts
@@ -48,6 +48,8 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { listNodes, writeNode } from "../src/store.js";
+import { strategyBacklogBand } from "../src/census.js";
+import { listNodesAtRef } from "./lib-store-at-ref.js";
 import { SensorRegistry, deriveGap, type Sensor } from "../src/sensors.js";
 import { IntentionSchemaError } from "../src/errors.js";
 import type { IntentionNode } from "../src/schema.js";
@@ -430,17 +432,37 @@ const tokenEconomySensor: Sensor = {
 // Name is the exact `success_signal.sensor` string
 // `strategy-graph-native-dispatch` declares — the driver resolves a sensor by
 // that verbatim name (`token-economy` uses the same match-the-declared-name
-// contract). The reading is dual, mirroring the strategy's dual source:
-//   (a) the phase-transition history in the local `intentions/` git log, and
-//   (b) the router's own selection log (emitted by graph-select-target).
+// contract). The reading has four segments, mirroring the strategy's sources:
+//   (a) the phase-transition history in the local `intentions/` git log,
+//   (b) the router's own selection log (emitted by graph-select-target),
+//   (c) the CURRENT open machinery-defect backlog share over the tactic
+//       population serving this strategy — the same classification
+//       `align-tactics-census.ts` applies, reused from `../src/census.js`, and
+//   (d) that same share SAMPLED BACKWARD through the `intentions/` git history,
+//       so the band reads as a trend rather than a single instant.
 // Format (stable and parseable):
-//   `lifecycle: <id> implement→qa→review→done (<YYYY-MM-DD>); router selections: <R> records, <D> nodes`
-// with the lifecycle half degrading to `none yet` (no completed graph-native
-// tactic lifecycle in history) and the selections half to `unknown` (missing or
-// unreadable log) — never a throw (total-sensor contract above).
+//   `lifecycle: <id> implement→qa→review→done (<YYYY-MM-DD>); router selections: <R> records, <D> nodes; backlog: <B>/<T> = <P>% (band ≤35%); backlog series <W>d: <P1>% → <P2>% → … (<verdict>)`
+// Every segment degrades independently and never throws (total-sensor contract
+// above): the lifecycle half to `none yet`, the selections half to `unknown`
+// (missing or unreadable log), the backlog half to `unknown` (store unreadable)
+// or `0/0 = n/a` (no tactics serve the strategy yet), and the series to
+// `unknown` (git history unavailable), `insufficient history` (fewer than two
+// distinct sampled store states), or a per-sample `skipped` token (that
+// historical ref's store does not read/validate).
 
 /** The verbatim `success_signal.sensor` name on strategy-graph-native-dispatch. */
-const LIFECYCLE_SENSOR_NAME = "the intention store and the router's selection log";
+export const LIFECYCLE_SENSOR_NAME =
+  "the intention store and the router's selection log — align-tactics-census.ts enumerates the open machinery-defect population serving this strategy; the selection log carries lifecycle completions";
+
+/** The band the recorded threshold declares ("at or below 35%"). */
+export const BACKLOG_BAND_PCT = 35;
+
+/** The strategy whose tactic population the band is measured over. */
+const BACKLOG_STRATEGY_ID = "strategy-graph-native-dispatch";
+
+/** Trailing window the backlog-share series samples over, and its step. */
+const BACKLOG_SERIES_WINDOW_DAYS = 28;
+const BACKLOG_SERIES_STEP_DAYS = 7;
 
 /**
  * Phases a graph-native tactic passes through; a full lifecycle observes ALL of
@@ -632,13 +654,129 @@ export function readSelectionLog(selectionLogPath: string): string {
 }
 
 /**
- * Compose the full lifecycle reading from its two halves. Exported for unit
- * tests, which inject a fixture git repo and a fixture selection log.
+ * Backlog half: the CURRENT open machinery-defect share over the tactic
+ * population serving `strategyId`, against the band the recorded threshold
+ * declares. Classification is `../src/census.js`'s `strategyBacklogBand` — the
+ * same rules `align-tactics-census.ts` applies, so the sensor and the census
+ * can never disagree.
+ *
+ * Enumeration uses the TOLERANT `listNodes` (a single unreadable node file must
+ * not blind the whole reading), wrapped in try/catch so a missing or unreadable
+ * store dir reads `unknown` rather than throwing — the total-sensor contract at
+ * the top of this file. `total === 0` (no tactic serves the strategy yet) reads
+ * `0/0 = n/a` rather than dividing by zero.
  */
-export function readLifecycleReading(repoDir: string, selectionLogPath: string): string {
+export function readBacklogBand(storeDir: string, strategyId: string): string {
+  let nodes: IntentionNode[];
+  try {
+    nodes = listNodes(storeDir);
+  } catch {
+    return "unknown";
+  }
+  const { backlog, total, pct } = strategyBacklogBand(nodes, strategyId);
+  if (pct === null) {
+    return `0/0 = n/a (band ≤${BACKLOG_BAND_PCT}%)`;
+  }
+  return `${backlog}/${total} = ${(pct * 100).toFixed(1)}% (band ≤${BACKLOG_BAND_PCT}%)`;
+}
+
+/**
+ * Series half: the same backlog share sampled backward through the local
+ * clone's `intentions/` git history, so the band reads as a trend rather than a
+ * single instant. One sample per `stepDays` step across the trailing
+ * `windowDays` window (28/7 → offsets 21, 14, 7, 0 days ago), each resolved to
+ * the last `intentions/`-touching commit before that instant.
+ *
+ * Samples that resolve to no commit are dropped, and consecutive identical SHAs
+ * are collapsed, so every element is a DISTINCT committed store state rather
+ * than a repeated flat value.
+ *
+ * Failure posture matches `readTacticVelocity` / `readLifecyclePhaseHistory`: a
+ * git failure (not a repo, no commits) reads `unknown`. Per sample, the read is
+ * `listNodesAtRef`, which is STRICT and throws when any node at that historical
+ * ref is unreadable or schema-invalid — a real possibility for old refs, so each
+ * sample is caught individually and degrades to the literal token `skipped`
+ * (as does a `null` pct: no tactic served the strategy at that ref). A throw
+ * never propagates out of this function.
+ *
+ * The trend verdict is computed over the ROUNDED values actually printed, so
+ * the rendered series and the verdict can never disagree through float noise.
+ */
+export function readBacklogSeries(
+  repoDir: string,
+  strategyId: string,
+  windowDays: number = BACKLOG_SERIES_WINDOW_DAYS,
+  stepDays: number = BACKLOG_SERIES_STEP_DAYS,
+): string {
+  const shas: string[] = [];
+  try {
+    for (let d = windowDays - stepDays; d >= 0; d -= stepDays) {
+      const sha = execFileSync(
+        "git",
+        ["-C", repoDir, "rev-list", "-1", `--before=${d} days ago`, "HEAD", "--", "intentions"],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+      ).trim();
+      if (sha === "") {
+        continue;
+      }
+      if (shas.length > 0 && shas[shas.length - 1] === sha) {
+        continue;
+      }
+      shas.push(sha);
+    }
+  } catch {
+    return "unknown";
+  }
+
+  const rendered: string[] = [];
+  const usable: number[] = [];
+  for (const sha of shas) {
+    let pct: number | null;
+    try {
+      pct = strategyBacklogBand(listNodesAtRef(repoDir, sha), strategyId).pct;
+    } catch {
+      rendered.push("skipped");
+      continue;
+    }
+    if (pct === null) {
+      rendered.push("skipped");
+      continue;
+    }
+    const value = Number((pct * 100).toFixed(1));
+    usable.push(value);
+    rendered.push(`${value.toFixed(1)}%`);
+  }
+
+  if (usable.length < 2) {
+    return "insufficient history";
+  }
+  let nonIncreasing = true;
+  for (let i = 0; i + 1 < usable.length; i += 1) {
+    if (usable[i + 1] > usable[i]) {
+      nonIncreasing = false;
+      break;
+    }
+  }
+  return `${rendered.join(" → ")} (${nonIncreasing ? "non-increasing" : "increasing"})`;
+}
+
+/**
+ * Compose the full lifecycle reading from its four segments. Exported for unit
+ * tests, which inject a fixture git repo and a fixture selection log. The store
+ * dir is derived from `repoDir` so the current band and the sampled history come
+ * from the same repository.
+ */
+export function readLifecycleReading(
+  repoDir: string,
+  selectionLogPath: string,
+  strategyId: string = BACKLOG_STRATEGY_ID,
+): string {
+  const storeDir = join(repoDir, "intentions");
   return (
     `lifecycle: ${readLifecyclePhaseHistory(repoDir)}; ` +
-    `router selections: ${readSelectionLog(selectionLogPath)}`
+    `router selections: ${readSelectionLog(selectionLogPath)}; ` +
+    `backlog: ${readBacklogBand(storeDir, strategyId)}; ` +
+    `backlog series ${BACKLOG_SERIES_WINDOW_DAYS}d: ${readBacklogSeries(repoDir, strategyId)}`
   );
 }
 

--- a/packages/intentionsutil/src/census.ts
+++ b/packages/intentionsutil/src/census.ts
@@ -1,0 +1,40 @@
+// Pure classification logic for the tactic census, extracted from
+// align-tactics-census.ts so other consumers (e.g. the lifecycle sensor) can
+// reuse the exact same rules without shelling out to the script.
+//
+// This module is fs-free and process-free by design: no `node:fs`, no
+// `child_process`. Callers supply the already-loaded node list.
+
+import type { IntentionNode } from "./schema.js";
+
+export type TacticClassification = "draft" | "born-parked" | "open" | "done";
+
+/** Verbatim semantics of align-tactics-census.ts's classify(). */
+export function classifyTactic(node: IntentionNode): TacticClassification {
+  if (node.phase === "done") return "done";
+  if (node.phase !== null) return "open";
+  // phase is null/absent here
+  return node.office_hours === null ? "draft" : "born-parked";
+}
+
+export interface BacklogBand {
+  backlog: number; // open + born-parked tactics serving the strategy
+  total: number; // ALL tactics serving the strategy (draft+born-parked+open+done)
+  pct: number | null; // null when total === 0 (no division by zero)
+}
+
+export function strategyBacklogBand(
+  nodes: IntentionNode[],
+  strategyId: string,
+): BacklogBand {
+  const tactics = nodes.filter(
+    (n) => n.kind === "tactic" && n.serves.includes(strategyId),
+  );
+  const total = tactics.length;
+  const backlog = tactics.filter((n) => {
+    const classification = classifyTactic(n);
+    return classification === "open" || classification === "born-parked";
+  }).length;
+  const pct = total === 0 ? null : backlog / total;
+  return { backlog, total, pct };
+}

--- a/packages/intentionsutil/src/index.ts
+++ b/packages/intentionsutil/src/index.ts
@@ -74,3 +74,5 @@ export {
   confirmPushDowns,
 } from "./sensors.js";
 export type { Sensor, Reading, IntentionCandidate } from "./sensors.js";
+export { classifyTactic, strategyBacklogBand } from "./census.js";
+export type { TacticClassification, BacklogBand } from "./census.js";

--- a/packages/intentionsutil/test/census.test.ts
+++ b/packages/intentionsutil/test/census.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import type { IntentionNode, OfficeHours } from "../src/schema.js";
+import { classifyTactic, strategyBacklogBand } from "../src/census.js";
+
+/** A well-formed office_hours record for a parked fixture node. */
+function parked(reason: string): OfficeHours {
+  return { reason, since: "2026-07-01", recommendation: null, session_type: "other" };
+}
+
+/** Build an IntentionNode fixture, filling required/default fields. */
+function node(partial: Partial<IntentionNode> & { id: string }): IntentionNode {
+  return {
+    id: partial.id,
+    kind: partial.kind ?? "tactic",
+    statement: partial.statement ?? `Statement for ${partial.id}`,
+    owner: partial.owner ?? "human",
+    status: partial.status ?? "codified",
+    parent: partial.parent ?? null,
+    serves: partial.serves ?? [],
+    recovers: partial.recovers ?? [],
+    rationale: partial.rationale ?? null,
+    reading: partial.reading ?? null,
+    gap: partial.gap ?? null,
+    clarifications: partial.clarifications ?? [],
+    tooling_goals: partial.tooling_goals ?? [],
+    success_signal: partial.success_signal ?? null,
+    attention: partial.attention ?? null,
+    phase: partial.phase ?? null,
+    execution: partial.execution ?? null,
+    validates: partial.validates ?? [],
+    blocked_by: partial.blocked_by ?? [],
+    office_hours: partial.office_hours ?? null,
+    pace_exempt: partial.pace_exempt ?? false,
+    rounds: partial.rounds ?? null,
+    attributes: partial.attributes ?? {},
+  };
+}
+
+describe("classifyTactic", () => {
+  it("phase:done -> done, regardless of office_hours", () => {
+    expect(classifyTactic(node({ id: "t", phase: "done" }))).toBe("done");
+  });
+
+  it("any other non-null phase -> open", () => {
+    expect(classifyTactic(node({ id: "t", phase: "qa" }))).toBe("open");
+    expect(classifyTactic(node({ id: "t", phase: "implement" }))).toBe("open");
+  });
+
+  it("phase:null + office_hours:null -> draft", () => {
+    expect(classifyTactic(node({ id: "t", phase: null, office_hours: null }))).toBe("draft");
+  });
+
+  it("phase:null + non-null office_hours -> born-parked", () => {
+    expect(
+      classifyTactic(node({ id: "t", phase: null, office_hours: parked("waiting") })),
+    ).toBe("born-parked");
+  });
+});
+
+describe("strategyBacklogBand", () => {
+  it("counts only kind:tactic nodes whose serves includes the strategy id", () => {
+    const nodes = [
+      node({ id: "strategy-x", kind: "strategy", serves: ["strategy-x"] }),
+      node({ id: "t-other-strategy", kind: "tactic", serves: ["strategy-y"], phase: "qa" }),
+      node({ id: "t1", kind: "tactic", serves: ["strategy-x"], phase: "qa" }),
+    ];
+    const band = strategyBacklogBand(nodes, "strategy-x");
+    expect(band.total).toBe(1);
+    expect(band.backlog).toBe(1);
+  });
+
+  it("backlog = open + born-parked; total also includes draft and done", () => {
+    const nodes = [
+      node({ id: "t-draft", kind: "tactic", serves: ["strategy-x"], phase: null, office_hours: null }),
+      node({
+        id: "t-parked",
+        kind: "tactic",
+        serves: ["strategy-x"],
+        phase: null,
+        office_hours: parked("r"),
+      }),
+      node({ id: "t-open", kind: "tactic", serves: ["strategy-x"], phase: "implement" }),
+      node({ id: "t-done", kind: "tactic", serves: ["strategy-x"], phase: "done" }),
+    ];
+    const band = strategyBacklogBand(nodes, "strategy-x");
+    expect(band.total).toBe(4);
+    expect(band.backlog).toBe(2); // t-parked + t-open
+    expect(band.pct).toBe(0.5);
+  });
+
+  it("total===0 yields pct:null", () => {
+    const band = strategyBacklogBand([], "strategy-x");
+    expect(band.total).toBe(0);
+    expect(band.backlog).toBe(0);
+    expect(band.pct).toBeNull();
+  });
+});

--- a/packages/intentionsutil/test/lifecycle-sensor.test.ts
+++ b/packages/intentionsutil/test/lifecycle-sensor.test.ts
@@ -1,16 +1,24 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
+  BACKLOG_BAND_PCT,
+  LIFECYCLE_SENSOR_NAME,
   buildDefaultRegistry,
+  readBacklogBand,
+  readBacklogSeries,
   readLifecyclePhaseHistory,
   readLifecycleReading,
   readSelectionLog,
 } from "../scripts/read-sensors.js";
+import { writeNodeFromJson } from "../scripts/write-node.js";
+import { readNode } from "../src/store.js";
 
-const LIFECYCLE_SENSOR_NAME = "the intention store and the router's selection log";
+const STRATEGY_ID = "strategy-graph-native-dispatch";
+const EMPTY_BAND = `0/0 = n/a (band ≤${BACKLOG_BAND_PCT}%)`;
 
 function tempDir(): string {
   return mkdtempSync(join(tmpdir(), "lifecycle-sensor-"));
@@ -151,7 +159,10 @@ describe("readLifecycleReading", () => {
       JSON.stringify({ selected: ["tactic-full"] }),
     ]);
     expect(readLifecycleReading(repo, log)).toBe(
-      "lifecycle: tactic-full implement→qa→review→done (2026-07-05); router selections: 1 records, 1 nodes",
+      "lifecycle: tactic-full implement→qa→review→done (2026-07-05); " +
+        "router selections: 1 records, 1 nodes; " +
+        `backlog: ${EMPTY_BAND}; ` +
+        "backlog series 28d: insufficient history",
     );
     rmSync(repo, { recursive: true, force: true });
   });
@@ -161,8 +172,140 @@ describe("readLifecycleReading", () => {
     writeFileSync(join(repo, "intentions", "tactic-open.md"), tacticFile("tactic-open", { phase: "implement" }));
     commitAll(repo, "add tactic-open");
     expect(readLifecycleReading(repo, join(tempDir(), "absent.jsonl"))).toBe(
-      "lifecycle: none yet; router selections: unknown",
+      "lifecycle: none yet; router selections: unknown; " +
+        `backlog: ${EMPTY_BAND}; ` +
+        "backlog series 28d: insufficient history",
     );
+    rmSync(repo, { recursive: true, force: true });
+  });
+});
+
+/** A schema-valid tactic node JSON serving the strategy under test. */
+function nodeJson(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    id: "tactic-fixture",
+    kind: "tactic",
+    statement: "A fixture tactic node.",
+    owner: "ai",
+    status: "draft",
+    parent: null,
+    serves: [STRATEGY_ID],
+    ...overrides,
+  });
+}
+
+/** ISO timestamp `n` days before now, for backdating fixture commits. */
+function daysAgo(n: number): string {
+  return new Date(Date.now() - n * 86400 * 1000).toISOString();
+}
+
+describe("readBacklogBand", () => {
+  it("counts open + born-parked over the whole served tactic population", () => {
+    const repo = initRepo();
+    const store = join(repo, "intentions");
+    writeNodeFromJson(store, nodeJson({ id: "tactic-draft", phase: null, office_hours: null }));
+    writeNodeFromJson(
+      store,
+      nodeJson({
+        id: "tactic-parked",
+        phase: null,
+        office_hours: { reason: "needs a call", since: "2026-07-01", recommendation: null },
+      }),
+    );
+    writeNodeFromJson(store, nodeJson({ id: "tactic-open", phase: "implement" }));
+    writeNodeFromJson(store, nodeJson({ id: "tactic-done", phase: "done" }));
+    expect(readBacklogBand(store, STRATEGY_ID)).toBe(
+      `2/4 = 50.0% (band ≤${BACKLOG_BAND_PCT}%)`,
+    );
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("reads n/a rather than dividing by zero when no tactic serves the strategy", () => {
+    const repo = initRepo();
+    const store = join(repo, "intentions");
+    writeNodeFromJson(store, nodeJson({ id: "tactic-other", serves: ["strategy-other"] }));
+    expect(readBacklogBand(store, STRATEGY_ID)).toBe(EMPTY_BAND);
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("reads unknown when the store dir does not exist", () => {
+    expect(readBacklogBand(join(tempDir(), "absent"), STRATEGY_ID)).toBe("unknown");
+  });
+});
+
+describe("readBacklogSeries", () => {
+  /**
+   * A repo with three day-spaced committed store states. Each entry is the set
+   * of `{ id, phase }` served tactics present at that commit; `extraFiles` lets
+   * a commit introduce a raw (possibly invalid) file.
+   */
+  function seriesRepo(
+    states: { phases: (string | null)[]; date: string; badFile?: boolean }[],
+  ): string {
+    const repo = initRepo();
+    const store = join(repo, "intentions");
+    for (const [index, state] of states.entries()) {
+      rmSync(store, { recursive: true, force: true });
+      mkdirSync(store);
+      state.phases.forEach((phase, i) => {
+        writeNodeFromJson(
+          store,
+          nodeJson({ id: `tactic-${i}`, phase, office_hours: null }),
+        );
+      });
+      if (state.badFile === true) {
+        writeFileSync(join(store, "tactic-broken.md"), "---\nid: tactic-broken\n---\nno kind\n");
+      }
+      commitAll(repo, `state ${index}`, state.date);
+    }
+    return repo;
+  }
+
+  it("renders a falling series as non-increasing", () => {
+    const repo = seriesRepo([
+      { phases: ["implement", "implement", "implement"], date: daysAgo(5) },
+      { phases: ["done", "done", "implement"], date: daysAgo(1.5) },
+      { phases: ["done", "done", "done"], date: daysAgo(0.2) },
+    ]);
+    expect(readBacklogSeries(repo, STRATEGY_ID, 3, 1)).toBe(
+      "100.0% → 33.3% → 0.0% (non-increasing)",
+    );
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("renders a series that rises at any step as increasing", () => {
+    const repo = seriesRepo([
+      { phases: ["done", "done", "done"], date: daysAgo(5) },
+      { phases: ["implement", "done", "done"], date: daysAgo(1.5) },
+      { phases: ["done", "done", "done"], date: daysAgo(0.2) },
+    ]);
+    expect(readBacklogSeries(repo, STRATEGY_ID, 3, 1)).toBe(
+      "0.0% → 33.3% → 0.0% (increasing)",
+    );
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("renders skipped for a ref whose store does not validate, without throwing", () => {
+    const repo = seriesRepo([
+      { phases: ["implement", "implement", "implement"], date: daysAgo(5) },
+      { phases: ["done", "done", "implement"], date: daysAgo(1.5), badFile: true },
+      { phases: ["done", "done", "done"], date: daysAgo(0.2) },
+    ]);
+    expect(readBacklogSeries(repo, STRATEGY_ID, 3, 1)).toBe(
+      "100.0% → skipped → 0.0% (non-increasing)",
+    );
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("reads unknown when git history is unavailable (not a repo)", () => {
+    expect(readBacklogSeries(tempDir(), STRATEGY_ID, 3, 1)).toBe("unknown");
+  });
+
+  it("reads insufficient history from a single distinct sampled store state", () => {
+    const repo = seriesRepo([
+      { phases: ["implement", "done"], date: daysAgo(0.2) },
+    ]);
+    expect(readBacklogSeries(repo, STRATEGY_ID, 3, 1)).toBe("insufficient history");
     rmSync(repo, { recursive: true, force: true });
   });
 });
@@ -171,5 +314,18 @@ describe("buildDefaultRegistry", () => {
   it("registers the lifecycle sensor under the name the strategy declares", () => {
     const registry = buildDefaultRegistry();
     expect(registry.resolve(LIFECYCLE_SENSOR_NAME).name).toBe(LIFECYCLE_SENSOR_NAME);
+  });
+});
+
+// Anti-drift guard: registry resolution is verbatim string match, so the
+// registered name must equal the recorded `success_signal.sensor` exactly.
+// Skips cleanly when the store is absent (same posture as committed-store.test.ts).
+const testDir = dirname(fileURLToPath(import.meta.url));
+const intentionsDir = join(dirname(dirname(dirname(testDir))), "intentions");
+
+describe.skipIf(!existsSync(intentionsDir))("recorded sensor name", () => {
+  it("LIFECYCLE_SENSOR_NAME equals strategy-graph-native-dispatch's success_signal.sensor", () => {
+    const node = readNode(intentionsDir, STRATEGY_ID);
+    expect(node.success_signal?.sensor).toBe(LIFECYCLE_SENSOR_NAME);
   });
 });


### PR DESCRIPTION
Implements the intention node `tactic-graph-native-signal-instrument-arm`
(graph-native tactic; no GitHub issue).

`strategy-graph-native-dispatch` carries a `success_signal` whose `reading` is
permanently `null`: `SensorRegistry.resolve` (`packages/intentionsutil/src/sensors.ts:49-59`)
is an exact-string `Map.get` match that throws with no fallback, and the
registered `LIFECYCLE_SENSOR_NAME` constant drifted from the recorded
`success_signal.sensor` string, so `readStoreSensors` bucketed the node under
`summary.unregistered` and never wrote a reading.

This PR ships Units 1 and 2 of the node's plan — the code changes. Unit 3
(landing a fresh reading on `main` via `npm run read-sensors`) is post-merge
work with no files in this PR; it is recorded as `## needs-main residue` on
the node's own body so qa routes the node to `main-qa` instead of `done`.

## Unit 1 — Extract the census classification into `src/` as the single home

New `packages/intentionsutil/src/census.ts` — a pure, fs-free module exporting
`classifyTactic` (reproducing `align-tactics-census.ts`'s open/born-parked/
draft/done rules verbatim) and `strategyBacklogBand` (counts open+born-parked
tactics serving a strategy as a fraction of all tactics serving it).
`align-tactics-census.ts` is re-pointed at the new module; its stdout format
is unchanged. Re-exported from `src/index.ts`. New `test/census.test.ts`
covers all four classification branches and the backlog-band counting,
including the `total === 0` → `pct: null` case.

## Unit 2 — Re-point the sensor name and add the backlog segment

`packages/intentionsutil/scripts/read-sensors.ts`:

- `LIFECYCLE_SENSOR_NAME` re-pointed to the verbatim 195-character recorded
  `success_signal.sensor` string (derived mechanically via `readNode`, never
  retyped), and now exported (mirrors `INTENTION_STORE_SENSOR_NAME`).
- New `readBacklogBand(storeDir, strategyId)` — the current backlog ratio
  against the strategy's declared ≤35% band, `"unknown"` on a load failure
  (never throws — preserves the sensor's total-sensor contract).
- New `readBacklogSeries(repoDir, strategyId, windowDays=28, stepDays=7)` —
  samples the backlog ratio at weekly git-history points via
  `listNodesAtRef`, guarding each sample individually (`listNodesAtRef` throws
  on a node unreadable at a historical ref; a throwing or empty sample
  degrades to `skipped`, never propagates) and appending a `(non-increasing)`
  / `(increasing)` trend verdict computed over the displayed, rounded values.
- `readLifecycleReading` now composes four segments:
  `lifecycle: …; router selections: …; backlog: …; backlog series 28d: …`.

`test/lifecycle-sensor.test.ts` updated in lockstep (imports the sensor-name
constant from the script rather than re-declaring it) and gains an anti-drift
guard test that reads the live committed node and asserts the registered name
equals its recorded `success_signal.sensor` — the strongest regression
barrier against this defect recurring — plus new coverage for
`readBacklogBand` and `readBacklogSeries` (including the schema-invalid
historical node → `skipped`, non-repo → `unknown`, and single-sample →
`insufficient history` cases).

Note: `strategyBacklogBand.pct` (Unit 1) is a fraction, not a percentage;
both new readers multiply by 100 before formatting.

## Verification

- `npx vitest run --project packages/intentionsutil --root .` — 45 files,
  898 tests passing.
- `npx tsc --noEmit -p packages/intentionsutil` — clean.
- `npm run lint --prefix packages/intentionsutil` — clean.
- Live sanity read against this worktree:
  `lifecycle: … ; router selections: unknown; backlog: 66/231 = 28.6% (band ≤35%); backlog series 28d: 47.6% → 39.8% → 29.7% → 28.6% (non-increasing)`
