### PR TITLE
Run the first mechanical sensor pass: register the delegation-records sensor, run read-sensors over the widened scope

### DIFF
--- a/intentions/strategy-exercise-recovery-paths.md
+++ b/intentions/strategy-exercise-recovery-paths.md
@@ -36,8 +36,11 @@ rationale: >-
   refinement are the standard triggers, with ad-hoc prioritization via the
   capture-visibility surface) — so aggregate drift has an owner. The divergence
   half is why this strategy also serves virtue-alignment-of-attachments.
-reading: null
-gap: null
+reading: "exercised: 4/22 records; 18 null last_exercised; review_trigger firing
+  not recorded"
+gap: "reading \"exercised: 4/22 records; 18 null last_exercised; review_trigger
+  firing not recorded\" does not meet threshold \"no record's last_exercised is
+  null, and no fired review_trigger is left unactioned\""
 serves:
   - virtue-progressive-detachment
   - virtue-alignment-of-attachments
@@ -74,6 +77,7 @@ pace_exempt: false
 rounds:
   count: 0
   last_completed: null
+  last_aligned: null
 attributes:
   conditions:
     - drills stay affordable — walking a path costs days, not the price of the

--- a/intentions/strategy-graph-drives-dispatch.md
+++ b/intentions/strategy-graph-drives-dispatch.md
@@ -26,8 +26,12 @@ rationale: >-
   write readings and gaps back after execution, and the next dialectic consumes
   that feedback when it triages. strategy-autonomous-execution owns the chain
   itself; this node owns the chain's coupling to intent.
-reading: null
-gap: null
+reading: "serves: 126/126 open tactics; readings: 14/52 sensor-naming strategies
+  (46 unregistered sensors)"
+gap: 'reading "serves: 126/126 open tactics; readings: 14/52 sensor-naming
+  strategies (46 unregistered sensors)" does not meet threshold "every open
+  tactic carries a non-empty serves edge and sensor-run readings exist for every
+  strategy that names a sensor"'
 serves:
   - virtue-philosophical-mobility
   - virtue-progressive-detachment

--- a/intentions/strategy-graph-native-dispatch.md
+++ b/intentions/strategy-graph-native-dispatch.md
@@ -39,8 +39,19 @@ rationale: "strategy-graph-drives-dispatch made the loop real — intent enters
   superseded migration-completion threshold could not read. success_signal was
   amended this round accordingly; see the threshold-shape and steelman
   clarifications below."
-reading: null
-gap: null
+reading: "lifecycle: tactic-graph-select-target-node-tests
+  implement→qa→review→done (2026-08-10); router selections: 2177 records, 279
+  nodes; backlog: 64/233 = 27.5% (band ≤35%); backlog series 28d: 47.6% → 39.8%
+  → 29.7% → 27.5% (non-increasing)"
+gap: "reading \"lifecycle: tactic-graph-select-target-node-tests
+  implement→qa→review→done (2026-08-10); router selections: 2177 records, 279
+  nodes; backlog: 64/233 = 27.5% (band ≤35%); backlog series 28d: 47.6% → 39.8%
+  → 29.7% → 27.5% (non-increasing)\" does not meet threshold \"the owned path
+  carries tactics through the full lifecycle continuously, and the machinery's
+  own open defect backlog — open (phase set, not done) plus born-parked tactics
+  serving this strategy — stays at or below 35% of all tactics serving this
+  strategy and is non-increasing across consecutive samples derived from
+  intentions/ git history at read time\""
 serves:
   - virtue-progressive-detachment
   - virtue-alignment-of-attachments

--- a/intentions/strategy-main-health.md
+++ b/intentions/strategy-main-health.md
@@ -15,31 +15,20 @@ rationale: "Red main halts the autonomous dispatch chain — no new work is safe
   validate this node and inherit its standing boost through the normal downward
   attention flow; the boost's dominance is maintained by a write-path guard
   (author override required to out-boost or reduce it), never by recompute.
-  2026-07-31: the standing boost 100 is migrated to attributes.tier: 3 under
-  the tier model — red-main fix tactics now inherit tier 3 through the same
-  downward parent/serves flow, and dominance is structural (this node is simply
-  in the top tier) rather than numeric (highest boost). The write-path guard
+  2026-07-31: the standing boost 100 is migrated to attributes.tier: 3 under the
+  tier model — red-main fix tactics now inherit tier 3 through the same downward
+  parent/serves flow, and dominance is structural (this node is simply in the
+  top tier) rather than numeric (highest boost). The write-path guard
   (validate-graph rule 18) is retargeted accordingly: no other node may author
   an explicit attributes.tier: 3 — an author may override that half by placing
   the ACK token in the authoring node's rationale or its attention.rationale —
   and this node must keep tier 3, an override that requires the ACK token in
   THIS node's own attention.rationale (its rationale, the field you are reading,
-  narrates the guard, so prose here must not exempt the node from it).
-  Earlier clarifications on
-  this node narrate 'boost 100'; they are dated historical records, superseded
-  in effect by this note, not rewritten."
-reading: "unreliable — signal under repair (hand-set 2026-07-23; the next
-  read-sensors run overwrites this with readMainHealth()'s literal output).
-  origin/main HEAD e2136ff9 carries eight check-runs, all concluding success,
-  but ALL inherited from a Graph Fast Path run on a graph/** branch sharing the
-  sha; none of unit-tests.yml's fifteen merge-gating jobs is present, so this
-  green is VACUOUS with respect to the trunk's own suite. Earlier the same day
-  HEAD 1edf47ee read red on two inherited `guard: failure` runs from the benign
-  fast-path race (tactic-graph-fastpath-guard-diff-base, PR 2898). Both readings
-  illustrate the attribution defect recorded in this round's clarifications
-  rather than main's actual content health. Supersedes the 2026-07-13 manual
-  stand-in, whose own instruction was to hand over once the sensor landed — it
-  has (readMainHealth, merged 2026-07-23)."
+  narrates the guard, so prose here must not exempt the node from it). Earlier
+  clarifications on this node narrate 'boost 100'; they are dated historical
+  records, superseded in effect by this note, not rewritten."
+reading: "green: every check on the current origin/main HEAD concludes success
+  (or neutral/skipped)"
 gap: null
 serves: []
 recovers: []

--- a/intentions/strategy-realign-attachments.md
+++ b/intentions/strategy-realign-attachments.md
@@ -22,8 +22,11 @@ rationale: >-
   recovery: a delegation moved to portable terms is far cheaper to unwind later.
   This is the graph's first strategy whose primary axis is divergence rather
   than irreversibility.
-reading: null
-gap: null
+reading: "high-divergence: 5 records; 4 covered by recovers; uncovered:
+  delegation-communications"
+gap: 'reading "high-divergence: 5 records; 4 covered by recovers; uncovered:
+  delegation-communications" does not meet threshold "every high-divergence
+  record is covered by a recovers edge or a recorded re-alignment"'
 serves:
   - virtue-alignment-of-attachments
 recovers: []
@@ -59,6 +62,7 @@ pace_exempt: false
 rounds:
   count: 0
   last_completed: null
+  last_aligned: null
 attributes:
   conditions:
     - fee-aligned vendors exist on portable terms (owned domains, open formats,

--- a/intentions/strategy-token-economy.md
+++ b/intentions/strategy-token-economy.md
@@ -29,8 +29,11 @@ rationale: "Claude access is prepaid (Max 20x plan): the marginal token is sunk
   vendor's growth via spend' divergence imported by delegation-anthropic-claude:
   on prepaid terms that import is bounded at plan price and reviewed at renewal,
   which is its alignment-of-attachments content."
-reading: null
-gap: null
+reading: "utilization: 10% weekly; tactics 28d: 304 created / 225 closed (net +79)"
+gap: 'reading "utilization: 10% weekly; tactics 28d: 304 created / 225 closed
+  (net +79)" does not meet threshold "utilization near 100% of the weekly
+  allowance while open claude-eligible tactics are non-increasing (closure at or
+  above arrival); full utilization with a growing backlog fails the signal"'
 serves:
   - virtue-alignment-of-attachments
 recovers: []

--- a/intentions/tactic-main-red-ac908454.md
+++ b/intentions/tactic-main-red-ac908454.md
@@ -6,7 +6,8 @@ owner: ai
 status: raw
 parent: null
 rationale: Auto-created by dispatch-diagnose-main on a failing main-health sensor read.
-reading: null
+reading: "green: every check on the current origin/main HEAD concludes success
+  (or neutral/skipped)"
 gap: null
 serves:
   - strategy-main-health

--- a/packages/intentionsutil/scripts/read-sensors.ts
+++ b/packages/intentionsutil/scripts/read-sensors.ts
@@ -945,35 +945,95 @@ export function renderDelegationRecordsReport(dir: string): string {
  * `review_trigger firing not recorded` clause is fixed prose: there is no
  * firing/actioned surface on the records to mechanically detect a "fired
  * review_trigger left unactioned", so the reading says so rather than guessing.
+ *
+ * Ends with the read date in the same `(sensor read <YYYY-MM-DD>)` form
+ * `readDelegationRecordsReading` uses, and for the same reason: the router's
+ * fresh-reading gate (`readingDate`, `src/router.ts`) scrapes the newest ISO
+ * date out of the reading prose and, once `rounds.last_aligned` is stamped,
+ * drops any strategy whose reading carries no parseable date with a
+ * `stale-reading` event — permanently and silently starving an undated strategy
+ * out of align selection no matter how often the sensor re-runs.
  */
-function readExerciseRecoveryPathsReading(dir: string): string {
+function readExerciseRecoveryPathsReading(dir: string, today: Date): string {
   const records = readDelegationRecords(dir);
   const n = records.length;
   const k = records.filter((r) => r.lastExercised !== null).length;
   const m = n - k;
-  return `exercised: ${k}/${n} records; ${m} null last_exercised; review_trigger firing not recorded`;
+  const readDate = today.toISOString().slice(0, 10);
+  return (
+    `exercised: ${k}/${n} records; ${m} null last_exercised; ` +
+    `review_trigger firing not recorded (sensor read ${readDate})`
+  );
 }
 
 /**
- * True when a `kind: delegation` node's `attributes.divergence.level` (trimmed,
- * lowercased) starts with `"high"`. Defensively parsed — missing or malformed
- * `divergence`/`level` is treated as not high-divergence rather than throwing,
- * mirroring this file's existing defensive-attributes precedent (`src/attention.ts:89-107`).
+ * The divergence levels `kind-delegation` declares for
+ * `attributes.divergence.level` (`intentions/kind-delegation.md`:
+ * `"divergence: {level: low|moderate|high, ...}"`).
  */
-function isHighDivergence(node: IntentionNode): boolean {
+const DIVERGENCE_LEVELS = ["low", "moderate", "high"] as const;
+
+/**
+ * The declared divergence levels a `kind: delegation` node's
+ * `attributes.divergence.level` names — or a HALT naming the record.
+ *
+ * The live corpus authors this field as compound free prose AROUND the declared
+ * vocabulary (`low-moderate`, `moderate — would-be`), so the value is tokenized
+ * on non-letter runs and each token matched against `DIVERGENCE_LEVELS` rather
+ * than compared whole. A value naming NO declared level (`critical`, an empty
+ * string, a restructured `divergence` object, a missing `divergence`) is a
+ * schema-invalid delegation record — not a not-high-divergence one — and throws
+ * `IntentionSchemaError` naming the record, exactly as `readDelegationRecords`
+ * above does for the other delegation attributes.
+ *
+ * Deliberately fail-loud rather than defensively parsed: reading an
+ * unrecognized level as "not high" would drop the record from both numerator
+ * and denominator of `strategy-realign-attachments`' reading, turning a
+ * one-word edit in an unprivileged data file into a silent all-clear on the
+ * exact condition that strategy exists to detect — a fail-open measurement on
+ * its own control (`.claude/rules/code-style.md`).
+ */
+function divergenceLevels(node: IntentionNode): Set<string> {
   const attrs = node.attributes;
-  if (!isPlainObject(attrs)) {
-    return false;
-  }
-  const divergence = attrs.divergence;
+  const divergence = isPlainObject(attrs) ? attrs.divergence : undefined;
   if (!isPlainObject(divergence)) {
-    return false;
+    throw new IntentionSchemaError(
+      `Delegation record "${node.id}" attributes.divergence must be an object naming a ` +
+        `level in {${DIVERGENCE_LEVELS.join(", ")}}.`,
+    );
   }
   const level = divergence.level;
   if (typeof level !== "string") {
-    return false;
+    throw new IntentionSchemaError(
+      `Delegation record "${node.id}" attributes.divergence.level must be a string, ` +
+        `got ${typeof level}.`,
+    );
   }
-  return level.trim().toLowerCase().startsWith("high");
+  const recognized = new Set(
+    level
+      .toLowerCase()
+      .split(/[^a-z]+/)
+      .filter((token): token is (typeof DIVERGENCE_LEVELS)[number] =>
+        (DIVERGENCE_LEVELS as readonly string[]).includes(token),
+      ),
+  );
+  if (recognized.size === 0) {
+    throw new IntentionSchemaError(
+      `Delegation record "${node.id}" attributes.divergence.level "${level}" names none of ` +
+        `the declared levels {${DIVERGENCE_LEVELS.join(", ")}}.`,
+    );
+  }
+  return recognized;
+}
+
+/**
+ * True when a `kind: delegation` node's divergence level names `high` at all —
+ * a compound value like `moderate-high` counts as high. Over-inclusion is the
+ * safe direction for a monitoring control: a record that might be high belongs
+ * in the uncovered list, never silently outside it.
+ */
+function isHighDivergence(node: IntentionNode): boolean {
+  return divergenceLevels(node).has("high");
 }
 
 /**
@@ -983,8 +1043,13 @@ function isHighDivergence(node: IntentionNode): boolean {
  * the ledger yet (per the strategy's own 2026-07-11-era clarification 7), so
  * only the `recovers`-edge half is mechanically checked — the reading does not
  * invent a convention that doesn't exist.
+ *
+ * Ends with `(sensor read <YYYY-MM-DD>)` for the same fresh-reading-gate reason
+ * documented on `readExerciseRecoveryPathsReading` above: a reading with no
+ * parseable date is dropped by the router's gate once `rounds.last_aligned` is
+ * stamped, silently starving the strategy out of align selection.
  */
-function readRealignAttachmentsReading(nodes: IntentionNode[]): string {
+function readRealignAttachmentsReading(nodes: IntentionNode[], today: Date): string {
   const recoveredIds = new Set<string>();
   for (const node of nodes) {
     for (const id of node.recovers) {
@@ -999,7 +1064,11 @@ function readRealignAttachmentsReading(nodes: IntentionNode[]): string {
   const c = covered.length;
   const uncovered = highDivergenceIds.filter((id) => !recoveredIds.has(id)).sort();
   const uncoveredList = uncovered.length > 0 ? uncovered.join(", ") : "none";
-  return `high-divergence: ${h} records; ${c} covered by recovers; uncovered: ${uncoveredList}`;
+  const readDate = today.toISOString().slice(0, 10);
+  return (
+    `high-divergence: ${h} records; ${c} covered by recovers; ` +
+    `uncovered: ${uncoveredList} (sensor read ${readDate})`
+  );
 }
 
 /**
@@ -1009,21 +1078,33 @@ function readRealignAttachmentsReading(nodes: IntentionNode[]): string {
  * count, and any other id gets a total fallback string (never throws) rather
  * than the old id-blind generic aggregate — the two strategies' thresholds
  * measure different things and neither matched the old shared reading.
- * `loadNodes` is injected (same pattern as `makeIntentionStoreSensor`) so unit
- * tests can supply fixture arrays without touching the live store; the
- * exercise-recovery-paths branch still reads `readDelegationRecords(intentionsDir)`
- * directly since its narrower `DelegationRecordReading` shape is sufficient
- * there (it doesn't need `divergence`, which isn't in that shape).
+ * Both store reads are injected so unit tests never touch the live store:
+ * `loadNodes` (same pattern as `makeIntentionStoreSensor`) feeds the
+ * realign-attachments branch, and `recordsDir` — defaulting to the real
+ * `intentionsDir` for production callers — feeds the exercise-recovery-paths
+ * branch, which reads `readDelegationRecords` directly since its narrower
+ * `DelegationRecordReading` shape is sufficient there (it doesn't need
+ * `divergence`, which isn't in that shape).
+ *
+ * `now` is the third injection point: both readings stamp the read date the
+ * router's fresh-reading gate parses, and it is read at `read()` time (not
+ * build time) so a long-lived registry never stamps a stale date. Tests pin it
+ * to a fixed clock so the asserted date clause cannot flake across UTC
+ * midnight.
  */
-export function makeDelegationRecordsSensor(loadNodes: () => IntentionNode[]): Sensor {
+export function makeDelegationRecordsSensor(
+  loadNodes: () => IntentionNode[],
+  recordsDir: string = intentionsDir,
+  now: () => Date = () => new Date(),
+): Sensor {
   return {
     name: DELEGATION_RECORDS_SENSOR_NAME,
     read(node): string {
       if (node.id === "strategy-exercise-recovery-paths") {
-        return readExerciseRecoveryPathsReading(intentionsDir);
+        return readExerciseRecoveryPathsReading(recordsDir, now());
       }
       if (node.id === "strategy-realign-attachments") {
-        return readRealignAttachmentsReading(loadNodes());
+        return readRealignAttachmentsReading(loadNodes(), now());
       }
       return `no per-node rule for ${node.id}`;
     },

--- a/packages/intentionsutil/scripts/read-sensors.ts
+++ b/packages/intentionsutil/scripts/read-sensors.ts
@@ -957,7 +957,7 @@ function readExerciseRecoveryPathsReading(dir: string): string {
 /**
  * True when a `kind: delegation` node's `attributes.divergence.level` (trimmed,
  * lowercased) starts with `"high"`. Defensively parsed — missing or malformed
- * `divergence`/`level` is treated as NOT high-divergence rather than throwing,
+ * `divergence`/`level` is treated as not high-divergence rather than throwing,
  * mirroring this file's existing defensive-attributes precedent (`src/attention.ts:89-107`).
  */
 function isHighDivergence(node: IntentionNode): boolean {

--- a/packages/intentionsutil/scripts/read-sensors.ts
+++ b/packages/intentionsutil/scripts/read-sensors.ts
@@ -937,12 +937,98 @@ export function renderDelegationRecordsReport(dir: string): string {
   return [header, ...rows].join("\n");
 }
 
-const delegationRecordsSensor: Sensor = {
-  name: DELEGATION_RECORDS_SENSOR_NAME,
-  read(): string {
-    return readDelegationRecordsReading(intentionsDir);
-  },
-};
+/**
+ * The `strategy-exercise-recovery-paths` branch: a plain count over ALL
+ * `kind: delegation` records (no declined-origin special-casing — this
+ * strategy's threshold, unlike `readDelegationRecordsReading`'s clarification-7
+ * aggregate, just asks how many records have `last_exercised` set). The
+ * `review_trigger firing not recorded` clause is fixed prose: there is no
+ * firing/actioned surface on the records to mechanically detect a "fired
+ * review_trigger left unactioned", so the reading says so rather than guessing.
+ */
+function readExerciseRecoveryPathsReading(dir: string): string {
+  const records = readDelegationRecords(dir);
+  const n = records.length;
+  const k = records.filter((r) => r.lastExercised !== null).length;
+  const m = n - k;
+  return `exercised: ${k}/${n} records; ${m} null last_exercised; review_trigger firing not recorded`;
+}
+
+/**
+ * True when a `kind: delegation` node's `attributes.divergence.level` (trimmed,
+ * lowercased) starts with `"high"`. Defensively parsed — missing or malformed
+ * `divergence`/`level` is treated as NOT high-divergence rather than throwing,
+ * mirroring this file's existing defensive-attributes precedent (`src/attention.ts:89-107`).
+ */
+function isHighDivergence(node: IntentionNode): boolean {
+  const attrs = node.attributes;
+  if (!isPlainObject(attrs)) {
+    return false;
+  }
+  const divergence = attrs.divergence;
+  if (!isPlainObject(divergence)) {
+    return false;
+  }
+  const level = divergence.level;
+  if (typeof level !== "string") {
+    return false;
+  }
+  return level.trim().toLowerCase().startsWith("high");
+}
+
+/**
+ * The `strategy-realign-attachments` branch: over `kind: delegation` nodes with
+ * high divergence, how many are covered by ANY node's `recovers` edge naming
+ * that record's id. There is no "recorded re-alignment" attribute convention on
+ * the ledger yet (per the strategy's own 2026-07-11-era clarification 7), so
+ * only the `recovers`-edge half is mechanically checked — the reading does not
+ * invent a convention that doesn't exist.
+ */
+function readRealignAttachmentsReading(nodes: IntentionNode[]): string {
+  const recoveredIds = new Set<string>();
+  for (const node of nodes) {
+    for (const id of node.recovers) {
+      recoveredIds.add(id);
+    }
+  }
+  const highDivergenceIds = nodes
+    .filter((node) => node.kind === "delegation" && isHighDivergence(node))
+    .map((node) => node.id);
+  const h = highDivergenceIds.length;
+  const covered = highDivergenceIds.filter((id) => recoveredIds.has(id));
+  const c = covered.length;
+  const uncovered = highDivergenceIds.filter((id) => !recoveredIds.has(id)).sort();
+  const uncoveredList = uncovered.length > 0 ? uncovered.join(", ") : "none";
+  return `high-divergence: ${h} records; ${c} covered by recovers; uncovered: ${uncoveredList}`;
+}
+
+/**
+ * Build the delegation-records sensor. Dispatches on the asking node's `id`:
+ * `strategy-exercise-recovery-paths` gets the plain exercised/null count,
+ * `strategy-realign-attachments` gets the high-divergence/recovers-coverage
+ * count, and any other id gets a total fallback string (never throws) rather
+ * than the old id-blind generic aggregate — the two strategies' thresholds
+ * measure different things and neither matched the old shared reading.
+ * `loadNodes` is injected (same pattern as `makeIntentionStoreSensor`) so unit
+ * tests can supply fixture arrays without touching the live store; the
+ * exercise-recovery-paths branch still reads `readDelegationRecords(intentionsDir)`
+ * directly since its narrower `DelegationRecordReading` shape is sufficient
+ * there (it doesn't need `divergence`, which isn't in that shape).
+ */
+export function makeDelegationRecordsSensor(loadNodes: () => IntentionNode[]): Sensor {
+  return {
+    name: DELEGATION_RECORDS_SENSOR_NAME,
+    read(node): string {
+      if (node.id === "strategy-exercise-recovery-paths") {
+        return readExerciseRecoveryPathsReading(intentionsDir);
+      }
+      if (node.id === "strategy-realign-attachments") {
+        return readRealignAttachmentsReading(loadNodes());
+      }
+      return `no per-node rule for ${node.id}`;
+    },
+  };
+}
 
 // --- intention-store sensor --------------------------------------------------
 // The verbatim `success_signal.sensor` name strategy-graph-drives-dispatch
@@ -1068,7 +1154,7 @@ export function buildDefaultRegistry(): SensorRegistry {
   registry.register(mainHealthSensor);
   registry.register(tokenEconomySensor);
   registry.register(lifecycleSensor);
-  registry.register(delegationRecordsSensor);
+  registry.register(makeDelegationRecordsSensor(() => listNodes(intentionsDir)));
   // Register the intention-store sensor last and have it derive the set of
   // registered sensor names from the registry itself at read() time — by then
   // the registry holds every sensor, including this one. Deriving the set (vs

--- a/packages/intentionsutil/test/delegation-records-sensor.test.ts
+++ b/packages/intentionsutil/test/delegation-records-sensor.test.ts
@@ -230,7 +230,7 @@ function delegationWithDivergence(
 ): IntentionNodeInput {
   const base = delegationNode(id);
   const attributes: Record<string, unknown> = {
-    ...(base.attributes as Record<string, unknown>),
+    ...base.attributes,
     ...(divergenceLevel === undefined ? {} : { divergence: { level: divergenceLevel } }),
     ...attributesOverride,
   };

--- a/packages/intentionsutil/test/delegation-records-sensor.test.ts
+++ b/packages/intentionsutil/test/delegation-records-sensor.test.ts
@@ -1,13 +1,15 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { IntentionSchemaError } from "../src/errors.js";
 import { SensorRegistry } from "../src/sensors.js";
-import { readNode, writeNode } from "../src/store.js";
+import { listNodes, readNode, writeNode } from "../src/store.js";
 import type { IntentionNodeInput } from "../src/schema.js";
 import {
   buildDefaultRegistry,
+  makeDelegationRecordsSensor,
   readDelegationRecords,
   readDelegationRecordsReading,
   readStoreSensors,
@@ -19,6 +21,18 @@ import {
 // so the test doubles as a guard: a rename of the production constant that
 // diverges from the strategy's declared sensor name fails this suite.
 const DELEGATION_SENSOR_NAME = "the delegation records themselves";
+
+// This test file lives at packages/intentionsutil/test/, so repo root is
+// three dirname() calls up — same pattern as office-hours.test.ts. The
+// `strategy-exercise-recovery-paths` branch of the delegation-records sensor
+// (per its production implementation) always reads the REAL repo's
+// `intentions/` dir via the module-level `intentionsDir` const — it does NOT
+// go through the injected `loadNodes` closure, unlike the
+// `strategy-realign-attachments` branch. So its expected reading is computed
+// dynamically from the real store below, not hardcoded, to avoid the test
+// drifting out of sync with the live delegation-record count.
+const realRepoRoot = dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
+const realIntentionsDir = join(realRepoRoot, "intentions");
 
 function tempStore(): string {
   return mkdtempSync(join(tmpdir(), "delegation-records-sensor-"));
@@ -208,26 +222,164 @@ describe("buildDefaultRegistry", () => {
   });
 });
 
-describe("readStoreSensors end-to-end", () => {
-  it("writes reading and a non-null gap onto a strategy naming this sensor", () => {
-    const dir = tempStore();
-    writeNode(dir, delegationNode("delegation-a", { lastExercised: null }));
-    writeNode(dir, strategyNode("strategy-exercise-fixture"));
+/** A fixture delegation node carrying an `attributes.divergence.level`. */
+function delegationWithDivergence(
+  id: string,
+  divergenceLevel: string | undefined,
+  attributesOverride?: Record<string, unknown>,
+): IntentionNodeInput {
+  const base = delegationNode(id);
+  const attributes: Record<string, unknown> = {
+    ...(base.attributes as Record<string, unknown>),
+    ...(divergenceLevel === undefined ? {} : { divergence: { level: divergenceLevel } }),
+    ...attributesOverride,
+  };
+  return { ...base, attributes };
+}
 
-    // The production sensor closes over the repo's own intentions dir, so build
-    // a registry whose delegation sensor reads THIS fixture store instead.
-    const registry = new SensorRegistry();
-    registry.register({
-      name: DELEGATION_SENSOR_NAME,
-      read: () => readDelegationRecordsReading(dir, new Date("2026-07-11T00:00:00Z")),
+describe("makeDelegationRecordsSensor", () => {
+  describe("strategy-exercise-recovery-paths branch", () => {
+    it("matches the format: exercised k/n; m null; fixed review_trigger prose", () => {
+      // Per the production implementation, this branch reads the REAL repo's
+      // intentions/ dir (module-level `intentionsDir`), not the injected
+      // `loadNodes` closure's dir — so this asserts the exact string format
+      // against a count computed fresh from the live store, not a hardcoded
+      // fixture expectation (which would drift as delegation records change).
+      const realRecords = readDelegationRecords(realIntentionsDir);
+      const n = realRecords.length;
+      const k = realRecords.filter((r) => r.lastExercised !== null).length;
+      const m = n - k;
+      const expected = `exercised: ${k}/${n} records; ${m} null last_exercised; review_trigger firing not recorded`;
+
+      // loadNodes is irrelevant to this branch, but still supplied per the
+      // factory's signature — an empty fixture store proves the branch does
+      // NOT depend on it.
+      const sensor = makeDelegationRecordsSensor(() => []);
+      const reading = sensor.read({
+        id: "strategy-exercise-recovery-paths",
+        kind: "strategy",
+        statement: "s",
+        owner: "human",
+        status: "raw",
+        parent: null,
+        serves: [],
+        recovers: [],
+        rationale: null,
+        reading: null,
+        gap: null,
+        clarifications: [],
+        tooling_goals: [],
+        success_signal: null,
+        attention: null,
+        phase: null,
+        execution: null,
+        validates: [],
+        blocked_by: [],
+        office_hours: null,
+        pace_exempt: false,
+        rounds: null,
+        attributes: {},
+      });
+      expect(reading).toBe(expected);
     });
+  });
+
+  describe("strategy-realign-attachments branch", () => {
+    it("reports 'none' uncovered when every high-divergence record has a recovers edge", () => {
+      const dir = tempStore();
+      writeNode(dir, delegationWithDivergence("delegation-high", "High"));
+      writeNode(dir, delegationWithDivergence("delegation-low", "low"));
+      writeNode(dir, {
+        id: "strategy-covers-it",
+        kind: "strategy",
+        statement: "covers delegation-high",
+        owner: "human",
+        status: "raw",
+        recovers: ["delegation-high"],
+      });
+      const node = readNode(dir, "delegation-high");
+      const sensor = makeDelegationRecordsSensorForDir(dir);
+
+      const reading = sensor.read({ ...node, id: "strategy-realign-attachments" });
+      expect(reading).toBe("high-divergence: 1 records; 1 covered by recovers; uncovered: none");
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("lists uncovered high-divergence record ids, sorted, comma-separated", () => {
+      const dir = tempStore();
+      writeNode(dir, delegationWithDivergence("delegation-z-high", "high"));
+      writeNode(dir, delegationWithDivergence("delegation-a-high", "high"));
+      writeNode(dir, delegationWithDivergence("delegation-low", "low"));
+      const node = readNode(dir, "delegation-low");
+      const sensor = makeDelegationRecordsSensorForDir(dir);
+
+      const reading = sensor.read({ ...node, id: "strategy-realign-attachments" });
+      expect(reading).toBe(
+        "high-divergence: 2 records; 0 covered by recovers; uncovered: delegation-a-high, delegation-z-high",
+      );
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("treats missing/malformed divergence as not high-divergence, never throws", () => {
+      const dir = tempStore();
+      writeNode(dir, delegationWithDivergence("delegation-no-divergence", undefined));
+      writeNode(dir, delegationWithDivergence("delegation-malformed", "high", { divergence: "not-an-object" }));
+      const node = readNode(dir, "delegation-no-divergence");
+      const sensor = makeDelegationRecordsSensorForDir(dir);
+
+      const reading = sensor.read({ ...node, id: "strategy-realign-attachments" });
+      expect(reading).toBe("high-divergence: 0 records; 0 covered by recovers; uncovered: none");
+      rmSync(dir, { recursive: true, force: true });
+    });
+  });
+
+  describe("fallback branch", () => {
+    it("returns a total 'no per-node rule' string for any other node id, never throws", () => {
+      const dir = tempStore();
+      writeNode(dir, delegationNode("delegation-a"));
+      const node = readNode(dir, "delegation-a");
+      const sensor = makeDelegationRecordsSensorForDir(dir);
+
+      const reading = sensor.read({ ...node, id: "some-unrelated-node" });
+      expect(reading).toBe("no per-node rule for some-unrelated-node");
+      rmSync(dir, { recursive: true, force: true });
+    });
+  });
+});
+
+/** Build a `makeDelegationRecordsSensor` whose `loadNodes` reads the given fixture dir. */
+function makeDelegationRecordsSensorForDir(dir: string) {
+  return makeDelegationRecordsSensor(() => listNodes(dir));
+}
+
+describe("readStoreSensors end-to-end", () => {
+  it("writes reading and a non-null gap onto a strategy naming this sensor (exercise-recovery-paths format)", () => {
+    const dir = tempStore();
+    writeNode(dir, strategyNode("strategy-exercise-recovery-paths"));
+
+    // Register the real per-id-dispatching sensor factory (not a hand-rolled
+    // stand-in), with the fixture strategy's id set to
+    // "strategy-exercise-recovery-paths" so the sensor's matching branch
+    // fires. That branch (per the production implementation) reads the REAL
+    // repo's intentions/ dir rather than this fixture store's dir — see the
+    // "strategy-exercise-recovery-paths branch" describe block above — so the
+    // expected reading is computed fresh from the live store, not hardcoded.
+    const registry = new SensorRegistry();
+    registry.register(makeDelegationRecordsSensor(() => listNodes(dir)));
 
     const summary = readStoreSensors(dir, registry);
     expect(summary.read).toBe(1);
     expect(summary.unregistered).toHaveLength(0);
 
-    const strategy = readNode(dir, "strategy-exercise-fixture");
-    expect(strategy.reading).toContain("0 of 1 delegation records exercised");
+    const realRecords = readDelegationRecords(realIntentionsDir);
+    const n = realRecords.length;
+    const k = realRecords.filter((r) => r.lastExercised !== null).length;
+    const m = n - k;
+
+    const strategy = readNode(dir, "strategy-exercise-recovery-paths");
+    expect(strategy.reading).toBe(
+      `exercised: ${k}/${n} records; ${m} null last_exercised; review_trigger firing not recorded`,
+    );
     expect(strategy.gap).not.toBeNull();
     rmSync(dir, { recursive: true, force: true });
   });

--- a/packages/intentionsutil/test/delegation-records-sensor.test.ts
+++ b/packages/intentionsutil/test/delegation-records-sensor.test.ts
@@ -1,9 +1,9 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { IntentionSchemaError } from "../src/errors.js";
+import { readingDate } from "../src/router.js";
 import { SensorRegistry } from "../src/sensors.js";
 import { listNodes, readNode, writeNode } from "../src/store.js";
 import type { IntentionNodeInput } from "../src/schema.js";
@@ -22,17 +22,13 @@ import {
 // diverges from the strategy's declared sensor name fails this suite.
 const DELEGATION_SENSOR_NAME = "the delegation records themselves";
 
-// This test file lives at packages/intentionsutil/test/, so repo root is
-// three dirname() calls up — same pattern as office-hours.test.ts. The
-// `strategy-exercise-recovery-paths` branch of the delegation-records sensor
-// (per its production implementation) always reads the REAL repo's
-// `intentions/` dir via the module-level `intentionsDir` const — it does NOT
-// go through the injected `loadNodes` closure, unlike the
-// `strategy-realign-attachments` branch. So its expected reading is computed
-// dynamically from the real store below, not hardcoded, to avoid the test
-// drifting out of sync with the live delegation-record count.
-const realRepoRoot = dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
-const realIntentionsDir = join(realRepoRoot, "intentions");
+// Every branch of the delegation-records sensor is exercised against an
+// injected fixture store: `loadNodes` for the `strategy-realign-attachments`
+// branch, and `makeDelegationRecordsSensor`'s `recordsDir` parameter for the
+// `strategy-exercise-recovery-paths` branch (which reads records straight off
+// disk). No test here reads the real repo's `intentions/` dir — that would
+// couple unit-test CI to mutable content and would derive the expected value
+// by re-running the very helper under test.
 
 function tempStore(): string {
   return mkdtempSync(join(tmpdir(), "delegation-records-sensor-"));
@@ -222,6 +218,15 @@ describe("buildDefaultRegistry", () => {
   });
 });
 
+// A pinned clock for the `now` injection point. Both per-strategy readings end
+// with `(sensor read <YYYY-MM-DD>)` — the token the router's fresh-reading gate
+// (`readingDate`, src/router.ts) parses; a strategy whose reading carries no
+// parseable date is dropped with a `stale-reading` event once
+// `rounds.last_aligned` is stamped. Pinning the clock keeps the asserted date
+// clause exact instead of flaking across UTC midnight.
+const FIXED_NOW = (): Date => new Date("2026-07-11T00:00:00Z");
+const FIXED_READ_DATE = "2026-07-11";
+
 /** A fixture delegation node carrying an `attributes.divergence.level`. */
 function delegationWithDivergence(
   id: string,
@@ -240,21 +245,23 @@ function delegationWithDivergence(
 describe("makeDelegationRecordsSensor", () => {
   describe("strategy-exercise-recovery-paths branch", () => {
     it("matches the format: exercised k/n; m null; fixed review_trigger prose", () => {
-      // Per the production implementation, this branch reads the REAL repo's
-      // intentions/ dir (module-level `intentionsDir`), not the injected
-      // `loadNodes` closure's dir — so this asserts the exact string format
-      // against a count computed fresh from the live store, not a hardcoded
-      // fixture expectation (which would drift as delegation records change).
-      const realRecords = readDelegationRecords(realIntentionsDir);
-      const n = realRecords.length;
-      const k = realRecords.filter((r) => r.lastExercised !== null).length;
-      const m = n - k;
-      const expected = `exercised: ${k}/${n} records; ${m} null last_exercised; review_trigger firing not recorded`;
+      // Fixture store: 2 of 3 delegation records exercised, 1 null. The
+      // expectation is hardcoded from those fixtures — never derived by
+      // re-running the helper under test.
+      const dir = tempStore();
+      writeNode(dir, delegationNode("delegation-a", { lastExercised: "2026-06-30" }));
+      writeNode(dir, delegationNode("delegation-b", { lastExercised: "2026-07-01" }));
+      writeNode(dir, delegationNode("delegation-c", { lastExercised: null }));
+      // A non-delegation node in the same store must not be counted.
+      writeNode(dir, strategyNode("strategy-ignored"));
+      const expected =
+        "exercised: 2/3 records; 1 null last_exercised; " +
+        `review_trigger firing not recorded (sensor read ${FIXED_READ_DATE})`;
 
       // loadNodes is irrelevant to this branch, but still supplied per the
-      // factory's signature — an empty fixture store proves the branch does
-      // NOT depend on it.
-      const sensor = makeDelegationRecordsSensor(() => []);
+      // factory's signature — an empty node list proves the branch does NOT
+      // depend on it, reading `recordsDir` off disk instead.
+      const sensor = makeDelegationRecordsSensor(() => [], dir, FIXED_NOW);
       const reading = sensor.read({
         id: "strategy-exercise-recovery-paths",
         kind: "strategy",
@@ -281,6 +288,10 @@ describe("makeDelegationRecordsSensor", () => {
         attributes: {},
       });
       expect(reading).toBe(expected);
+      // The gate token itself, asserted explicitly: without a parseable date
+      // the router drops this strategy from align selection.
+      expect(reading).toMatch(/\(sensor read \d{4}-\d{2}-\d{2}\)$/);
+      rmSync(dir, { recursive: true, force: true });
     });
   });
 
@@ -301,7 +312,13 @@ describe("makeDelegationRecordsSensor", () => {
       const sensor = makeDelegationRecordsSensorForDir(dir);
 
       const reading = sensor.read({ ...node, id: "strategy-realign-attachments" });
-      expect(reading).toBe("high-divergence: 1 records; 1 covered by recovers; uncovered: none");
+      expect(reading).toBe(
+        "high-divergence: 1 records; 1 covered by recovers; " +
+          `uncovered: none (sensor read ${FIXED_READ_DATE})`,
+      );
+      // The gate token itself, asserted explicitly: without a parseable date
+      // the router drops this strategy from align selection.
+      expect(reading).toMatch(/\(sensor read \d{4}-\d{2}-\d{2}\)$/);
       rmSync(dir, { recursive: true, force: true });
     });
 
@@ -315,20 +332,91 @@ describe("makeDelegationRecordsSensor", () => {
 
       const reading = sensor.read({ ...node, id: "strategy-realign-attachments" });
       expect(reading).toBe(
-        "high-divergence: 2 records; 0 covered by recovers; uncovered: delegation-a-high, delegation-z-high",
+        "high-divergence: 2 records; 0 covered by recovers; " +
+          `uncovered: delegation-a-high, delegation-z-high (sensor read ${FIXED_READ_DATE})`,
       );
       rmSync(dir, { recursive: true, force: true });
     });
 
-    it("treats missing/malformed divergence as not high-divergence, never throws", () => {
+    it("reads compound levels by token: 'low-moderate' is not high, 'moderate-high' is", () => {
+      // The live corpus authors this field as compound free prose around the
+      // declared low|moderate|high vocabulary (`low-moderate`,
+      // `moderate — would-be`), so classification tokenizes rather than
+      // comparing the whole string, and over-includes: a value naming `high`
+      // at all belongs in the uncovered list.
       const dir = tempStore();
-      writeNode(dir, delegationWithDivergence("delegation-no-divergence", undefined));
-      writeNode(dir, delegationWithDivergence("delegation-malformed", "high", { divergence: "not-an-object" }));
-      const node = readNode(dir, "delegation-no-divergence");
+      writeNode(dir, delegationWithDivergence("delegation-compound-high", "moderate-high"));
+      writeNode(dir, delegationWithDivergence("delegation-very-high", "very high"));
+      writeNode(dir, delegationWithDivergence("delegation-low-moderate", "low-moderate"));
+      writeNode(dir, delegationWithDivergence("delegation-prose", "moderate — would-be"));
+      const node = readNode(dir, "delegation-low-moderate");
       const sensor = makeDelegationRecordsSensorForDir(dir);
 
       const reading = sensor.read({ ...node, id: "strategy-realign-attachments" });
-      expect(reading).toBe("high-divergence: 0 records; 0 covered by recovers; uncovered: none");
+      expect(reading).toBe(
+        "high-divergence: 2 records; 0 covered by recovers; " +
+          `uncovered: delegation-compound-high, delegation-very-high (sensor read ${FIXED_READ_DATE})`,
+      );
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("HALTS naming the record when divergence.level names no declared level", () => {
+      // Fail-loud, not fail-open: silently reading an unrecognized level as
+      // "not high" would drop the record from both numerator and denominator,
+      // making a one-word edit in a data file a silent all-clear on the exact
+      // condition this strategy exists to detect.
+      const dir = tempStore();
+      writeNode(dir, delegationWithDivergence("delegation-unknown-level", "critical"));
+      const node = readNode(dir, "delegation-unknown-level");
+      const sensor = makeDelegationRecordsSensorForDir(dir);
+
+      const read = () => sensor.read({ ...node, id: "strategy-realign-attachments" });
+      expect(read).toThrow(IntentionSchemaError);
+      expect(read).toThrow(/delegation-unknown-level.*critical/s);
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("HALTS naming the record when divergence is missing or not an object", () => {
+      const missingDir = tempStore();
+      writeNode(missingDir, delegationWithDivergence("delegation-no-divergence", undefined));
+      const missingNode = readNode(missingDir, "delegation-no-divergence");
+      const readMissing = () =>
+        makeDelegationRecordsSensorForDir(missingDir).read({
+          ...missingNode,
+          id: "strategy-realign-attachments",
+        });
+      expect(readMissing).toThrow(IntentionSchemaError);
+      expect(readMissing).toThrow(/delegation-no-divergence.*divergence/s);
+      rmSync(missingDir, { recursive: true, force: true });
+
+      const malformedDir = tempStore();
+      writeNode(
+        malformedDir,
+        delegationWithDivergence("delegation-malformed", "high", { divergence: "not-an-object" }),
+      );
+      const malformedNode = readNode(malformedDir, "delegation-malformed");
+      const readMalformed = () =>
+        makeDelegationRecordsSensorForDir(malformedDir).read({
+          ...malformedNode,
+          id: "strategy-realign-attachments",
+        });
+      expect(readMalformed).toThrow(/delegation-malformed.*divergence/s);
+      rmSync(malformedDir, { recursive: true, force: true });
+    });
+
+    it("HALTS naming the record when divergence.level is not a string", () => {
+      const dir = tempStore();
+      writeNode(
+        dir,
+        delegationWithDivergence("delegation-list-level", undefined, {
+          divergence: { level: ["high", "moderate"] },
+        }),
+      );
+      const node = readNode(dir, "delegation-list-level");
+      const sensor = makeDelegationRecordsSensorForDir(dir);
+
+      const read = () => sensor.read({ ...node, id: "strategy-realign-attachments" });
+      expect(read).toThrow(/delegation-list-level.*level must be a string/s);
       rmSync(dir, { recursive: true, force: true });
     });
   });
@@ -347,39 +435,43 @@ describe("makeDelegationRecordsSensor", () => {
   });
 });
 
-/** Build a `makeDelegationRecordsSensor` whose `loadNodes` reads the given fixture dir. */
+/**
+ * Build a `makeDelegationRecordsSensor` reading the given fixture dir through
+ * every injection point — `loadNodes`, `recordsDir`, and the pinned clock.
+ */
 function makeDelegationRecordsSensorForDir(dir: string) {
-  return makeDelegationRecordsSensor(() => listNodes(dir));
+  return makeDelegationRecordsSensor(() => listNodes(dir), dir, FIXED_NOW);
 }
 
 describe("readStoreSensors end-to-end", () => {
   it("writes reading and a non-null gap onto a strategy naming this sensor (exercise-recovery-paths format)", () => {
     const dir = tempStore();
     writeNode(dir, strategyNode("strategy-exercise-recovery-paths"));
+    // Fixture records the sensor counts: 1 of 2 exercised, 1 null.
+    writeNode(dir, delegationNode("delegation-a", { lastExercised: "2026-06-30" }));
+    writeNode(dir, delegationNode("delegation-b", { lastExercised: null }));
 
     // Register the real per-id-dispatching sensor factory (not a hand-rolled
     // stand-in), with the fixture strategy's id set to
     // "strategy-exercise-recovery-paths" so the sensor's matching branch
-    // fires. That branch (per the production implementation) reads the REAL
-    // repo's intentions/ dir rather than this fixture store's dir — see the
-    // "strategy-exercise-recovery-paths branch" describe block above — so the
-    // expected reading is computed fresh from the live store, not hardcoded.
+    // fires. Both injection points — `loadNodes` and `recordsDir` — point at
+    // this fixture store, so the reading below is a hardcoded fixture
+    // expectation and the run never touches the live intentions/ dir.
     const registry = new SensorRegistry();
-    registry.register(makeDelegationRecordsSensor(() => listNodes(dir)));
+    registry.register(makeDelegationRecordsSensor(() => listNodes(dir), dir, FIXED_NOW));
 
     const summary = readStoreSensors(dir, registry);
     expect(summary.read).toBe(1);
     expect(summary.unregistered).toHaveLength(0);
 
-    const realRecords = readDelegationRecords(realIntentionsDir);
-    const n = realRecords.length;
-    const k = realRecords.filter((r) => r.lastExercised !== null).length;
-    const m = n - k;
-
     const strategy = readNode(dir, "strategy-exercise-recovery-paths");
     expect(strategy.reading).toBe(
-      `exercised: ${k}/${n} records; ${m} null last_exercised; review_trigger firing not recorded`,
+      "exercised: 1/2 records; 1 null last_exercised; " +
+        `review_trigger firing not recorded (sensor read ${FIXED_READ_DATE})`,
     );
+    // The persisted reading carries the date the router's fresh-reading gate
+    // parses — the whole point of the clause.
+    expect(readingDate(strategy.reading ?? "")).toBe(FIXED_READ_DATE);
     expect(strategy.gap).not.toBeNull();
     rmSync(dir, { recursive: true, force: true });
   });


### PR DESCRIPTION
## Summary

Implements `tactic-first-sensor-pass`: the first mechanical sensor pass over the widened `read-sensors` scope, registering the last mechanically-computable named-but-unregistered sensor and landing the first driver-written readings across every strategy that names one of the six registered sensors — including `strategy-graph-drives-dispatch`'s own first reading, this round's signal-validating artifact.

- **Unit 1** — `packages/intentionsutil/scripts/read-sensors.ts`'s `"the delegation records themselves"` sensor now dispatches on the asking node's `id`, replacing the old id-blind generic aggregate (which never actually measured `strategy-realign-attachments`' threshold): `strategy-exercise-recovery-paths` gets a plain exercised/null count over all delegation records (`exercised: <k>/<n> records; <m> null last_exercised; review_trigger firing not recorded` — the review_trigger clause is fixed prose, since no firing/actioned surface exists to mechanically detect it), `strategy-realign-attachments` gets high-divergence coverage by any node's `recovers` edge (`high-divergence: <h> records; <c> covered by recovers; uncovered: <ids or "none">` — no "recorded re-alignment" convention exists on the ledger yet, so only the `recovers`-edge half is checked), and any other node id gets a total `"no per-node rule for <id>"` fallback. New unit test coverage in `packages/intentionsutil/test/delegation-records-sensor.test.ts` for all three branches.
- **Unit 2** — ran `npx tsx packages/intentionsutil/scripts/read-sensors.ts` over the widened scope and committed the refreshed `intentions/*.md` reading+gap writes: `strategy-graph-drives-dispatch` (first reading — `serves: 126/126 open tactics; readings: 14/52 sensor-naming strategies (46 unregistered sensors)`, honestly gapped since owner-review readings are still missing), `strategy-exercise-recovery-paths`, `strategy-realign-attachments`, `strategy-graph-native-dispatch`, `strategy-token-economy`, `strategy-main-health`, `tactic-main-red-ac908454`.

## Out of scope

Writing a "recorded re-alignment" convention on the delegation ledger (does not exist yet — the sensor honestly reports it as unchecked rather than inventing one). Any `voice.ts`/attention scoring change. The office-hours owner-review readings, which are the born-parked siblings `tactic-owner-review-reading-pass-a`/`-b`.

## Testing

```verify
npx vitest run --project packages/intentionsutil --root .
npx tsx packages/intentionsutil/scripts/read-sensors.ts
```

A second driver run after the commit is idempotent apart from the deliberately volatile halves (git-derived selection-log/backlog-series counts, CI-status strings). `npx tsx packages/intentionsutil/scripts/validate-graph.ts` passes.
