### PR TITLE
graph: cap cross-cycle fix-interrupt re-entry on stalled reviews (tactic-graph-review-exclusion-stall-recovery-main-qa-regression)

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/reconcile-graph-review-stall
+++ b/.claude/skills/dispatch-propagate/scripts/reconcile-graph-review-stall
@@ -42,6 +42,10 @@
 #
 # Stdout protocol, one line per tactic acted on; NOTHING for a skip:
 #   recovered <id> -> fix (ci=<verdict> merge=<state>)
+#   held <id> -> fix-cycle-cap (cycles=<n>)   — the lifetime cross-cycle cap
+#     (FIX_CYCLE_CAP, src/transitions.ts) is exhausted; a tracked hold was
+#     landed instead of a fresh execution.fix entry (see
+#     _hold_node_review_stall_cycle_cap below).
 #
 # Exit codes: 0 always (including a no-op sweep and any per-node error —
 # best-effort, matching reconcile-graph-merged's doctrine); 1 only for a hard
@@ -59,10 +63,14 @@
 # this sweep, and dispatch-acquire-lock reclaims a holder whose heartbeat is
 # older than MAX_HOLD_SECONDS (default 300s). A graph-commit can block far
 # longer than that (it waits on the global landing lock for up to
-# LOCK_WAIT_SECONDS, default 1050s), so this sweep runs AT MOST ONE
-# graph-commit per tick: every `fix`-routed node's `--set-fix` write is
-# batched into ONE commit (exactly as reconcile-graph-merged batches its plan).
-# Per-tick actions are
+# LOCK_WAIT_SECONDS, default 1050s), so every `fix`-routed node's `--set-fix`
+# write is batched into ONE commit (exactly as reconcile-graph-merged batches
+# its plan) rather than one graph-commit per node. A cross-cycle-cap hold
+# (`_hold_node_review_stall_cycle_cap`, below) is the one exception: hold-node
+# lands its OWN graph-commit synchronously, so a tick with both capped and
+# fresh-entry candidates can still make more than one graph-commit — the
+# heartbeat is refreshed immediately around each hold-node call for exactly
+# this reason. Per-tick actions are
 # additionally capped (GRAPH_REVIEW_STALL_CAP), and the lock heartbeat is
 # refreshed between candidates so the per-PR polling loop cannot age the lock
 # out on its own.
@@ -96,6 +104,55 @@ fi
 refresh_lock() {
   [[ -x "$SCRIPT_DIR/dispatch-acquire-lock" ]] || return 0
   "$SCRIPT_DIR/dispatch-acquire-lock" --heartbeat >/dev/null 2>&1 || true
+}
+
+# FIX_CYCLE_CAP mirrors packages/intentionsutil/src/transitions.ts's constant
+# of the same name (currently 3) — used only for the hold reason's diagnostic
+# prose below, never for the capped decision itself (that stays
+# apply-fix-state.ts's `--check-cycle-cap`, the single source of truth for the
+# comparison). Keep this literal in sync if the source constant changes.
+FIX_CYCLE_CAP=3
+
+# _hold_node_review_stall_cycle_cap <id> <pr> <cycles> — land a tracked hold
+# (reusing the `fix-attempt-cap` hold kind — graph-select-target's
+# `_hold_node_fix_cap` already covers the in-episode exhaustion case, and this
+# is the same remediation for the cross-cycle case: resolve the hold tactic to
+# get a fresh budget) once a node's LIFETIME fix-cycle count reaches
+# FIX_CYCLE_CAP, instead of entering another fresh `execution.fix` episode.
+# `--reset-fix-cycle` (not `--reset-fix-attempt`: there is no active interrupt
+# at this call site — enumeration already guarantees `execution.fix` is null)
+# gives the node a fresh cross-cycle budget once the hold is resolved. hold-node
+# lands its own graph-commit (fresh-origin/main refresh, hold node write, source
+# blocked_by edge), independent of this sweep's batched --set-fix land below.
+# Prints hold-node's stdout line on success; rc mirrors hold-node's own exit code.
+_hold_node_review_stall_cycle_cap() {
+  local id="$1" pr="$2" cycles="$3"
+  local tmpdir reason_file rec_file rc
+  tmpdir=$(mktemp -d) || return 1
+  reason_file="$tmpdir/reason.txt"
+  rec_file="$tmpdir/recommendation.txt"
+  {
+    printf 'reconcile-graph-review-stall: %s has entered and resolved the CI-fix ' "$id"
+    printf 'interrupt %s time(s) on PR #%s without landing a stable review — the ' \
+      "$cycles" "$pr"
+    printf 'cross-cycle cap of %s is exhausted. Each prior episode cleared with a fresh ' \
+      "$FIX_CYCLE_CAP"
+    printf 'attempt:1 budget (the in-episode FIX_ATTEMPT_CAP alone cannot stop this thrash).\n'
+  } > "$reason_file"
+  {
+    printf 'Review PR #%s to diagnose why review keeps stalling on repeated CI regressions ' "$pr"
+    printf "(the node's worktree tmp/fix-checks-summary.md across episodes, and PR comments, "
+    printf 'carry the per-episode diagnosis). Resolve THIS HOLD TACTIC (phase: done, then '
+    printf 'prune) to unblock %s with a fresh cross-cycle budget, or abandon/redesign the ' "$id"
+    printf 'tactic if the current approach cannot work.\n'
+  } > "$rec_file"
+
+  ( cd "$REPO_ROOT" && packages/intentionsutil/scripts/hold-node "$id" --kind fix-attempt-cap \
+      --reason-file "$reason_file" --recommendation-file "$rec_file" --reset-fix-cycle ) \
+    >/dev/null 2>&1
+  rc=$?
+  rm -rf "$tmpdir"
+  return $rc
 }
 
 # --- Rollback path for the staged --set-fix writes ---------------------------
@@ -221,6 +278,36 @@ while IFS=$'\t' read -r id pr; do
 
   case "$ROUTE" in
     fix)
+      # Cross-cycle cap (tactic-graph-review-exclusion-stall-recovery-main-qa-
+      # regression, needs-main residue item 9): `--set-fix` below would start a
+      # FRESH `execution.fix` episode (this candidate's enumeration already
+      # guarantees no interrupt is active), and `--clear-fix` never resets
+      # `execution.attempts[FIX_CYCLE_ATTEMPT_KEY]` — so a node that repeatedly
+      # enters this branch, resolves, and re-stalls would otherwise get a fresh
+      # `attempt: 1` budget every cycle and thrash indefinitely. Check the
+      # lifetime cap BEFORE entering; a capped node is routed to a tracked hold
+      # instead of a fresh entry.
+      cycle_out=$(node --import tsx/esm "$UTIL_SCRIPTS/apply-fix-state.ts" "$id" --check-cycle-cap --dir "$REPO_ROOT/intentions" 2>/dev/null) || {
+        echo "reconcile-graph-review-stall: apply-fix-state --check-cycle-cap failed for $id" >&2
+        continue
+      }
+      if [[ "$(jq -r '.cycleCapped' <<<"$cycle_out" 2>/dev/null)" == "true" ]]; then
+        cycles=$(jq -r '.cycles' <<<"$cycle_out" 2>/dev/null)
+        # hold-node lands its OWN graph-commit (fresh-origin/main refresh +
+        # write + land), separate from this sweep's batched --set-fix land —
+        # a potentially lock-blocking call, so refresh the heartbeat around it
+        # exactly as the batched land does below.
+        refresh_lock
+        if _hold_node_review_stall_cycle_cap "$id" "$pr" "$cycles"; then
+          echo "held $id -> fix-cycle-cap (cycles=$cycles)"
+          ACTED=$(( ACTED + 1 ))
+        else
+          echo "reconcile-graph-review-stall: hold-node --kind fix-attempt-cap (cycle cap) failed for $id" >&2
+        fi
+        refresh_lock
+        continue
+      fi
+
       # Snapshot the node's origin/main blob BEFORE staging the write, so any
       # later failure (this write, or the batched land below) restores a clean
       # tree. A candidate with no origin/main blob has no rollback path — skip

--- a/packages/intentionsutil/scripts/apply-fix-state.ts
+++ b/packages/intentionsutil/scripts/apply-fix-state.ts
@@ -57,29 +57,64 @@
 //                      the point it lands the tracked hold. Errors if no
 //                      interrupt is set.
 //
+//   --check-cycle-cap  Pure read of the CROSS-CYCLE cap (`FIX_CYCLE_CAP`,
+//                      `src/transitions.ts`), distinct from `--check-cap`:
+//                      that mode bounds retries WITHIN one open interrupt
+//                      episode, this one bounds LIFETIME fresh entries
+//                      (`execution.attempts[FIX_CYCLE_ATTEMPT_KEY]`, never
+//                      reset by `--clear-fix`). Makes NO write, and — unlike
+//                      every other read/write mode above — does NOT require
+//                      an active interrupt: it is meant to be checked BEFORE
+//                      `--set-fix`, to decide whether a fresh entry should be
+//                      allowed at all. Called by `reconcile-graph-review-stall`
+//                      before re-entering the interrupt on a stalled review.
+//
+//   --reset-cycle      Write-only: resets `execution.attempts[FIX_CYCLE_ATTEMPT_KEY]`
+//                      to 0, giving a human-resolved cross-cycle hold a fresh
+//                      lifetime budget. Called by `hold-node --reset-fix-cycle`
+//                      at the point it lands a cross-cycle-cap hold. Does not
+//                      require an active interrupt (mirrors `--check-cycle-cap`).
+//
 // Usage:
 //   node --import tsx/esm apply-fix-state.ts <node-id> \
-//     (--set-fix | --clear-fix | --record-push <sha> | --spend-attempt | --check-cap | --reset-attempt) \
+//     (--set-fix | --clear-fix | --record-push <sha> | --spend-attempt | --check-cap | \
+//      --reset-attempt | --check-cycle-cap | --reset-cycle) \
 //     [--dir <intentions-dir>]
 //
 // Stdout: one JSON object, shape per mode —
-//   set-fix:        { "mode": "set",         "id", "attempt": <n>, "since": <date>, "wrote": true }
-//   clear-fix:      { "mode": "clear",       "id", "phase": <resolved>, "reset": bool, "wrote": true }
-//   record-push:    { "mode": "record",      "id", "pushed_sha": <sha>, "wrote": true }
-//   spend-attempt:  { "mode": "spend",       "id", "attempt": <n>, "wrote": true }
-//   check-cap:      { "mode": "check-cap",   "id", "capped": bool, "consumed": <n>, "attempt": <n> }
-//   reset-attempt:  { "mode": "reset-attempt", "id", "wrote": true, "attempt": 1 }
+//   set-fix:         { "mode": "set",         "id", "attempt": <n>, "since": <date>, "wrote": true }
+//   clear-fix:       { "mode": "clear",       "id", "phase": <resolved>, "reset": bool, "wrote": true }
+//   record-push:     { "mode": "record",      "id", "pushed_sha": <sha>, "wrote": true }
+//   spend-attempt:   { "mode": "spend",       "id", "attempt": <n>, "wrote": true }
+//   check-cap:       { "mode": "check-cap",   "id", "capped": bool, "consumed": <n>, "attempt": <n> }
+//   reset-attempt:   { "mode": "reset-attempt", "id", "wrote": true, "attempt": 1 }
+//   check-cycle-cap: { "mode": "check-cycle-cap", "id", "wrote": false, "cycles": <n>, "cycleCapped": bool }
+//   reset-cycle:     { "mode": "reset-cycle", "id", "wrote": true, "cycles": 0 }
 
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { readNode, writeNode } from "../src/store.js";
 import type { Execution, FixState } from "../src/schema.js";
-import { FIX_ATTEMPT_CAP, REVIEWED_MARKER } from "../src/transitions.js";
+import {
+  FIX_ATTEMPT_CAP,
+  FIX_CYCLE_ATTEMPT_KEY,
+  FIX_CYCLE_CAP,
+  incrementAttempt,
+  REVIEWED_MARKER,
+} from "../src/transitions.js";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = dirname(dirname(dirname(scriptDir)));
 
-type Mode = "set" | "clear" | "record" | "spend" | "check-cap" | "reset-attempt";
+type Mode =
+  | "set"
+  | "clear"
+  | "record"
+  | "spend"
+  | "check-cap"
+  | "reset-attempt"
+  | "check-cycle-cap"
+  | "reset-cycle";
 
 interface Args {
   id: string;
@@ -101,7 +136,7 @@ export function parseArgs(argv: string[]): Args {
   const setMode = (m: Mode): void => {
     if (mode !== null) {
       throw new Error(
-        "apply-fix-state: --set-fix, --clear-fix, --record-push, --spend-attempt, --check-cap, and --reset-attempt are mutually exclusive",
+        "apply-fix-state: --set-fix, --clear-fix, --record-push, --spend-attempt, --check-cap, --reset-attempt, --check-cycle-cap, and --reset-cycle are mutually exclusive",
       );
     }
     mode = m;
@@ -133,6 +168,12 @@ export function parseArgs(argv: string[]): Args {
       case "--reset-attempt":
         setMode("reset-attempt");
         break;
+      case "--check-cycle-cap":
+        setMode("check-cycle-cap");
+        break;
+      case "--reset-cycle":
+        setMode("reset-cycle");
+        break;
       case "--dir": {
         const v = argv[++i];
         if (v === undefined || v === "") throw new Error("apply-fix-state: --dir requires a directory argument");
@@ -148,7 +189,7 @@ export function parseArgs(argv: string[]): Args {
   if (id === "") throw new Error("apply-fix-state: <node-id> is required");
   if (mode === null) {
     throw new Error(
-      "apply-fix-state: one of --set-fix | --clear-fix | --record-push <sha> | --spend-attempt | --check-cap | --reset-attempt is required",
+      "apply-fix-state: one of --set-fix | --clear-fix | --record-push <sha> | --spend-attempt | --check-cap | --reset-attempt | --check-cycle-cap | --reset-cycle is required",
     );
   }
   return { id, mode, pushedSha, dir };
@@ -177,6 +218,10 @@ export interface FixStateResult {
   capped?: boolean;
   /** check-cap: the count of attempts consumed so far (`attempt - 1`). */
   consumed?: number;
+  /** check-cycle-cap/reset-cycle: the lifetime fix-cycle count (`execution.attempts[FIX_CYCLE_ATTEMPT_KEY]`). */
+  cycles?: number;
+  /** check-cycle-cap: whether `cycles` is at or above `FIX_CYCLE_CAP`. */
+  cycleCapped?: boolean;
 }
 
 /** The node shape `applyFixState` mutates: a tactic with an `execution` block. */
@@ -199,7 +244,11 @@ function requireFix(currentFix: FixState | null, id: string, whatFor: string): F
 /**
  * `--set-fix`: enter the interrupt. Fresh when none is set; a defensive double-
  * call bumps `attempt` and preserves `since`/`pushed_sha` so an in-flight count
- * is not clobbered.
+ * is not clobbered. A genuinely fresh entry (`currentFix === null`) also bumps
+ * the LIFETIME `FIX_CYCLE_ATTEMPT_KEY` counter on `execution.attempts` — unlike
+ * `fix.attempt`, this survives `--clear-fix`, so it accumulates across
+ * enter/clear/re-stall cycles rather than resetting to 1 every time. The
+ * defensive double-call branch is not a new cycle, so it does not bump it.
  */
 function applySet(
   args: Args,
@@ -211,7 +260,9 @@ function applySet(
     currentFix === null
       ? { since: todayUtc(), attempt: 1, pushed_sha: null }
       : { ...currentFix, attempt: currentFix.attempt + 1 };
-  node.execution = { ...execution, fix };
+  const nextExecution: Execution =
+    currentFix === null ? incrementAttempt(execution, FIX_CYCLE_ATTEMPT_KEY) : execution;
+  node.execution = { ...nextExecution, fix };
   writeNode(args.dir, node);
   return { mode: "set", id: args.id, wrote: true, attempt: fix.attempt, since: fix.since };
 }
@@ -301,6 +352,47 @@ function applyCheckCap(
 }
 
 /**
+ * `--check-cycle-cap`: pure read of the CROSS-CYCLE cap. Makes NO write, and
+ * — unlike every other check/spend/clear/record/reset mode — does NOT require
+ * an active interrupt: `execution.fix` is null at the point this is meant to
+ * be called (BEFORE `--set-fix`, to decide whether a fresh entry should be
+ * allowed at all). Reports the lifetime fix-cycle count
+ * (`execution.attempts[FIX_CYCLE_ATTEMPT_KEY]`, defaulting to 0 when absent)
+ * and whether it has already reached `FIX_CYCLE_CAP`.
+ */
+function applyCheckCycleCap(
+  args: Args,
+  _node: TacticNode,
+  execution: Execution,
+  _currentFix: FixState | null,
+): FixStateResult {
+  const cycles = execution.attempts[FIX_CYCLE_ATTEMPT_KEY] ?? 0;
+  return {
+    mode: "check-cycle-cap",
+    id: args.id,
+    wrote: false,
+    cycles,
+    cycleCapped: cycles >= FIX_CYCLE_CAP,
+  };
+}
+
+/**
+ * `--reset-cycle`: write-only reset of `execution.attempts[FIX_CYCLE_ATTEMPT_KEY]`
+ * to 0, giving a human-resolved cross-cycle-cap hold a fresh lifetime budget.
+ * Does not require an active interrupt (mirrors `--check-cycle-cap`).
+ */
+function applyResetCycle(
+  args: Args,
+  node: TacticNode,
+  execution: Execution,
+  _currentFix: FixState | null,
+): FixStateResult {
+  node.execution = { ...execution, attempts: { ...execution.attempts, [FIX_CYCLE_ATTEMPT_KEY]: 0 } };
+  writeNode(args.dir, node);
+  return { mode: "reset-cycle", id: args.id, wrote: true, cycles: 0 };
+}
+
+/**
  * `--reset-attempt`: write-only reset of `execution.fix.attempt` to 1,
  * preserving `since`/`pushed_sha` and the ladder `phase`, giving a
  * human-cleared (or newly-held) node a fresh budget. Called by
@@ -344,6 +436,8 @@ const MODE_HANDLERS: Record<
   spend: applySpend,
   "check-cap": applyCheckCap,
   "reset-attempt": applyResetAttempt,
+  "check-cycle-cap": applyCheckCycleCap,
+  "reset-cycle": applyResetCycle,
   record: applyRecord,
 };
 

--- a/packages/intentionsutil/scripts/hold-node
+++ b/packages/intentionsutil/scripts/hold-node
@@ -34,7 +34,7 @@
 #   hold-node <source-node-id>
 #             --kind <provision-conflict|fix-attempt-cap|worktree-residue>
 #             --reason-file <f> --recommendation-file <f>
-#             [--body-file <f>] [--reset-fix-attempt]
+#             [--body-file <f>] [--reset-fix-attempt] [--reset-fix-cycle]
 #
 # --reason-file / --recommendation-file are FILES (not inline strings): both are
 #   multi-line diagnostic text, passed through to hold-node-decide.ts verbatim.
@@ -42,6 +42,12 @@
 # --reset-fix-attempt: additionally reset the SOURCE's `execution.fix.attempt`
 #   counter (see the call site below for why it must happen here, not in the
 #   caller).
+# --reset-fix-cycle: additionally reset the SOURCE's LIFETIME
+#   `execution.attempts[FIX_CYCLE_ATTEMPT_KEY]` cross-cycle counter (distinct
+#   from --reset-fix-attempt's in-episode counter — see apply-fix-state.ts's
+#   `--reset-cycle`). Called by `reconcile-graph-review-stall` when it lands a
+#   cross-cycle-cap hold, so resolving the hold gives the node a fresh
+#   lifetime budget rather than leaving it permanently capped.
 #
 # Stdout: exactly one line — `held <hold-id> (<disposition>)`, where
 # <disposition> is NONE (born fresh) | EXISTING (re-entry on an open hold) |
@@ -61,7 +67,7 @@ DUMP_NODE_TS="$SCRIPT_DIR/dump-node.ts"
 APPLY_FIX_TS="$SCRIPT_DIR/apply-fix-state.ts"
 GRAPH_COMMIT="$SCRIPT_DIR/graph-commit"
 
-USAGE="usage: hold-node <source-node-id> --kind <provision-conflict|fix-attempt-cap|worktree-residue> --reason-file <f> --recommendation-file <f> [--body-file <f>] [--reset-fix-attempt]"
+USAGE="usage: hold-node <source-node-id> --kind <provision-conflict|fix-attempt-cap|worktree-residue> --reason-file <f> --recommendation-file <f> [--body-file <f>] [--reset-fix-attempt] [--reset-fix-cycle]"
 
 SOURCE_ID=""
 KIND=""
@@ -69,6 +75,7 @@ REASON_FILE=""
 RECOMMENDATION_FILE=""
 BODY_FILE=""
 RESET_FIX_ATTEMPT=0
+RESET_FIX_CYCLE=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --kind) KIND="${2:-}"; shift 2 || { echo "$USAGE" >&2; exit 2; } ;;
@@ -76,6 +83,7 @@ while [[ $# -gt 0 ]]; do
     --recommendation-file) RECOMMENDATION_FILE="${2:-}"; shift 2 || { echo "$USAGE" >&2; exit 2; } ;;
     --body-file) BODY_FILE="${2:-}"; shift 2 || { echo "$USAGE" >&2; exit 2; } ;;
     --reset-fix-attempt) RESET_FIX_ATTEMPT=1; shift ;;
+    --reset-fix-cycle) RESET_FIX_CYCLE=1; shift ;;
     -*) echo "hold-node: unknown option \"$1\"" >&2; echo "$USAGE" >&2; exit 2 ;;
     *)
       if [[ -n "$SOURCE_ID" ]]; then
@@ -229,6 +237,13 @@ SOURCE_CHANGED=0
 if [[ "$RESET_FIX_ATTEMPT" == 1 ]]; then
   if ! (cd "$REPO_ROOT" && node --import tsx/esm "$APPLY_FIX_TS" "$SOURCE_ID" --reset-attempt) >/dev/null; then
     echo "hold-node: apply-fix-state --reset-attempt failed for $SOURCE_ID" >&2
+    exit 1
+  fi
+  SOURCE_CHANGED=1
+fi
+if [[ "$RESET_FIX_CYCLE" == 1 ]]; then
+  if ! (cd "$REPO_ROOT" && node --import tsx/esm "$APPLY_FIX_TS" "$SOURCE_ID" --reset-cycle) >/dev/null; then
+    echo "hold-node: apply-fix-state --reset-cycle failed for $SOURCE_ID" >&2
     exit 1
   fi
   SOURCE_CHANGED=1

--- a/packages/intentionsutil/src/transitions.ts
+++ b/packages/intentionsutil/src/transitions.ts
@@ -101,6 +101,30 @@ const FIX_INTERRUPTIBLE: ReadonlySet<string> = new Set(["implement", "qa", "revi
 export const FIX_ATTEMPT_CAP = 3;
 
 /**
+ * The `execution.attempts` key tracking a tactic's LIFETIME count of fresh
+ * fix-interrupt entries — bumped by `apply-fix-state.ts`'s `--set-fix` only on
+ * a genuinely fresh entry (`execution.fix` was null), and, unlike
+ * `execution.fix.attempt`, never reset by `--clear-fix`. This is the counter
+ * `FIX_CYCLE_CAP` compares against.
+ */
+export const FIX_CYCLE_ATTEMPT_KEY = "fix-cycle";
+
+/**
+ * Cross-cycle cap on fix-interrupt ENTRIES, distinct from `FIX_ATTEMPT_CAP`
+ * (which bounds retries WITHIN one open `execution.fix` episode).
+ * `--clear-fix` wipes `execution.fix` to null on resolution, so a node that
+ * repeatedly enters the interrupt, resolves it, and re-stalls would otherwise
+ * get a fresh `attempt: 1` budget every cycle and thrash indefinitely —
+ * `reconcile-graph-review-stall`'s fix-interrupt entry is the primary caller
+ * that can retrigger `--set-fix` after a prior episode already resolved (a
+ * `phase: review` + `reviewed` tactic is excluded from normal selection, so
+ * only that sweep, not the normal per-tick gate, can re-enter it). Counted via
+ * `FIX_CYCLE_ATTEMPT_KEY` on `execution.attempts`, which `--clear-fix` never
+ * touches.
+ */
+export const FIX_CYCLE_CAP = 3;
+
+/**
  * Whether a live CI verdict at `phase` should set the orthogonal `execution.fix`
  * interrupt (spec §1.1, clarification 18). Only a `failing` verdict at an
  * interruptible ladder phase fires; `unknown`/`passing` never do, and a `done`

--- a/packages/intentionsutil/test/apply-fix-state.test.ts
+++ b/packages/intentionsutil/test/apply-fix-state.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { readNode, writeNode } from "../src/store.js";
+import { FIX_CYCLE_ATTEMPT_KEY, FIX_CYCLE_CAP } from "../src/transitions.js";
 import { applyFixState, parseArgs } from "../scripts/apply-fix-state.js";
 
 function tempDir(): string {
@@ -267,6 +268,86 @@ describe("applyFixState store round-trip", () => {
   });
 });
 
+describe("cross-cycle cap (--check-cycle-cap / --reset-cycle)", () => {
+  it("--set-fix on a fresh entry bumps the lifetime cycle counter; --clear-fix does not reset it", () => {
+    const dir = tempDir();
+    seedTactic(dir, "qa", []);
+    applyFixState({ id: "tactic-syn", mode: "set", pushedSha: null, dir });
+    expect(readNode(dir, "tactic-syn").execution?.attempts[FIX_CYCLE_ATTEMPT_KEY]).toBe(1);
+    applyFixState({ id: "tactic-syn", mode: "clear", pushedSha: null, dir });
+    expect(readNode(dir, "tactic-syn").execution?.attempts[FIX_CYCLE_ATTEMPT_KEY]).toBe(1);
+    applyFixState({ id: "tactic-syn", mode: "set", pushedSha: null, dir });
+    expect(readNode(dir, "tactic-syn").execution?.attempts[FIX_CYCLE_ATTEMPT_KEY]).toBe(2);
+  });
+
+  it("a defensive double --set-fix (no intervening --clear-fix) does not bump the cycle counter", () => {
+    const dir = tempDir();
+    seedTactic(dir, "qa", []);
+    applyFixState({ id: "tactic-syn", mode: "set", pushedSha: null, dir });
+    applyFixState({ id: "tactic-syn", mode: "set", pushedSha: null, dir }); // defensive re-set, same episode
+    expect(readNode(dir, "tactic-syn").execution?.attempts[FIX_CYCLE_ATTEMPT_KEY]).toBe(1);
+  });
+
+  it("--check-cycle-cap with no interrupt in flight reports the lifetime count and makes no write", () => {
+    const dir = tempDir();
+    seedTactic(dir, "qa", []);
+    applyFixState({ id: "tactic-syn", mode: "set", pushedSha: null, dir });
+    applyFixState({ id: "tactic-syn", mode: "clear", pushedSha: null, dir });
+    const path = join(dir, "tactic-syn.md");
+    const mtimeBefore = statSync(path).mtimeMs;
+    const r = applyFixState({ id: "tactic-syn", mode: "check-cycle-cap", pushedSha: null, dir });
+    expect(r.mode).toBe("check-cycle-cap");
+    expect(r.wrote).toBe(false);
+    expect(r.cycles).toBe(1);
+    expect(r.cycleCapped).toBe(false);
+    expect(statSync(path).mtimeMs).toBe(mtimeBefore);
+    expect(readNode(dir, "tactic-syn").execution?.fix).toBeNull();
+  });
+
+  it("a node that enters and clears the fix-interrupt FIX_CYCLE_CAP times in a row is routed to a hold (cycleCapped: true) on the next re-entry check, instead of getting a fresh attempt:1 budget", () => {
+    const dir = tempDir();
+    seedTactic(dir, "qa", []);
+    for (let i = 0; i < FIX_CYCLE_CAP; i++) {
+      const before = applyFixState({ id: "tactic-syn", mode: "check-cycle-cap", pushedSha: null, dir });
+      expect(before.cycleCapped).toBe(false);
+      const set = applyFixState({ id: "tactic-syn", mode: "set", pushedSha: null, dir });
+      expect(set.attempt).toBe(1); // fresh attempt:1 budget every cycle, as designed
+      applyFixState({ id: "tactic-syn", mode: "clear", pushedSha: null, dir });
+    }
+    const capped = applyFixState({ id: "tactic-syn", mode: "check-cycle-cap", pushedSha: null, dir });
+    expect(capped.cycles).toBe(FIX_CYCLE_CAP);
+    expect(capped.cycleCapped).toBe(true);
+  });
+
+  it("--reset-cycle resets the lifetime counter to 0 with no active interrupt required, and makes a write", () => {
+    const dir = tempDir();
+    seedTactic(dir, "qa", []);
+    for (let i = 0; i < FIX_CYCLE_CAP; i++) {
+      applyFixState({ id: "tactic-syn", mode: "set", pushedSha: null, dir });
+      applyFixState({ id: "tactic-syn", mode: "clear", pushedSha: null, dir });
+    }
+    expect(applyFixState({ id: "tactic-syn", mode: "check-cycle-cap", pushedSha: null, dir }).cycleCapped).toBe(
+      true,
+    );
+    const r = applyFixState({ id: "tactic-syn", mode: "reset-cycle", pushedSha: null, dir });
+    expect(r.mode).toBe("reset-cycle");
+    expect(r.wrote).toBe(true);
+    expect(r.cycles).toBe(0);
+    expect(readNode(dir, "tactic-syn").execution?.attempts[FIX_CYCLE_ATTEMPT_KEY]).toBe(0);
+    expect(applyFixState({ id: "tactic-syn", mode: "check-cycle-cap", pushedSha: null, dir }).cycleCapped).toBe(
+      false,
+    );
+  });
+
+  it("--check-cycle-cap on a node with no fix-cycle history yet reports cycles: 0, capped: false", () => {
+    const dir = tempDir();
+    seedTactic(dir, "qa", []);
+    const r = applyFixState({ id: "tactic-syn", mode: "check-cycle-cap", pushedSha: null, dir });
+    expect(r.cycles).toBe(0);
+    expect(r.cycleCapped).toBe(false);
+  });
+});
+
 describe("apply-fix-state parseArgs", () => {
   it("parses --set-fix", () => {
     const a = parseArgs(["tactic-syn", "--set-fix"]);
@@ -298,6 +379,16 @@ describe("apply-fix-state parseArgs", () => {
     expect(a).toMatchObject({ id: "tactic-syn", mode: "reset-attempt", pushedSha: null });
   });
 
+  it("parses --check-cycle-cap", () => {
+    const a = parseArgs(["tactic-syn", "--check-cycle-cap"]);
+    expect(a).toMatchObject({ id: "tactic-syn", mode: "check-cycle-cap", pushedSha: null });
+  });
+
+  it("parses --reset-cycle", () => {
+    const a = parseArgs(["tactic-syn", "--reset-cycle"]);
+    expect(a).toMatchObject({ id: "tactic-syn", mode: "reset-cycle", pushedSha: null });
+  });
+
   it("rejects combining two modes", () => {
     expect(() => parseArgs(["tactic-syn", "--set-fix", "--clear-fix"])).toThrow(/mutually exclusive/);
   });
@@ -316,6 +407,12 @@ describe("apply-fix-state parseArgs", () => {
 
   it("rejects combining --reset-attempt with --check-cap", () => {
     expect(() => parseArgs(["tactic-syn", "--reset-attempt", "--check-cap"])).toThrow(
+      /mutually exclusive/,
+    );
+  });
+
+  it("rejects combining --check-cycle-cap with --reset-cycle", () => {
+    expect(() => parseArgs(["tactic-syn", "--check-cycle-cap", "--reset-cycle"])).toThrow(
       /mutually exclusive/,
     );
   });


### PR DESCRIPTION
Implements the intention node
`tactic-graph-review-exclusion-stall-recovery-main-qa-regression`. No GitHub
issue is associated with this graph node; the implement→qa transition is
driven by `transition-node --set-pr`, not by a `Closes #N` line.

## What

`reconcile-graph-review-stall`'s fix-interrupt entry had no cross-cycle
attempt cap: `FIX_ATTEMPT_CAP` only bounds retries *within* one open
`execution.fix` episode. `--clear-fix` wipes `execution.fix` to null on
resolution, so a node that repeatedly enters the interrupt, resolves it, and
re-stalls got a fresh `attempt: 1` budget every cycle — no lifetime counter
anywhere.

## How

- `packages/intentionsutil/src/transitions.ts` — new `FIX_CYCLE_ATTEMPT_KEY`
  ("fix-cycle") and `FIX_CYCLE_CAP` (3) constants.
- `packages/intentionsutil/scripts/apply-fix-state.ts`:
  - `--set-fix` now bumps `execution.attempts[FIX_CYCLE_ATTEMPT_KEY]` on a
    genuinely fresh entry (not on the defensive double-set-fix branch). This
    counter reuses the existing generic `attempts` map, survives
    `--clear-fix`, and accumulates across cycles.
  - New `--check-cycle-cap`: pure read of the lifetime count vs the cap, with
    no active-interrupt requirement (checked *before* `--set-fix`).
  - New `--reset-cycle`: write-only reset of the lifetime counter to 0.
- `packages/intentionsutil/scripts/hold-node` — new `--reset-fix-cycle` flag,
  mirroring `--reset-fix-attempt`, so resolving a cross-cycle hold gives the
  node a fresh lifetime budget.
- `.claude/skills/dispatch-propagate/scripts/reconcile-graph-review-stall` —
  before re-entering the fix interrupt on a stalled review, checks the cycle
  cap. When exhausted, lands a tracked hold (reusing the existing
  `fix-attempt-cap` hold kind — same remediation model: resolve the hold to
  get a fresh budget) instead of a fresh entry, via a new
  `_hold_node_review_stall_cycle_cap` helper mirroring
  `graph-select-target`'s `_hold_node_fix_cap`.
- `packages/intentionsutil/test/apply-fix-state.test.ts` — new tests covering
  the cycle counter's bump-on-fresh-entry / survive-clear-fix behavior, the
  new `--check-cycle-cap`/`--reset-cycle` modes, and end-to-end
  enter/clear/re-stall cycling up to and past `FIX_CYCLE_CAP`.

## Note

The node body's fix-direction referenced a `ci_pending_strike_bump`/`clear`
sidecar pattern and a `ci-pending-stalled` hold as reusable precedent —
neither exists in this codebase (verified by grep). The implementation
instead reuses what actually exists: the generic `execution.attempts` map for
the counter, and the existing `fix-attempt-cap` hold kind for the tracked
hold, rather than inventing a parallel mechanism.

No fixture reproduces a production multi-cycle review-stall thrash yet (only
one node has ever gone through this reconciler, still on its first cycle), so
this is verified by unit test rather than an end-to-end shell harness — no
`test-reconcile-graph-review-stall.sh` exists to extend (no sibling
`test-reconcile-graph-merged.sh` exists either; these sweep scripts have no
existing shell-test convention to follow).
