### PR TITLE
tactic-rsi-skill: build /rsi + /rsi-plan and render-rsi-plan.ts

### DIFF
--- a/.claude/skills/dispatch-propagate/scripts/run-unit-tests.sh
+++ b/.claude/skills/dispatch-propagate/scripts/run-unit-tests.sh
@@ -15,6 +15,7 @@ RUN_CI_SCRIPTS=false
 RUN_PR_SCRIPTS=false
 RUN_TOKEN_AUDIT_SCRIPTS=false
 RUN_FILE_ISSUE_SCRIPTS=false
+RUN_RSI_SCRIPTS=false
 EXPLICIT=false
 
 while [[ $# -gt 0 ]]; do
@@ -55,8 +56,13 @@ while [[ $# -gt 0 ]]; do
       EXPLICIT=true
       shift
       ;;
+    --rsi-scripts)
+      RUN_RSI_SCRIPTS=true
+      EXPLICIT=true
+      shift
+      ;;
     *)
-      echo "Usage: run-unit-tests.sh [--app <dir>] [--nix] [--rules] [--ci-scripts] [--pr-scripts] [--token-audit-scripts] [--file-issue-scripts]" >&2
+      echo "Usage: run-unit-tests.sh [--app <dir>] [--nix] [--rules] [--ci-scripts] [--pr-scripts] [--token-audit-scripts] [--file-issue-scripts] [--rsi-scripts]" >&2
       exit 1
       ;;
   esac
@@ -88,6 +94,7 @@ if [ "$EXPLICIT" = false ]; then
       .claude/skills/dispatch-propagate/scripts/*) RUN_PR_SCRIPTS=true ;;
       .claude/skills/dispatch-token-audit/scripts/*) RUN_TOKEN_AUDIT_SCRIPTS=true ;;
       .claude/skills/file-issue/scripts/*) RUN_FILE_ISSUE_SCRIPTS=true ;;
+      .claude/skills/rsi/scripts/*) RUN_RSI_SCRIPTS=true ;;
     esac
   done <<< "$CHANGED"
 fi
@@ -245,7 +252,28 @@ if [ "$RUN_FILE_ISSUE_SCRIPTS" = true ]; then
   fi
 fi
 
-if [ ${#APP_DIRS[@]} -eq 0 ] && [ "$RUN_NIX" = false ] && [ "$RUN_RULES" = false ] && [ "$RUN_CI_SCRIPTS" = false ] && [ "$RUN_PR_SCRIPTS" = false ] && [ "$RUN_TOKEN_AUDIT_SCRIPTS" = false ] && [ "$RUN_FILE_ISSUE_SCRIPTS" = false ]; then
+# Run rsi script tests (the /rsi claim primitive; no test-helpers.sh in that dir)
+if [ "$RUN_RSI_SCRIPTS" = true ]; then
+  echo "=== RSI script tests ==="
+  RSI_SCRIPTS="$REPO_ROOT/.claude/skills/rsi/scripts"
+  RSI_FAIL=false
+  for test_script in "$RSI_SCRIPTS"/test-*.sh; do
+    name=$(basename "$test_script")
+    [[ "$name" == "test-helpers.sh" ]] && continue
+    echo "--- $name ---"
+    if "$test_script"; then
+      echo "PASS: $name"
+    else
+      echo "FAIL: $name" >&2
+      RSI_FAIL=true
+    fi
+  done
+  if [ "$RSI_FAIL" = true ]; then
+    FAILURES+=(rsi-scripts)
+  fi
+fi
+
+if [ ${#APP_DIRS[@]} -eq 0 ] && [ "$RUN_NIX" = false ] && [ "$RUN_RULES" = false ] && [ "$RUN_CI_SCRIPTS" = false ] && [ "$RUN_PR_SCRIPTS" = false ] && [ "$RUN_TOKEN_AUDIT_SCRIPTS" = false ] && [ "$RUN_FILE_ISSUE_SCRIPTS" = false ] && [ "$RUN_RSI_SCRIPTS" = false ]; then
   echo "No test suites matched changed files. Nothing to check."
   exit 0
 fi

--- a/.claude/skills/rsi-plan/SKILL.md
+++ b/.claude/skills/rsi-plan/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: rsi-plan
+description: Refresh rsi-plan.md from graph state — draft the three queue summaries as dated records on their owning strategy nodes, run render-rsi-plan.ts, and report the mechanical staleness flags. Rendering only; it makes no judgment about what to do next and takes no dispatch action.
+user-invocable: true
+---
+
+# RSI Plan
+
+The **rendering** half of the `/rsi` loop. `/rsi` invokes this as step 1 in a
+subagent; it may also be run alone to refresh the dashboard.
+
+The split is deliberate (`strategy-recursive-self-improvement`, 2026-08-10
+review round): **this skill renders, `/rsi` judges.** Drafting summaries and
+regenerating the file is mechanical work that fits a subagent. Deciding what the
+flags mean — which graph updates are required, whether an item is dispatch's
+work or an rsi shortcut, whether an `/align` session is needed, how the task plan
+should change — belongs to the `/rsi` main thread, which holds the serialized
+claim and can talk to the author. **Never make those decisions here.** Report
+the flags and stop.
+
+## What is out of scope
+
+- Deciding, recommending, or executing next steps. Report; do not route.
+- Pausing or resuming dispatch. That authority is `/rsi`'s.
+- Editing `rsi-plan.md` by hand, in whole or in part. Every section is
+  rendered; a hand-edited section is a defect (strategy condition 5). If the
+  file should say something it does not, change the **graph** and re-render.
+- Any graph write other than the three `attributes.queue_summary` fields below.
+
+## Step 1 — Sync, and confirm the store you are about to read
+
+The render reads the store at `origin/main`, not the working tree, so a stale
+remote-tracking ref renders a stale dashboard and pushes it to main as current.
+Fetch first:
+
+```bash
+git fetch origin main
+```
+
+## Step 2 — Produce the usage aggregate
+
+Per-workflow token attribution is part of the fitness function, and an absent
+aggregate renders as an explicit *unavailable* line rather than as zero spend.
+Produce one:
+
+```bash
+mkdir -p tmp
+.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh --days 7 --json-out tmp/usage-audit.json
+```
+
+This parses local session transcripts; it needs no network. If it fails, say so
+and continue — the render degrades honestly.
+
+## Step 3 — Draft the three queue summaries
+
+Each summary is a short prose read of one queue's current state and near-term
+priorities. **The graph is the source of truth, never the `.md`**: each summary
+lands on the strategy that owns its queue, and the render pulls it from there.
+
+| queue | owning node |
+|---|---|
+| dispatch | `strategy-graph-native-dispatch` |
+| office-hours | `strategy-attention-surface` |
+| rsi | `strategy-recursive-self-improvement` |
+
+Write each as `attributes.queue_summary: {date, summary}` on its owning node.
+The field — rather than the top-level `reading` — is deliberate: `reading` is
+sensor-owned, and `read-sensors.ts` overwrites it on every batch run, so a
+summary parked there would be silently clobbered. `attributes.queue_summary` is
+outside `strategyFingerprint`'s substance hash, so re-drafting a summary each
+iteration invalidates no open child's strategy stamp.
+
+Ground each summary in what you can read, not in recall:
+
+- **dispatch** — open tactics by phase, the backlog band and its trend, what is
+  in `review`/`main-qa` and what it is waiting on, and the pause state.
+  `npx tsx packages/intentionsutil/scripts/align-tactics-census.ts` and
+  `graph-census-debt.ts` are the mechanical views.
+- **office-hours** — the rank-lifted parks and what they block. Canonical view:
+  `npx tsx packages/intentionsutil/scripts/office-hours-select.ts --list`.
+  Never hand-roll a park probe.
+- **rsi** — the state of the task plan: what landed since the last iteration,
+  what is in flight, what is blocked.
+
+Keep each to a short paragraph. This is the one place in the file where a model
+writes prose, so it carries what a table cannot: *why* the queue looks like this.
+
+Land all three in ONE `graph-commit` round, following the standard edit-round
+discipline — `dump-node.ts --out-dir <dir>` for the base manifest BEFORE any
+edit, `write-node.ts --file <json>` to write (it preserves existing bodies), and
+`graph-commit --base <manifest>` to land. Verify the landing by parsing
+`origin/main`, never by exit code.
+
+## Step 4 — Render
+
+```bash
+npx tsx packages/intentionsutil/scripts/render-rsi-plan.ts
+```
+
+Writes `rsi-plan.md` and prints one `FLAG <kind> <subject> — <detail>` line per
+staleness finding on stderr. `--check` renders without writing and exits 1 if
+the committed file is stale; `--json` emits `{markdown, flags}` and writes
+nothing.
+
+The flag kinds, and what each means mechanically:
+
+| kind | meaning |
+|---|---|
+| `summary-missing` / `summary-stale` | a queue summary is absent or older than 7 days — step 3 did not land |
+| `threshold-breach` | a measured signal's reading does not meet its recorded threshold |
+| `unread-sensor` | a registered sensor has never been read — run `read-sensors.ts` |
+| `task-done` / `task-parked` | an rsi task node completed or parked; the plan sequence needs re-deriving |
+| `spend-deviation` | dispatch did not outpace office-hours/rsi — the fitness function's recorded expectation failed |
+
+## Step 5 — Land the file, and report
+
+`rsi-plan.md` is single-writer and direct-pushed to main with no PR flow — a
+recorded exception to `strategy-graph-native-dispatch`'s
+direct-push-restricted-to-`intentions/` condition, carried until
+`tactic-rsi-direct-push-condition-reconcile` amends it (strategy condition 5).
+Commit only `rsi-plan.md` and push.
+
+Then report to the caller, and stop:
+
+1. Every flag, verbatim, grouped by kind.
+2. What changed in the file versus its previous revision (`git diff HEAD~1 -- rsi-plan.md`).
+3. Anything the render could not read (a failed aggregate, an unreachable ref).
+
+No recommendations. No next steps. The `/rsi` main thread decides.

--- a/.claude/skills/rsi/SKILL.md
+++ b/.claude/skills/rsi/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: rsi
+description: Run one recursive-self-improvement iteration over the dispatch harness — claim the serialized rsi worktree, refresh rsi-plan.md via /rsi-plan, judge what the flags mean, and either record harness work in the graph or execute rsi-plan tasks to budget. Attended and author-invoked; one iteration per invocation; fails closed when another rsi session holds the claim.
+user-invocable: true
+---
+
+# RSI
+
+One iteration of the recursive self-improvement loop over the dispatch harness,
+per invocation. Recorded in `intentions/strategy-recursive-self-improvement.md`
+— read it at `origin/main` before deciding anything; the nine conditions and
+twelve clarifications there are authoritative and this file is their mechanism.
+
+**What this skill is not.** It is not a graph executor and not a second
+orchestration surface. The dispatch router owns execution. `/rsi` plans harness
+optimization and, where the critical path is genuinely deadlocked, shortcuts one
+node through the **existing** dispatch phase skills, reused verbatim. If you
+find yourself writing an orchestration rule that dispatch does not already have,
+stop — that is the divergence the record forbids.
+
+**Attended, never cron** (strategy condition 9). `/rsi` is author-invoked and
+runs with the author present. Do not schedule it, do not wake it up, do not
+chain iterations. Unattended recursion is the harness's job; the interactive
+limbs below exist precisely because the author is there.
+
+## Step 0 — Claim, fail closed
+
+```bash
+.claude/skills/rsi/scripts/rsi-claim
+```
+
+Run this **with `dangerouslyDisableSandbox: true`** — it reads the Claude daemon
+over a Unix socket the sandbox blocks silently (`.claude/rules/sandbox.md`), and
+sandboxed it exits 12 rather than lying.
+
+The `strategy-recursive-self-improvement` worktree IS the claim (worktree-as-
+claim, the router's own liveness rule — no lock file, no second detection
+mechanism). Outcomes:
+
+- **exit 0** — prints the worktree path. Proceed.
+- **exit 11** — another `/rsi` session holds it. **Print the script's message to
+  the author and stop.** Do not wait, do not retry in a loop, do not work around
+  it. Serialization is the design.
+- **exit 12** — the probe could not answer. Also stop: an unanswerable probe is
+  held, never free.
+
+On exit 0, enter the worktree — `provision-node-worktree strategy-recursive-self-improvement <phase>`
+if it does not exist, otherwise `EnterWorktree` at the printed path followed by
+the mandatory `.claude/skills/dispatch-propagate/scripts/assert-worktree-fresh`.
+A non-zero freshness check means STOP and freshen; never proceed on unverified
+state.
+
+## Step 1 — Refresh the plan (subagent)
+
+Invoke `/rsi-plan` in a subagent. It drafts the three queue summaries onto their
+owning strategy nodes, runs `render-rsi-plan.ts`, lands `rsi-plan.md`, and
+returns the staleness flags.
+
+Rendering is the subagent's whole job. It returns flags; it recommends nothing.
+
+## Step 2 — Judge (main thread, never delegated)
+
+This is the step that makes `/rsi` more than a dashboard, and it is why the loop
+is attended. Read the returned flags and `rsi-plan.md`, then decide — in this
+thread, with the author reachable:
+
+1. **What does each flag mean?** A `threshold-breach` may be a real regression, a
+   sensor measuring the wrong thing, or a threshold that has outlived its
+   framing. Say which.
+2. **What graph updates are required?** Harness defects become tactic nodes.
+   Ambiguities in author intention become office-hours items. Nothing that
+   matters is tracked anywhere but the graph.
+3. **Harness or rsi?** Default: the harness does the work. Route to an rsi
+   shortcut ONLY for a critical-path item the harness structurally cannot reach
+   — the bootstrap-deadlock case (dispatch paused, the fix is what would unpause
+   it; a node blocked by a park only the author can clear). "It would be faster"
+   is not a reason.
+4. **Is an `/align` session needed?** When a finding cannot be resolved from
+   recorded guidance — the author's intent is genuinely unrecorded — escalate to
+   `/align` rather than guessing. That is step 3.
+5. **How should the task plan change?** Completed tasks come out, missing
+   critical tasks go in. The plan is re-derived every iteration, not appended to.
+
+**Evaluation scope** each iteration, from the recorded requirement:
+
+- bugs inconsistent with documented intention;
+- execution inefficiencies — token waste from poorly managed context,
+  unoptimized model choice, redundant work, repeated errors;
+- ambiguities in author intention, e.g. parked office-hours nodes sitting on the
+  critical path;
+- technical debt not justified by the current greenfield design.
+
+**The fitness function** (strategy clarification 10) is what all of this
+optimizes: the value the combined dispatch + office-hours + rsi system delivers
+toward author intentions — closure velocity plus strategy signal progress, per
+token, attributed per workflow. Dispatch is expected to dominate spend; a
+`spend-deviation` flag is a review trigger, not a datum to note and pass.
+
+## Step 3 — Escalate to `/align` when intent is unrecorded
+
+Only for findings step 2 could not resolve from the record. `/align` runs the
+interview and lands the strategy edit; come back here after.
+
+## Step 4 — Act, to budget
+
+**Budget** (strategy condition 6): each session's default budget is **1**. An
+rsi-implement task costs **1**; every other task costs **0** unless its node
+declares `attributes.rsi_cost`. Execute until the budget is exhausted, then stop
+and report — do not overrun because something looks nearly done.
+
+Two kinds of work:
+
+**4a — Record (cost 0).** Draft tactics for the harness optimizations step 2
+identified, as graph nodes serving the right strategy. Land via `graph-commit`;
+verify by parsing `origin/main`, never by exit code. Most iterations should be
+mostly this: the harness does the work, rsi decides what the work is.
+
+**4b — Execute (cost 1 each).** Drive a claimed node through the dispatch phase
+skills. **The orchestration loop for this lands in R3
+(`tactic-rsi-implement-skill`) and is not built yet** — until it is, an
+execute-class task is hand-orchestrated in this attended session using the
+monitor's proven path: claim the node's worktree, spawn the phase skill for its
+persisted phase as a **session** via `dispatch-graph-execute` /
+`dispatch-spawn-job`, await the terminal disposition, verify the transition off
+`origin/main`, repeat. Two rules hold either way:
+
+- **Never hand-merge.** The tick's merge lane runs even while dispatch is
+  paused. Let it.
+- **Never run a phase skill in an Agent-tool subagent.** `/qa-fix`,
+  `/review-fix` and `/align-tactics` depend on the Workflow tool, which a
+  subagent cannot use. They must be spawned sessions.
+
+On a park or a non-mechanical blocker, do not push through: conduct the
+office-hours engagement here, attended, and record the outcome in the graph.
+
+## Pause and resume authority
+
+`/rsi` holds pause/resume authority over the dispatch queue for integrity errors
+affecting the stability or correctness of the workflow (strategy condition 4).
+
+- Pause through the **doctrinal** mechanism — the `dispatch.config` boolean once
+  `tactic-dispatch-pause-config-field` lands; the sentinel file
+  (`${XDG_DATA_HOME:-$HOME/.local/share}/commons-dispatch/paused`) is interim
+  practice, read canonically by `lib-pause-state.sh`'s `dispatch_pause_state`.
+- **Every pause records explicit, mechanically evaluable resume criteria** as
+  structured data, rendered into `rsi-plan.md`. A pause with no recorded
+  criterion, or with prose-only criteria no check can evaluate, is a defect.
+- **Never lift a pause early without recording why.** Resume when every recorded
+  criterion holds, having re-measured each — not when the queue looks quiet.
+
+`/rsi` and its work are pace-exempt: the budget and the serialization are the
+throttle, not the pace curve (strategy condition 7).
+
+## Step 5 — Report and stop
+
+One iteration per invocation. Report:
+
+1. the flags and what you judged each to mean;
+2. what landed — nodes, `rsi-plan.md`, any pause/resume act, with commits;
+3. budget spent and what it bought;
+4. what the next iteration should pick up first.
+
+Then stop. Do not start another iteration.

--- a/.claude/skills/rsi/scripts/rsi-claim
+++ b/.claude/skills/rsi/scripts/rsi-claim
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# rsi-claim — the /rsi serialization primitive.
+#
+# `strategy-recursive-self-improvement` condition 1: "at most one /rsi session is
+# active at a time — invocation claims a singleton resource (the
+# strategy-recursive-self-improvement worktree, worktree-as-claim, the same
+# liveness rule the router uses) and fails with a printed error when the claim is
+# held; fail-closed and automatic, never operator discipline, and never a second
+# detection mechanism beside the claim primitive."
+#
+# So this script adds NO detection of its own. It asks
+# `lib-claude-agents.sh`'s `claude_sessions_under` — the same probe the router
+# uses to decide whether a node's worktree is occupied — about exactly one path:
+# `.claude/worktrees/strategy-recursive-self-improvement`. The worktree IS the
+# claim; there is no lock file, no PID file, no registry.
+#
+# FAIL-CLOSED. Three outcomes, and only the first proceeds:
+#   free     — no other session is in the worktree; /rsi may run.       exit 0
+#   held     — another live session holds it; /rsi must not run.        exit 11
+#   unknown  — the probe could not answer (daemon unreachable, sandboxed
+#              read, malformed output). Treated as HELD.                exit 12
+# `unknown` is not a soft case. A sandboxed `claude agents --json` returns `[]`,
+# indistinguishable from a genuine "no sessions" (`.claude/rules/sandbox.md`) —
+# so a claim that trusted an unanswerable probe would start a second concurrent
+# /rsi against the one that is actually running. The helper already folds
+# uncorroborated-empty into unknown; this script keeps that fold rather than
+# re-deriving it.
+#
+# SELF-EXCLUSION. /rsi may be invoked from a session that is ALREADY inside the
+# rsi worktree (the ordinary case once the loop is running: judge, escalate,
+# execute, iterate). Its own session must not be read as a rival claim, so every
+# session whose pid is an ANCESTOR of this script's process is excluded. Pid
+# ancestry, not a session-id env var: the script is run by whatever session is
+# asking, and the ancestry is a fact of the process tree rather than something a
+# caller has to be trusted to pass correctly.
+#
+# SANDBOX. The probe shells out to `claude agents --json`, which reaches the
+# local Claude daemon over a Unix socket that the sandbox's network-namespace
+# isolation blocks — silently, returning `[]`. Every invocation of this script
+# must therefore run with `dangerouslyDisableSandbox: true`
+# (`.claude/rules/sandbox.md`, "claude agents --json"). Run sandboxed, it exits
+# 12 (unknown) rather than falsely reporting `free`.
+#
+# Usage:
+#   rsi-claim                 # claim; print the worktree path on stdout when free
+#   rsi-claim --state         # print free|held|unknown and exit 0 either way
+#
+# Stdout on a successful claim is the absolute worktree path, so a caller can
+# `cd` (or EnterWorktree) into it without re-deriving the location.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# .claude/skills/rsi/scripts/rsi-claim → the CHECKOUT root is four levels up.
+# That may itself be a worktree (this script is copied into every checkout), so
+# it locates the libraries but must NOT be used to locate the worktrees
+# container.
+CHECKOUT_ROOT="$(cd -- "$SCRIPT_DIR/../../../.." && pwd)"
+
+# The worktrees container lives under the PROJECT root — the parent of the
+# shared git common dir — never under whichever worktree this copy of the script
+# happens to sit in. Resolving it from CHECKOUT_ROOT would yield a nested
+# `<worktree>/.claude/worktrees/…` path that never exists, and a
+# does-not-exist path reports `free`: the claim would pass unconditionally,
+# turning the serialization guarantee into a no-op.
+PROJECT_ROOT="$(dirname -- "$(git -C "$CHECKOUT_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)")"
+if [[ -z "$PROJECT_ROOT" || "$PROJECT_ROOT" == "." ]]; then
+  printf 'rsi-claim: could not resolve the project root from %s — not a git repository?\n' \
+    "$CHECKOUT_ROOT" >&2
+  exit 2
+fi
+
+RSI_NODE_ID="strategy-recursive-self-improvement"
+RSI_WORKTREE="$PROJECT_ROOT/.claude/worktrees/$RSI_NODE_ID"
+
+# shellcheck source=/dev/null
+source "$CHECKOUT_ROOT/.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh"
+
+STATE_ONLY=0
+case "${1:-}" in
+  --state) STATE_ONLY=1 ;;
+  "") ;;
+  *)
+    printf 'rsi-claim: unknown argument %s (expected --state or nothing)\n' "$1" >&2
+    exit 2
+    ;;
+esac
+
+# Every pid from this process up to init — the set whose sessions are "us".
+ancestor_pids() {
+  local pid=$$
+  while [[ -n "$pid" && "$pid" != "0" && "$pid" != "1" ]]; do
+    printf '%s\n' "$pid"
+    pid="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')"
+  done
+}
+
+claim_state() {
+  # A worktree that does not exist cannot be held. This is the first-ever /rsi
+  # invocation, or the previous one's worktree was reaped: free, and the caller
+  # provisions it.
+  if [[ ! -d "$RSI_WORKTREE" ]]; then
+    printf 'free\n'
+    return 0
+  fi
+
+  local sessions
+  if ! sessions="$(claude_sessions_under "$RSI_WORKTREE")"; then
+    printf 'unknown\n'
+    return 0
+  fi
+
+  if [[ -z "${sessions//[[:space:]]/}" ]]; then
+    printf 'free\n'
+    return 0
+  fi
+
+  local mine
+  mine="$(ancestor_pids)"
+
+  # Column 2 is the session pid (claude_sessions_under emits
+  # sessionId<TAB>pid<TAB>status<TAB>name). A row whose pid is one of ours is
+  # this very session and is not a rival claim. Any surviving row is.
+  local rival
+  rival="$(awk -F'\t' -v mine="$mine" '
+    BEGIN { n = split(mine, a, "\n"); for (i = 1; i <= n; i++) if (a[i] != "") own[a[i]] = 1 }
+    ($2 != "" && !($2 in own)) { print $1 "\t" $4; exit }
+  ' <<<"$sessions")"
+
+  if [[ -n "$rival" ]]; then
+    # The holder's identity travels ON the state line. `claim_state` runs in a
+    # command substitution, so a variable set here would never reach the parent
+    # shell — and under `set -u` the parent's read of it would abort the script
+    # with exit 1, turning a correct REFUSAL into a bare failure the caller
+    # cannot distinguish from a crash.
+    printf 'held\t%s\n' "$rival"
+    return 0
+  fi
+  printf 'free\n'
+}
+
+CLAIM_LINE="$(claim_state)"
+STATE="${CLAIM_LINE%%$'\t'*}"
+# `sessionId<TAB>name` when held; empty otherwise.
+HOLDER="${CLAIM_LINE#*$'\t'}"
+[[ "$HOLDER" == "$CLAIM_LINE" ]] && HOLDER=""
+
+if [[ "$STATE_ONLY" == "1" ]]; then
+  printf '%s\n' "$STATE"
+  exit 0
+fi
+
+case "$STATE" in
+  free)
+    printf '%s\n' "$RSI_WORKTREE"
+    exit 0
+    ;;
+  held)
+    printf 'rsi-claim: REFUSED — an /rsi session already holds %s (session %s).\n' \
+      "$RSI_WORKTREE" "${HOLDER%%$'\t'*}" >&2
+    printf "rsi-claim: /rsi is serialized by design (%s condition 1). Wait for that session to finish, or release a terminal holder with 'claude rm <session-id>'.\n" \
+      "$RSI_NODE_ID" >&2
+    exit 11
+    ;;
+  *)
+    printf 'rsi-claim: REFUSED — could not determine whether %s is held.\n' "$RSI_WORKTREE" >&2
+    printf 'rsi-claim: an unanswerable probe is treated as held, never as free. Most likely cause: this ran sandboxed, which silently blocks the daemon read. Re-run with dangerouslyDisableSandbox (.claude/rules/sandbox.md).\n' >&2
+    exit 12
+    ;;
+esac

--- a/.claude/skills/rsi/scripts/test-rsi-claim.sh
+++ b/.claude/skills/rsi/scripts/test-rsi-claim.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Unit tests for rsi-claim — the /rsi serialization primitive.
+#
+# The claim's whole value is that it FAILS CLOSED, so the cases that matter are
+# the ones where the session probe cannot answer. Those are unreachable against
+# a real daemon, so `claude` is stubbed: CLAUDE_AGENTS_CMD points at a script
+# whose output each case controls. A `claude daemon` process is likewise stubbed
+# where the helper's empty-read corroboration needs to see one.
+#
+# Runs from anywhere; creates and removes its own temp tree.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+CLAIM="$SCRIPT_DIR/rsi-claim"
+
+PASS=0
+FAIL=0
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  FAIL=$((FAIL + 1))
+}
+
+ok() {
+  printf 'ok: %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+expect_state() {
+  local label="$1" want="$2" got
+  got="$("$CLAIM" --state 2>/dev/null)"
+  if [[ "$got" == "$want" ]]; then
+    ok "$label (state=$want)"
+  else
+    fail "$label — expected state '$want', got '$got'"
+  fi
+}
+
+expect_exit() {
+  local label="$1" want="$2"
+  "$CLAIM" >/dev/null 2>&1
+  local got=$?
+  if [[ "$got" == "$want" ]]; then
+    ok "$label (exit=$want)"
+  else
+    fail "$label — expected exit $want, got $got"
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# A real repository, so the script's project-root resolution runs for real
+# rather than being stubbed — that resolution is itself a regression risk (a
+# path under the wrong root does not exist, and a non-existent worktree reports
+# `free`, silently disabling the claim).
+PROJECT="$TMP/project"
+mkdir -p "$PROJECT"
+git -C "$PROJECT" init -q
+git -C "$PROJECT" config user.email test@example.com
+git -C "$PROJECT" config user.name Test
+mkdir -p "$PROJECT/.claude/skills/rsi/scripts" \
+         "$PROJECT/.claude/skills/dispatch-propagate/scripts"
+cp "$CLAIM" "$PROJECT/.claude/skills/rsi/scripts/rsi-claim"
+cp "$SCRIPT_DIR/../../dispatch-propagate/scripts/lib-claude-agents.sh" \
+   "$PROJECT/.claude/skills/dispatch-propagate/scripts/lib-claude-agents.sh"
+git -C "$PROJECT" add -A >/dev/null
+git -C "$PROJECT" commit -qm init
+
+CLAIM="$PROJECT/.claude/skills/rsi/scripts/rsi-claim"
+WORKTREE="$PROJECT/.claude/worktrees/strategy-recursive-self-improvement"
+
+# --- Stub plumbing ----------------------------------------------------------
+
+STUB_BIN="$TMP/bin"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/claude" <<'STUB'
+#!/usr/bin/env bash
+# Emits whatever RSI_TEST_AGENTS_JSON holds, exiting with RSI_TEST_AGENTS_RC.
+if [[ "${RSI_TEST_AGENTS_RC:-0}" != "0" ]]; then
+  exit "${RSI_TEST_AGENTS_RC}"
+fi
+printf '%s\n' "${RSI_TEST_AGENTS_JSON:-[]}"
+STUB
+chmod +x "$STUB_BIN/claude"
+export CLAUDE_AGENTS_CMD="$STUB_BIN/claude"
+
+# The helper corroborates an empty read by pgrep-ing for a live `claude daemon`
+# process before calling it a definite "no sessions". That probe must be stubbed
+# too, via the seam the helper documents (CLAUDE_AGENTS_PGREP_CMD): the host
+# running these tests very often HAS a real daemon, which would corroborate the
+# "no daemon visible" case and silently invert its assertion.
+cat > "$STUB_BIN/pgrep" <<'STUB'
+#!/usr/bin/env bash
+exit "${RSI_TEST_DAEMON_VISIBLE:-1}"
+STUB
+chmod +x "$STUB_BIN/pgrep"
+export CLAUDE_AGENTS_PGREP_CMD="$STUB_BIN/pgrep"
+
+# --- Cases ------------------------------------------------------------------
+
+# 1. No worktree at all: nothing can hold a path that does not exist.
+export RSI_TEST_AGENTS_JSON='[]'
+expect_state "absent worktree is free" "free"
+expect_exit "absent worktree claims" 0
+
+mkdir -p "$WORKTREE"
+
+# 2. A rival live session in the worktree: refuse, exit 11.
+export RSI_TEST_AGENTS_JSON='[{"sessionId":"sess-rival","pid":999999,"status":"running","name":"strategy-recursive-self-improvement"}]'
+expect_state "rival session holds the claim" "held"
+expect_exit "held claim refuses with 11" 11
+
+# 3. The caller's OWN session must not read as a rival. The stub reports a
+#    session whose pid is this test process — an ancestor of the claim script —
+#    which is exactly the shape of /rsi re-invoking itself inside its worktree.
+export RSI_TEST_AGENTS_JSON="[{\"sessionId\":\"sess-self\",\"pid\":$$,\"status\":\"running\",\"name\":\"strategy-recursive-self-improvement\"}]"
+expect_state "own session is not a rival claim" "free"
+expect_exit "own session still claims" 0
+
+# 4. An unanswerable probe is HELD, never free — the sandbox failure mode.
+export RSI_TEST_AGENTS_RC=1
+expect_state "probe failure is unknown" "unknown"
+expect_exit "unknown claim refuses with 12" 12
+unset RSI_TEST_AGENTS_RC
+
+# 5. An UNCORROBORATED empty read is unknown too: a sandboxed `claude agents
+#    --json` returns `[]` indistinguishably from a genuine no-sessions answer,
+#    so `[]` only means free when a daemon process is visible.
+export RSI_TEST_AGENTS_JSON='[]'
+export RSI_TEST_DAEMON_VISIBLE=1   # pgrep exits 1 — no daemon visible
+expect_state "uncorroborated empty read is unknown" "unknown"
+
+export RSI_TEST_DAEMON_VISIBLE=0   # pgrep exits 0 — daemon visible
+expect_state "corroborated empty read is free" "free"
+
+# 6. An unknown argument is a usage error, not a silent claim.
+"$CLAIM" --nonsense >/dev/null 2>&1
+if [[ $? == 2 ]]; then
+  ok "unknown argument exits 2"
+else
+  fail "unknown argument should exit 2"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" == "0" ]]

--- a/packages/intentionsutil/scripts/read-sensors.ts
+++ b/packages/intentionsutil/scripts/read-sensors.ts
@@ -53,6 +53,7 @@ import { listNodes, writeNode } from "../src/store.js";
 import { strategyBacklogBand } from "../src/census.js";
 import { listNodesAtRef } from "./lib-store-at-ref.js";
 import { SensorRegistry, type Sensor } from "../src/sensors.js";
+import { attributeSpend, type SpendBucket } from "../src/rsi.js";
 import { IntentionSchemaError } from "../src/errors.js";
 import type { IntentionNode } from "../src/schema.js";
 import { computeDependencyAudit } from "./dependency-audit.js";
@@ -1267,6 +1268,150 @@ export function makeIntentionStoreSensor(
   };
 }
 
+// --- rsi sensor --------------------------------------------------------------
+// Name is the exact `success_signal.sensor` string
+// `strategy-recursive-self-improvement` declares — same match-the-declared-name
+// contract as `token-economy`/lifecycle above.
+//
+// Why it is registered HERE rather than in a metrics registry of its own: that
+// strategy's condition 8 says rsi metrics are "sensors registered in the graph's
+// existing success_signal/readings machinery on their owning strategies — never
+// a parallel metric registry". Registering here is what makes `rsi-plan.md`'s
+// metrics section a render of readings rather than a side system, and it drops
+// the graph's standing unregistered-sensor count by one.
+//
+// Reading format (stable and parseable), one segment per source the declared
+// sensor names, plus the token attribution the fitness function needs:
+//   `pause: <state>; backlog: <B>/<T> = <P>% (band ≤35%); parked: <N> (<M> blocking); worktrees: <W>; tokens <window>: dispatch <x>% / office-hours <y>% / rsi <z>%`
+// Every segment degrades independently to `unknown` and never throws (the
+// total-sensor contract at the top of this file).
+
+/** The verbatim `success_signal.sensor` name strategy-recursive-self-improvement declares. */
+export const RSI_SENSOR_NAME =
+  "the rsi-plan.md metrics section — sensors registered in the graph's existing " +
+  "success_signal/readings machinery on their owning strategies (backlog band, " +
+  "parked critical-path count, held-session/worktree census, pause state), " +
+  "rendered by render-rsi-plan.ts each iteration, plus per-workflow token " +
+  "attribution across dispatch, office-hours, and rsi";
+
+/**
+ * Dispatch pause state, delegated to the canonical shell helper
+ * (`lib-pause-state.sh`'s `dispatch_pause_state`) rather than re-testing the
+ * sentinel path here. The helper already distinguishes `paused` /`not-paused` /
+ * `unknown` — an unsearchable state directory means the sentinel's presence
+ * cannot be determined, and a second implementation of that logic would drift
+ * from the gate the tick itself consults.
+ */
+export function readPauseState(repoDir: string): string {
+  const lib = join(
+    repoDir,
+    ".claude/skills/dispatch-propagate/scripts/lib-pause-state.sh",
+  );
+  try {
+    return execFileSync(
+      "bash",
+      ["-c", `source ${JSON.stringify(lib)} && dispatch_pause_state`],
+      execOpts,
+    ).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+/** Count of provisioned worktrees under `.claude/worktrees/`. */
+function readWorktreeCount(repoDir: string): string {
+  try {
+    const out = execFileSync(
+      "git",
+      ["-C", repoDir, "worktree", "list", "--porcelain"],
+      execOpts,
+    );
+    return String(out.split("\n").filter((l) => l.startsWith("worktree ")).length);
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Parked-node census over the store: how many nodes are parked, and how many of
+ * those actually BLOCK an open node (`blocked_by` edge onto them). The second
+ * number is the critical-path one — a park nothing depends on costs nothing,
+ * whereas a park holding open work is what `rsi-plan.md` §3 exists to surface.
+ */
+export function readParkedCensus(storeDir: string): string {
+  let nodes: IntentionNode[];
+  try {
+    nodes = listNodes(storeDir);
+  } catch {
+    return "unknown";
+  }
+  const parked = new Set(nodes.filter((n) => n.office_hours !== null).map((n) => n.id));
+  const blocking = new Set<string>();
+  for (const node of nodes) {
+    if (node.office_hours !== null || node.phase === null || node.phase === "done") continue;
+    for (const blocker of node.blocked_by) {
+      if (parked.has(blocker)) blocking.add(blocker);
+    }
+  }
+  return `${parked.size} (${blocking.size} blocking)`;
+}
+
+/**
+ * Per-workflow token shares from an already-produced usage aggregate.
+ *
+ * The aggregate is NOT produced here. `aggregate-usage.sh` parses every session
+ * transcript in the window — far too heavy for a batch sensor driver that runs
+ * over the whole store. `/rsi-plan` runs it once per iteration and this sensor
+ * reads the artifact, reporting `unavailable` when there is none. Reporting
+ * absence honestly matters more than usual here: a fabricated 0% for rsi would
+ * silently satisfy the recorded "dispatch dominates spend" expectation, which is
+ * a review trigger, not a formality.
+ */
+export function readWorkflowSpend(usagePath: string): string {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(readFileSync(usagePath, "utf8"));
+  } catch {
+    return "unavailable";
+  }
+  if (typeof doc !== "object" || doc === null) return "unavailable";
+  const byPhase = (doc as Record<string, unknown>).by_phase;
+  if (typeof byPhase !== "object" || byPhase === null) return "unavailable";
+  const spend = attributeSpend(byPhase as Record<string, SpendBucket>);
+  return spend
+    .map((s) => `${s.workflow} ${(s.share * 100).toFixed(0)}%`)
+    .join(" / ");
+}
+
+/**
+ * Compose the full rsi reading from its segments. Exported for unit tests,
+ * which inject a fixture repo, a fixture store and a fixture usage aggregate.
+ */
+export function readRsiReading(
+  repoDir: string,
+  storeDir: string,
+  usagePath: string,
+  window: string,
+): string {
+  return (
+    `pause: ${readPauseState(repoDir)}; ` +
+    `backlog: ${readBacklogBand(storeDir, BACKLOG_STRATEGY_ID)}; ` +
+    `parked: ${readParkedCensus(storeDir)}; ` +
+    `worktrees: ${readWorktreeCount(repoDir)}; ` +
+    `tokens ${window}: ${readWorkflowSpend(usagePath)}`
+  );
+}
+
+const rsiSensor: Sensor = {
+  name: RSI_SENSOR_NAME,
+  read(): string {
+    const usagePath =
+      process.env.RSI_USAGE_AGGREGATE_PATH ?? join(repoRoot, "tmp", "usage-audit.json");
+    const window = process.env.RSI_USAGE_WINDOW ?? "7d";
+    return readRsiReading(repoRoot, intentionsDir, usagePath, window);
+  },
+};
+
 /**
  * Build the default registry of local-first own-execution sensors. Exported so
  * the registration set can be unit-tested (verification deferred to #2372/QA).
@@ -1279,6 +1424,7 @@ export function buildDefaultRegistry(): SensorRegistry {
   registry.register(tokenEconomySensor);
   registry.register(lifecycleSensor);
   registry.register(dependencyAuditSensor);
+  registry.register(rsiSensor);
   registry.register(makeDelegationRecordsSensor(() => listNodes(intentionsDir)));
   // Register the intention-store sensor last and have it derive the set of
   // registered sensor names from the registry itself at read() time — by then
@@ -1292,6 +1438,20 @@ export function buildDefaultRegistry(): SensorRegistry {
     ),
   );
   return registry;
+}
+
+/**
+ * The names the default registry resolves — the set a consumer needs to answer
+ * "is this node's declared sensor actually measured?".
+ *
+ * `render-rsi-plan.ts` uses it to decide which graph signals are real metrics
+ * (measured, with a threshold) versus declared-but-unread aspirations. Derived
+ * from the registry itself, never hand-listed, for the same reason
+ * `makeIntentionStoreSensor` derives its set: a hand-list silently drifts the
+ * moment a sensor is added above.
+ */
+export function registeredSensorNames(): ReadonlySet<string> {
+  return buildDefaultRegistry().names();
 }
 
 // --- Core driver -----------------------------------------------------------

--- a/packages/intentionsutil/scripts/read-sensors.ts
+++ b/packages/intentionsutil/scripts/read-sensors.ts
@@ -53,7 +53,7 @@ import { listNodes, writeNode } from "../src/store.js";
 import { strategyBacklogBand } from "../src/census.js";
 import { listNodesAtRef } from "./lib-store-at-ref.js";
 import { SensorRegistry, type Sensor } from "../src/sensors.js";
-import { attributeSpend, type SpendBucket } from "../src/rsi.js";
+import { attributeSpend, spendBucketsFrom } from "../src/rsi.js";
 import { IntentionSchemaError } from "../src/errors.js";
 import type { IntentionNode } from "../src/schema.js";
 import { computeDependencyAudit } from "./dependency-audit.js";
@@ -1374,10 +1374,9 @@ export function readWorkflowSpend(usagePath: string): string {
   } catch {
     return "unavailable";
   }
-  if (typeof doc !== "object" || doc === null) return "unavailable";
-  const byPhase = (doc as Record<string, unknown>).by_phase;
-  if (typeof byPhase !== "object" || byPhase === null) return "unavailable";
-  const spend = attributeSpend(byPhase as Record<string, SpendBucket>);
+  const buckets = spendBucketsFrom(doc);
+  if (buckets === null) return "unavailable";
+  const spend = attributeSpend(buckets);
   return spend
     .map((s) => `${s.workflow} ${(s.share * 100).toFixed(0)}%`)
     .join(" / ");

--- a/packages/intentionsutil/scripts/render-rsi-plan.ts
+++ b/packages/intentionsutil/scripts/render-rsi-plan.ts
@@ -1,0 +1,320 @@
+// render-rsi-plan — regenerate `rsi-plan.md` from graph state.
+//
+// `rsi-plan.md` is a DERIVED dashboard: `strategy-recursive-self-improvement`
+// condition 5 makes every section a render of the graph, and a hand-edited
+// section a defect. This script is the renderer. The `/rsi-plan` skill runs it;
+// the `/rsi` main thread reads the staleness flags it emits and decides what to
+// do about them (rendering here, judgment there — never mixed).
+//
+// Reads the store AT A GIT REF (default `origin/main`), not the local working
+// tree, for the same reason `office-hours-select.ts` does: a renderer that reads
+// its own checkout answers from whatever that worktree last synced, so a stale
+// worktree silently publishes stale phases, stale parks and stale readings into
+// a file that is then pushed to main as current. It never fetches — a caller
+// that needs absolute freshness runs `git fetch origin main` first.
+//
+// Run from anywhere (the repo root is resolved relative to this file, not cwd):
+//   npx tsx packages/intentionsutil/scripts/render-rsi-plan.ts
+//   npx tsx packages/intentionsutil/scripts/render-rsi-plan.ts --check
+//   npx tsx packages/intentionsutil/scripts/render-rsi-plan.ts --json
+//
+// Flags:
+//   --out <path>    write here instead of `<repoRoot>/rsi-plan.md`
+//   --ref <git-ref> read the store at this ref instead of `origin/main`
+//   --date <D>      render date `YYYY-MM-DD`; defaults to today (UTC)
+//   --usage <path>  usage aggregate JSON for per-workflow token attribution;
+//                   defaults to `<repoRoot>/tmp/usage-audit.json`
+//   --window <W>    label for the aggregate's window (default `7d`)
+//   --check         render and compare against `--out` WITHOUT writing; exit 1
+//                   when they differ (the "is the committed file stale?" gate)
+//   --json          emit `{markdown, flags}` as JSON on stdout and write nothing
+//
+// Exit codes:
+//   0  rendered (or, under --check, the file is already current)
+//   1  --check found the file stale, or an argument was invalid
+//   2  a required input could not be read (bad ref, unreadable store)
+//
+// Staleness flags always go to STDERR, one `FLAG <kind> <subject> — <detail>`
+// line each, whatever the mode. They are the render's second output, not a
+// debug aside: the `/rsi` judgment step consumes them.
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { listNodesAtRef } from "./lib-store-at-ref.js";
+import { registeredSensorNames } from "./read-sensors.js";
+import {
+  attributeSpend,
+  renderRsiPlan,
+  type ParkedItem,
+  type RsiRender,
+  type SpendBucket,
+  type WorkflowSpend,
+} from "../src/rsi.js";
+
+// --- Paths -----------------------------------------------------------------
+// The script lives at `packages/intentionsutil/scripts/render-rsi-plan.ts`, so
+// the repo root is three directories up. Resolve from this file's own location,
+// never from cwd — every other script in this directory does the same, and it
+// is what lets `/rsi-plan` invoke this from a worktree.
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = dirname(dirname(dirname(scriptDir)));
+
+const USAGE = `usage: render-rsi-plan.ts [--out <path>] [--ref <git-ref>] [--date <YYYY-MM-DD>]
+                          [--usage <path>] [--window <label>] [--check] [--json]
+  Renders rsi-plan.md from the intention store at <git-ref> (default origin/main).
+`;
+
+interface Args {
+  out: string;
+  ref: string;
+  date: string;
+  usage: string;
+  window: string;
+  check: boolean;
+  json: boolean;
+}
+
+/** Today in UTC as `YYYY-MM-DD`. */
+function todayUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function parseArgs(argv: string[]): Args {
+  const out: Args = {
+    out: join(repoRoot, "rsi-plan.md"),
+    ref: "origin/main",
+    date: todayUtc(),
+    usage: join(repoRoot, "tmp", "usage-audit.json"),
+    window: "7d",
+    check: false,
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const takeValue = (name: string): string => {
+      const value = argv[++i];
+      if (value === undefined || value === "") {
+        throw new Error(`render-rsi-plan: ${name} requires a value`);
+      }
+      return value;
+    };
+    switch (a) {
+      case "--out":
+        out.out = takeValue("--out");
+        break;
+      case "--ref":
+        out.ref = takeValue("--ref");
+        break;
+      case "--date":
+        out.date = takeValue("--date");
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(out.date)) {
+          throw new Error(`render-rsi-plan: --date must be YYYY-MM-DD, got '${out.date}'`);
+        }
+        break;
+      case "--usage":
+        out.usage = takeValue("--usage");
+        break;
+      case "--window":
+        out.window = takeValue("--window");
+        break;
+      case "--check":
+        out.check = true;
+        break;
+      case "--json":
+        out.json = true;
+        break;
+      case "--help":
+      case "-h":
+        process.stdout.write(USAGE);
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`render-rsi-plan: unknown argument '${a}'`);
+    }
+  }
+  return out;
+}
+
+// --- Parked rows ------------------------------------------------------------
+
+/**
+ * Parse `office-hours-select.ts --list` output into rows.
+ *
+ * The selector's `--list` mode emits one TAB-separated `rank<TAB>type<TAB>id<TAB>since`
+ * row per parked node, and — for a rank-LIFTED park — a following
+ * `NOTE — <id> ranks at tier …` line on the SAME stream. The NOTE binds to the
+ * row above it, which is how a park declares the blocked source it inherited
+ * its rank from. Attaching it to the preceding row (rather than dropping it as
+ * chatter) is the whole point of §3: it answers "what does this park block?".
+ *
+ * Exported for tests, which feed it captured selector output rather than
+ * shelling out.
+ */
+export function parseParkedList(stdout: string): ParkedItem[] {
+  const items: ParkedItem[] = [];
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trimEnd();
+    if (trimmed === "") continue;
+    if (trimmed.startsWith("NOTE —") || trimmed.startsWith("NOTE -")) {
+      const last = items[items.length - 1];
+      // A NOTE with no preceding row cannot be bound to anything; dropping it
+      // is correct, but it must not be mistaken for a row.
+      if (last !== undefined) last.note = trimmed.replace(/^NOTE\s+[—-]\s*/, "");
+      continue;
+    }
+    const parts = trimmed.split("\t");
+    if (parts.length < 4) continue;
+    const rank = Number(parts[0]);
+    if (!Number.isFinite(rank)) continue;
+    items.push({ rank, sessionType: parts[1], id: parts[2], since: parts[3], note: null });
+  }
+  return items;
+}
+
+/**
+ * Run the office-hours selector at `ref` and parse its rows.
+ *
+ * BOTH streams are parsed. The selector writes rows to stdout and its
+ * `NOTE — <id> ranks at tier …` advisories to STDERR; a render that read stdout
+ * alone would drop exactly the rank-lift lines §3 is built around. `spawnSync`
+ * (not `execFileSync`) is used because it surfaces both captured streams — and
+ * the two are interleaved by re-attaching each NOTE to the row it names, so the
+ * binding survives the fact that the streams arrive separately.
+ *
+ * A non-zero exit is fatal (`.claude/rules/code-style.md`): an empty parked list
+ * is a real, meaningful answer, so substituting one for a failed probe would
+ * publish "nothing is parked" into a file that then gets pushed to main.
+ */
+function readParked(ref: string): ParkedItem[] {
+  const script = join(scriptDir, "office-hours-select.ts");
+  const proc = spawnSync("npx", ["tsx", script, "--list", "--ref", ref], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (proc.error !== undefined) {
+    throw new Error(`office-hours-select could not be run: ${proc.error.message}`);
+  }
+  if (proc.status !== 0) {
+    throw new Error(
+      `office-hours-select --list exited ${proc.status ?? "on a signal"}: ${proc.stderr.trim()}`,
+    );
+  }
+  const rows = parseParkedList(proc.stdout);
+  // Second pass: bind the stderr NOTE advisories to the rows they name. Each
+  // advisory begins `NOTE — <node-id> ranks at …`, so the id is its second
+  // token; matching on that is exact, not positional.
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  for (const line of proc.stderr.split("\n")) {
+    const match = line.match(/^NOTE\s+[—-]\s*(\S+)\s+(.*)$/);
+    if (match === null) continue;
+    const row = byId.get(match[1]);
+    if (row !== undefined) row.note = `${match[1]} ${match[2]}`.trim();
+  }
+  return rows;
+}
+
+// --- Token attribution ------------------------------------------------------
+
+/**
+ * Per-workflow spend from a `aggregate-usage.sh --json-out` document, or `null`
+ * when the aggregate is absent or unreadable.
+ *
+ * `null` is not a fallback that hides an error: `renderRsiPlan` renders it as an
+ * explicit "unavailable" line naming the command that produces the aggregate.
+ * The alternative — zeros — would read as "rsi spent nothing", a false measured
+ * claim, which matters because dispatch-dominance is a recorded review trigger.
+ */
+function readSpend(usagePath: string): WorkflowSpend[] | null {
+  if (!existsSync(usagePath)) return null;
+  let doc: unknown;
+  try {
+    doc = JSON.parse(readFileSync(usagePath, "utf8"));
+  } catch (err) {
+    process.stderr.write(`render-rsi-plan: usage aggregate unreadable (${String(err)})\n`);
+    return null;
+  }
+  if (typeof doc !== "object" || doc === null) return null;
+  const byPhase = (doc as Record<string, unknown>).by_phase;
+  if (typeof byPhase !== "object" || byPhase === null) {
+    process.stderr.write(
+      `render-rsi-plan: usage aggregate at ${usagePath} has no by_phase object\n`,
+    );
+    return null;
+  }
+  return attributeSpend(byPhase as Record<string, SpendBucket>);
+}
+
+// --- Main -------------------------------------------------------------------
+
+function resolveSha(ref: string): string {
+  return execFileSync("git", ["-C", repoRoot, "rev-parse", ref], {
+    encoding: "utf8",
+  }).trim();
+}
+
+export function render(args: Args): RsiRender {
+  const nodes = listNodesAtRef(repoRoot, args.ref);
+  return renderRsiPlan({
+    nodes,
+    parked: readParked(args.ref),
+    spend: readSpend(args.usage),
+    spendWindow: args.window,
+    registeredSensors: registeredSensorNames(),
+    ref: args.ref,
+    sha: resolveSha(args.ref),
+    generatedAt: args.date,
+  });
+}
+
+function main(argv: string[]): void {
+  let args: Args;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    process.stderr.write(`${String(err instanceof Error ? err.message : err)}\n${USAGE}`);
+    process.exit(1);
+  }
+
+  let result: RsiRender;
+  try {
+    result = render(args);
+  } catch (err) {
+    process.stderr.write(
+      `render-rsi-plan: ${String(err instanceof Error ? err.message : err)}\n`,
+    );
+    process.exit(2);
+  }
+
+  for (const flag of result.flags) {
+    process.stderr.write(`FLAG ${flag.kind} ${flag.subject} — ${flag.detail}\n`);
+  }
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  if (args.check) {
+    const current = existsSync(args.out) ? readFileSync(args.out, "utf8") : "";
+    if (current === result.markdown) {
+      process.stderr.write(`render-rsi-plan: ${args.out} is current\n`);
+      return;
+    }
+    process.stderr.write(
+      `render-rsi-plan: ${args.out} is STALE — re-render it (drop --check)\n`,
+    );
+    process.exit(1);
+  }
+
+  writeFileSync(args.out, result.markdown);
+  process.stderr.write(
+    `render-rsi-plan: wrote ${args.out} (${result.flags.length} flag(s))\n`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2));
+}

--- a/packages/intentionsutil/scripts/render-rsi-plan.ts
+++ b/packages/intentionsutil/scripts/render-rsi-plan.ts
@@ -47,9 +47,9 @@ import { registeredSensorNames } from "./read-sensors.js";
 import {
   attributeSpend,
   renderRsiPlan,
+  spendBucketsFrom,
   type ParkedItem,
   type RsiRender,
-  type SpendBucket,
   type WorkflowSpend,
 } from "../src/rsi.js";
 
@@ -236,15 +236,14 @@ function readSpend(usagePath: string): WorkflowSpend[] | null {
     process.stderr.write(`render-rsi-plan: usage aggregate unreadable (${String(err)})\n`);
     return null;
   }
-  if (typeof doc !== "object" || doc === null) return null;
-  const byPhase = (doc as Record<string, unknown>).by_phase;
-  if (typeof byPhase !== "object" || byPhase === null) {
+  const buckets = spendBucketsFrom(doc);
+  if (buckets === null) {
     process.stderr.write(
       `render-rsi-plan: usage aggregate at ${usagePath} has no by_phase object\n`,
     );
     return null;
   }
-  return attributeSpend(byPhase as Record<string, SpendBucket>);
+  return attributeSpend(buckets);
 }
 
 // --- Main -------------------------------------------------------------------

--- a/packages/intentionsutil/src/rsi.ts
+++ b/packages/intentionsutil/src/rsi.ts
@@ -1,0 +1,782 @@
+// Pure render logic for `rsi-plan.md` — the derived dashboard the `/rsi` loop
+// maintains (`strategy-recursive-self-improvement` condition 5: "the graph
+// stays the sole tracker: rsi-plan.md is a derived, fully rendered artifact —
+// every section is produced by render-rsi-plan.ts from graph state ... a
+// hand-edited section is a defect").
+//
+// This module is fs-free, git-free and process-free by design, exactly like
+// `census.ts`: the caller (`scripts/render-rsi-plan.ts`) loads the store at a
+// git ref, shells out to `office-hours-select.ts --list`, and reads the token
+// aggregate, then hands the already-gathered inputs here. That split is what
+// makes the whole render testable on in-memory fixtures.
+//
+// WHERE EACH SECTION'S SOURCE OF TRUTH LIVES (all of it in the graph):
+//
+//   §1 priorities  — strategy nodes ordered by resolved `(tier, rank)`.
+//   §2 dispatch    — `attributes.queue_summary` on strategy-graph-native-dispatch
+//                    plus the mechanical phase census of its tactics.
+//   §3 parked      — `attributes.queue_summary` on strategy-attention-surface
+//                    plus `office-hours-select.ts --list` rows (rank-lifted
+//                    NOTE lines included — never a hand-rolled park probe).
+//   §4 metrics     — every goal-layer node whose `success_signal.sensor` name
+//                    is REGISTERED in the read-sensors registry, with its
+//                    `reading`, `threshold` and derived gap.
+//   §5 telemetry   — `tooling_goals` entries of `kind: sensor` across the
+//                    graph: the graph's own record of instrumentation it wants
+//                    and does not yet have.
+//   §6 task plan   — tactics serving strategy-recursive-self-improvement, with
+//                    `attributes.rsi_cost` as the budget cost.
+//
+// THE QUEUE-SUMMARY FIELD, AND WHY IT IS NOT `reading`. The recorded design
+// says the three model-drafted queue summaries "land first as dated readings on
+// their owning strategy nodes ... and are rendered from there". The top-level
+// `reading` field cannot carry them: it is sensor-owned — `read-sensors.ts`
+// overwrites it on every batch run, and two of the three owners
+// (strategy-graph-native-dispatch's lifecycle sensor,
+// strategy-recursive-self-improvement's own rsi sensor) are registered, so a
+// hand-drafted summary parked there would be silently clobbered on the next
+// read. The summaries therefore live in `attributes.queue_summary` — a dated
+// record on the owning strategy node, which is what the design asked for, in
+// the one place a non-sensor writer may own. It is fingerprint-safe:
+// `strategyFingerprint` (router.ts) hashes only `attributes.conditions` out of
+// `attributes`, so re-drafting a summary each iteration does not invalidate the
+// strategy stamp of a single open child.
+
+import { ownTier } from "./schema.js";
+import type { IntentionNode } from "./schema.js";
+import { resolveAttention } from "./attention.js";
+import { deriveGap } from "./sensors.js";
+import { classifyTactic, strategyBacklogBand } from "./census.js";
+
+// --- Node ids this render is anchored to ------------------------------------
+
+/** The strategy whose loop owns this file, and whose tactics are the task plan. */
+export const RSI_STRATEGY_ID = "strategy-recursive-self-improvement";
+
+/** Owner of the dispatch queue summary. */
+export const DISPATCH_STRATEGY_ID = "strategy-graph-native-dispatch";
+
+/** Owner of the office-hours queue summary. */
+export const OFFICE_HOURS_STRATEGY_ID = "strategy-attention-surface";
+
+/** The three queues, in render order, each keyed to the strategy that owns it. */
+export const QUEUE_OWNERS: ReadonlyArray<{ queue: string; strategyId: string }> = [
+  { queue: "dispatch", strategyId: DISPATCH_STRATEGY_ID },
+  { queue: "office-hours", strategyId: OFFICE_HOURS_STRATEGY_ID },
+  { queue: "rsi", strategyId: RSI_STRATEGY_ID },
+];
+
+/**
+ * How many days a queue summary may age before the render flags it. An /rsi
+ * iteration re-drafts all three, so anything older than a week means either no
+ * iteration ran or one skipped its draft step.
+ */
+export const SUMMARY_STALE_DAYS = 7;
+
+/**
+ * How many UNLIFTED parks §3 lists. Every rank-lifted park is always shown —
+ * those are the critical-path ones. The rest are a long tail (the store carries
+ * ~90 parks), so the section shows the highest-ranked few and states how many it
+ * dropped rather than reproducing the whole queue.
+ */
+export const PARKED_UNLIFTED_SHOWN = 10;
+
+// --- Inputs -----------------------------------------------------------------
+
+/** A dated, model-drafted queue summary read from `attributes.queue_summary`. */
+export interface QueueSummary {
+  /** `YYYY-MM-DD` — the day the summary was drafted. */
+  date: string;
+  /** The drafted prose. Rendered verbatim; never edited in the .md. */
+  summary: string;
+}
+
+/**
+ * One parked row as emitted by `office-hours-select.ts --list`. `note` carries
+ * the selector's `NOTE —` advisory verbatim when the row has one: that line is
+ * how a rank-LIFTED park declares the blocked source it inherited its rank
+ * from, which is precisely the critical-path signal §3 exists to surface.
+ */
+export interface ParkedItem {
+  rank: number;
+  sessionType: string;
+  id: string;
+  since: string;
+  note: string | null;
+}
+
+/** One workflow's share of the audited window's token spend. */
+export interface WorkflowSpend {
+  workflow: string;
+  priceProxyUsd: number;
+  costUsd: number;
+  turns: number;
+  /** Fraction of the window's total `priceProxyUsd`, in [0, 1]. */
+  share: number;
+}
+
+/** A per-skill spend bucket, as `aggregate-usage.sh` emits it under `by_phase`. */
+export interface SpendBucket {
+  price_proxy_usd?: number;
+  cost_usd?: number;
+  turns?: number;
+}
+
+/** Everything `renderRsiPlan` needs, all of it gathered by the caller. */
+export interface RsiRenderInput {
+  /** The whole store, read at `ref` — not the local working tree. */
+  nodes: IntentionNode[];
+  /** Rows from `office-hours-select.ts --list`. */
+  parked: ParkedItem[];
+  /**
+   * Per-workflow token attribution, or `null` when no aggregate was available.
+   * `null` renders an explicit "unavailable" line — never a zero, which would
+   * read as "rsi spent nothing" rather than "nothing was measured".
+   */
+  spend: WorkflowSpend[] | null;
+  /** Window the spend covers, e.g. `7d`. Ignored when `spend` is null. */
+  spendWindow: string;
+  /** Names the read-sensors registry currently resolves. */
+  registeredSensors: ReadonlySet<string>;
+  /** The git ref the store was read at, and its resolved commit. */
+  ref: string;
+  sha: string;
+  /** `YYYY-MM-DD` render date. Injected so the render is deterministic. */
+  generatedAt: string;
+}
+
+// --- Staleness flags --------------------------------------------------------
+
+/**
+ * A mechanical staleness finding. `/rsi-plan` renders these for the `/rsi` main
+ * thread's judgment step — this module never decides what to DO about one
+ * (strategy condition: rendering is the subagent's job, judgment is the main
+ * thread's).
+ */
+export interface StalenessFlag {
+  kind:
+    | "task-done"
+    | "task-parked"
+    | "summary-missing"
+    | "summary-stale"
+    | "threshold-breach"
+    | "unread-sensor"
+    | "spend-deviation";
+  /** The node id (or workflow name) the finding is about. */
+  subject: string;
+  detail: string;
+}
+
+export interface RsiRender {
+  markdown: string;
+  flags: StalenessFlag[];
+}
+
+// --- Field readers ----------------------------------------------------------
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The dated queue summary on a strategy node, or `null` when absent. Returns
+ * `null` — rather than throwing — for a malformed value, because the caller
+ * turns absence into a rendered "not drafted" line plus a `summary-missing`
+ * flag, which is more useful to the judgment step than an aborted render. A
+ * malformed value is not silently treated as valid: it takes the same
+ * absent path and the same flag.
+ */
+export function queueSummaryOf(node: IntentionNode | undefined): QueueSummary | null {
+  if (node === undefined) return null;
+  const raw = node.attributes.queue_summary;
+  if (!isPlainObject(raw)) return null;
+  const { date, summary } = raw;
+  if (typeof date !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(date)) return null;
+  if (typeof summary !== "string" || summary.trim() === "") return null;
+  return { date, summary: summary.trim() };
+}
+
+/**
+ * An rsi task's budget cost. Default 0, per the recorded budget semantics
+ * ("an rsi-implement task costs 1 and other tasks cost 0 unless a task
+ * specifies its own cost") — a task declares its own via `attributes.rsi_cost`.
+ */
+export function rsiTaskCost(node: IntentionNode): number {
+  const raw = node.attributes.rsi_cost;
+  return typeof raw === "number" && Number.isFinite(raw) && raw >= 0 ? raw : 0;
+}
+
+/** Whole days between two `YYYY-MM-DD` dates, `later - earlier`. */
+export function daysBetween(earlier: string, later: string): number {
+  const a = Date.parse(`${earlier}T00:00:00Z`);
+  const b = Date.parse(`${later}T00:00:00Z`);
+  if (Number.isNaN(a) || Number.isNaN(b)) return 0;
+  return Math.round((b - a) / 86_400_000);
+}
+
+// --- Token attribution ------------------------------------------------------
+
+/**
+ * Which workflow each attributable skill belongs to. Keyed by the
+ * `attributionSkill` values `aggregate-usage.sh` emits under `by_phase`.
+ *
+ * This map is the ONE place the dispatch/office-hours/rsi split is defined, and
+ * it must be extended when a new skill joins one of the three workflows —
+ * mirroring the same single-source discipline `aggregate-usage.sh`'s
+ * `worker_skills` list carries. A skill absent from every list lands in
+ * `other`, which is rendered rather than dropped: an unattributed bucket that
+ * silently vanished would make every share above it look larger than it is.
+ */
+export const WORKFLOW_SKILLS: ReadonlyMap<string, readonly string[]> = new Map([
+  [
+    "dispatch",
+    [
+      // The seven phase buckets `aggregate-usage.sh` always seeds…
+      "plan-implement",
+      "review-fix",
+      "security-review-fix",
+      "qa-fix",
+      "code-review-fix",
+      "fix-checks",
+      "dispatch-worker",
+      // …plus every other skill that has appeared as an `attributionSkill` on a
+      // dispatch-lane turn.
+      "plan-issue",
+      "implement",
+      "implement-unit",
+      "code-review",
+      "qa-main",
+      "fix-conflicts",
+      "dispatch-conflict",
+      "dispatch-invalid-state",
+      "dispatch-diagnose-main",
+      "dispatch-propagate",
+      "resolve-epic",
+      "align-tactics",
+      "commit-merge-push",
+    ] as const,
+  ],
+  [
+    "office-hours",
+    [
+      "office-hours",
+      "align",
+      "align-strategy",
+      "align-init",
+      "reading-review",
+      "new-requirement",
+      "file-issue",
+    ] as const,
+  ],
+  ["rsi", ["rsi", "rsi-plan"] as const],
+]);
+
+/** The workflow a skill bucket belongs to, or `"other"` when unmapped. */
+export function workflowOfSkill(skill: string): string {
+  for (const [workflow, skills] of WORKFLOW_SKILLS) {
+    if (skills.includes(skill)) return workflow;
+  }
+  return "other";
+}
+
+/**
+ * Fold `aggregate-usage.sh`'s per-skill `by_phase` buckets into the three
+ * workflows plus `other`, in a fixed render order. Buckets are summed on
+ * `price_proxy_usd` (the uniform-rate figure the audit ranks on, so shares
+ * compare token volume rather than model choice) with `cost_usd` reported
+ * alongside as the truthful bill.
+ */
+export function attributeSpend(byPhase: Record<string, SpendBucket>): WorkflowSpend[] {
+  const order = ["dispatch", "office-hours", "rsi", "other"];
+  const totals = new Map<string, { proxy: number; cost: number; turns: number }>(
+    order.map((w) => [w, { proxy: 0, cost: 0, turns: 0 }]),
+  );
+  for (const [skill, bucket] of Object.entries(byPhase)) {
+    const acc = totals.get(workflowOfSkill(skill));
+    if (acc === undefined) continue;
+    acc.proxy += bucket.price_proxy_usd ?? 0;
+    acc.cost += bucket.cost_usd ?? 0;
+    acc.turns += bucket.turns ?? 0;
+  }
+  const grandProxy = [...totals.values()].reduce((sum, t) => sum + t.proxy, 0);
+  return order.map((workflow) => {
+    const t = totals.get(workflow)!;
+    return {
+      workflow,
+      priceProxyUsd: t.proxy,
+      costUsd: t.cost,
+      turns: t.turns,
+      share: grandProxy === 0 ? 0 : t.proxy / grandProxy,
+    };
+  });
+}
+
+// --- Render helpers ---------------------------------------------------------
+
+/** Escape the pipe characters that would otherwise split a markdown table cell. */
+function cell(text: string): string {
+  return text.replace(/\|/g, "\\|").replace(/\r?\n/g, " ").trim();
+}
+
+/** One-line clip for table cells, with an ellipsis when it bites. */
+function clip(text: string, max: number): string {
+  const flat = cell(text);
+  return flat.length <= max ? flat : `${flat.slice(0, max - 1).trimEnd()}…`;
+}
+
+function num(value: number, digits = 1): string {
+  return value.toFixed(digits);
+}
+
+function pct(fraction: number): string {
+  return `${(fraction * 100).toFixed(1)}%`;
+}
+
+// --- The render -------------------------------------------------------------
+
+/**
+ * Render the whole of `rsi-plan.md` from graph state, plus the mechanical
+ * staleness flags the `/rsi` judgment step reads.
+ *
+ * Deterministic: every ordering has a unique final tiebreak (node id), and the
+ * only wall-clock input is the caller-supplied `generatedAt`. Two runs against
+ * the same store, ref and date emit byte-identical markdown — which is what
+ * makes `--check` a usable "is the committed file stale?" gate.
+ */
+export function renderRsiPlan(input: RsiRenderInput): RsiRender {
+  const { nodes, generatedAt } = input;
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const flags: StalenessFlag[] = [];
+  const out: string[] = [];
+
+  out.push("# rsi-plan");
+  out.push("");
+  out.push(
+    `> **Generated file — do not hand-edit.** Rendered by ` +
+      `\`packages/intentionsutil/scripts/render-rsi-plan.ts\` on ${generatedAt} from ` +
+      `the intention store at \`${input.ref}\` (\`${input.sha.slice(0, 8)}\`).`,
+  );
+  out.push(">");
+  out.push(
+    `> Single writer: the \`/rsi\` skill, serialized on the ` +
+      `\`${RSI_STRATEGY_ID}\` worktree claim, direct-pushed to main ` +
+      `(\`${RSI_STRATEGY_ID}\` condition 5). The graph is the sole tracker — ` +
+      `every section here is derived, and a hand-edited section is a defect. ` +
+      `To change what this file says, change the graph and re-render.`,
+  );
+  out.push("");
+
+  out.push(...renderPriorities(nodes));
+  out.push(...renderDispatchQueue(nodes, byId, generatedAt, flags));
+  out.push(...renderParked(input, byId, generatedAt, flags));
+  out.push(...renderMetrics(input, flags));
+  out.push(...renderTelemetry(nodes));
+  out.push(...renderTaskPlan(nodes, byId, generatedAt, flags));
+
+  return { markdown: `${out.join("\n").replace(/\n+$/, "")}\n`, flags };
+}
+
+// --- §1 ---------------------------------------------------------------------
+
+function renderPriorities(nodes: IntentionNode[]): string[] {
+  const resolved = resolveAttention(nodes);
+  const strategies = nodes
+    .filter((n) => n.kind === "strategy")
+    .map((n) => {
+      const attention = resolved.get(n.id);
+      return {
+        node: n,
+        tier: attention?.tier ?? ownTier(n),
+        rank: attention?.value ?? 0,
+      };
+    })
+    .sort((a, b) => b.tier - a.tier || b.rank - a.rank || a.node.id.localeCompare(b.node.id))
+    .slice(0, 10);
+
+  const out = [
+    "## 1. Top author priorities",
+    "",
+    "Ordered by the graph's own attention resolution — effective tier first, then",
+    "composed rank (`resolveAttention`, `src/attention.ts`). No hand-ranking: to",
+    "move an item, author an `attention` boost or a tier on its node.",
+    "",
+    "| # | tier | rank | strategy | open / total tactics |",
+    "|---|---|---|---|---|",
+  ];
+  strategies.forEach((s, i) => {
+    const band = strategyBacklogBand(nodes, s.node.id);
+    const open = nodes.filter(
+      (n) =>
+        n.kind === "tactic" &&
+        n.serves.includes(s.node.id) &&
+        classifyTactic(n) === "open",
+    ).length;
+    out.push(
+      `| ${i + 1} | ${s.tier} | ${num(s.rank)} | \`${s.node.id}\` — ` +
+        `${clip(s.node.statement, 90)} | ${open} / ${band.total} |`,
+    );
+  });
+  out.push("");
+  return out;
+}
+
+// --- §2 ---------------------------------------------------------------------
+
+function renderQueueSummary(
+  queue: string,
+  strategyId: string,
+  byId: Map<string, IntentionNode>,
+  today: string,
+  flags: StalenessFlag[],
+): string[] {
+  const summary = queueSummaryOf(byId.get(strategyId));
+  if (summary === null) {
+    flags.push({
+      kind: "summary-missing",
+      subject: strategyId,
+      detail: `no \`attributes.queue_summary\` for the ${queue} queue — /rsi-plan must draft one`,
+    });
+    return [
+      `**${queue} queue summary** — *not drafted.* The \`/rsi-plan\` step drafts it`,
+      `onto \`${strategyId}\` as \`attributes.queue_summary\`.`,
+      "",
+    ];
+  }
+  const age = daysBetween(summary.date, today);
+  if (age > SUMMARY_STALE_DAYS) {
+    flags.push({
+      kind: "summary-stale",
+      subject: strategyId,
+      detail: `${queue} queue summary is ${age}d old (drafted ${summary.date}, limit ${SUMMARY_STALE_DAYS}d)`,
+    });
+  }
+  return [
+    `**${queue} queue summary** (drafted ${summary.date}${age > SUMMARY_STALE_DAYS ? `, **${age}d stale**` : ""}, ` +
+      `source of truth \`${strategyId}\`):`,
+    "",
+    summary.summary,
+    "",
+  ];
+}
+
+function renderDispatchQueue(
+  nodes: IntentionNode[],
+  byId: Map<string, IntentionNode>,
+  today: string,
+  flags: StalenessFlag[],
+): string[] {
+  const out = ["## 2. Dispatch queue — delegated priorities", ""];
+  out.push(...renderQueueSummary("dispatch", DISPATCH_STRATEGY_ID, byId, today, flags));
+
+  const tactics = nodes.filter(
+    (n) => n.kind === "tactic" && n.serves.includes(DISPATCH_STRATEGY_ID),
+  );
+  const byPhase = new Map<string, IntentionNode[]>();
+  for (const t of tactics) {
+    if (classifyTactic(t) !== "open") continue;
+    const phase = t.phase ?? "(none)";
+    const bucket = byPhase.get(phase);
+    if (bucket === undefined) byPhase.set(phase, [t]);
+    else bucket.push(t);
+  }
+  const band = strategyBacklogBand(nodes, DISPATCH_STRATEGY_ID);
+  out.push(
+    `Backlog band: **${band.pct === null ? "n/a" : pct(band.pct)}** ` +
+      `(${band.backlog}/${band.total} tactics serving \`${DISPATCH_STRATEGY_ID}\`; ` +
+      "recorded threshold 35% and non-increasing).",
+    "",
+    "| phase | count | nodes |",
+    "|---|---|---|",
+  );
+  for (const phase of [...byPhase.keys()].sort()) {
+    const ids = byPhase.get(phase)!.map((t) => t.id).sort();
+    out.push(
+      `| \`${phase}\` | ${ids.length} | ${clip(ids.map((i) => `\`${i}\``).join(", "), 220)} |`,
+    );
+  }
+  if (byPhase.size === 0) out.push("| — | 0 | no open tactics |");
+  out.push("");
+  return out;
+}
+
+// --- §3 ---------------------------------------------------------------------
+
+function renderParked(
+  input: RsiRenderInput,
+  byId: Map<string, IntentionNode>,
+  today: string,
+  flags: StalenessFlag[],
+): string[] {
+  const out = ["## 3. Office-hours queue — parked nodes on the critical path", ""];
+  out.push(
+    ...renderQueueSummary("office-hours", OFFICE_HOURS_STRATEGY_ID, byId, today, flags),
+  );
+
+  // Rank-lifted rows first: a park carrying a NOTE inherited its rank from a
+  // blocked source, which is exactly the "what does this park block?" question
+  // §3 exists to answer. Within each group, rank descending, id ascending.
+  const sorted = [...input.parked].sort(
+    (a, b) =>
+      Number(b.note !== null) - Number(a.note !== null) ||
+      b.rank - a.rank ||
+      a.id.localeCompare(b.id),
+  );
+  // §3 is the CRITICAL-PATH view, not the whole queue: every rank-lifted park
+  // (each one holds open work) plus the highest-ranked unlifted parks. The
+  // remainder is reported as a count with the command that lists it — a cap
+  // that is stated is a scope decision; a cap that is silent reads as "this is
+  // everything".
+  const lifted = sorted.filter((p) => p.note !== null);
+  const unlifted = sorted.filter((p) => p.note === null);
+  const shownUnlifted = unlifted.slice(0, PARKED_UNLIFTED_SHOWN);
+  const shown = [...lifted, ...shownUnlifted];
+  out.push(
+    "Canonical source: `office-hours-select.ts --list`, read at the same ref as the",
+    "rest of this render. Parked blockers are already rank-lifted from what they",
+    "block — the `blocks` column names the source a park inherited its rank from,",
+    "which is what makes it critical-path. Never hand-roll this list.",
+    "",
+    "| rank | type | parked node | since | blocks |",
+    "|---|---|---|---|---|",
+  );
+  for (const item of shown) {
+    out.push(
+      `| ${num(item.rank)} | ${cell(item.sessionType)} | \`${item.id}\` | ${cell(item.since)} | ` +
+        `${liftedSource(item)} |`,
+    );
+  }
+  if (shown.length === 0) out.push("| — | — | nothing parked | — | — |");
+  out.push("");
+  if (unlifted.length > shownUnlifted.length) {
+    out.push(
+      `Showing every rank-lifted park (${lifted.length}) and the top ` +
+        `${shownUnlifted.length} of ${unlifted.length} unlifted parks by rank. The ` +
+        `remaining **${unlifted.length - shownUnlifted.length}** are not shown here — ` +
+        "`npx tsx packages/intentionsutil/scripts/office-hours-select.ts --list` is the full queue.",
+      "",
+    );
+  }
+
+  const blockedByParked = countBlockedByParked(input.nodes);
+  out.push(
+    `Parked total: **${sorted.length}**, of which **${sorted.filter((p) => p.note !== null).length}** are ` +
+      `rank-lifted from a blocked source. Live nodes held by a \`blocked_by\` edge onto ` +
+      `a parked node: **${blockedByParked}**.`,
+    "",
+  );
+  return out;
+}
+
+/**
+ * The blocked source a rank-lifted park inherited its rank from, as a table
+ * cell. The selector's advisory reads `<id> ranks at tier T/R inherited from
+ * blocked source <source> (own: …)`; the source id is the only part §3 needs —
+ * the rank is already its own column, and the park's own id is already the row.
+ * A note that does not match the expected shape is rendered verbatim rather
+ * than dropped, so a selector wording change degrades to noisy, not silent.
+ */
+function liftedSource(item: ParkedItem): string {
+  if (item.note === null) return "—";
+  const match = item.note.match(/blocked source (\S+)/);
+  return match === null ? clip(item.note, 160) : `\`${match[1]}\``;
+}
+
+/** Open tactics with at least one `blocked_by` edge onto a parked node. */
+function countBlockedByParked(nodes: IntentionNode[]): number {
+  const parked = new Set(nodes.filter((n) => n.office_hours !== null).map((n) => n.id));
+  return nodes.filter(
+    (n) =>
+      n.office_hours === null &&
+      n.phase !== null &&
+      n.phase !== "done" &&
+      n.blocked_by.some((b) => parked.has(b)),
+  ).length;
+}
+
+// --- §4 ---------------------------------------------------------------------
+
+function renderMetrics(input: RsiRenderInput, flags: StalenessFlag[]): string[] {
+  const out = [
+    "## 4. Metrics",
+    "",
+    "Every graph signal whose `success_signal.sensor` name is REGISTERED in the",
+    "read-sensors registry (`scripts/read-sensors.ts`) — i.e. every signal that is",
+    "actually measured, with a threshold to be measured against. This is a subset of",
+    "graph signals rendered from the existing readings machinery, never a parallel",
+    "metric registry (`" +
+      RSI_STRATEGY_ID +
+      "` condition 8). Registering a new rsi metric",
+    "means adding a sensor there and naming it on the owning node.",
+    "",
+    "**Fitness function.** rsi optimizes the value the combined dispatch +",
+    "office-hours + rsi system delivers toward author intentions — closure velocity",
+    "plus strategy signal progress, per token, attributed per workflow. Greenfield",
+    "expectation: dispatch spend significantly outpaces office-hours and rsi; a",
+    "deviation from that is itself a review trigger, not a datum to note and pass.",
+    "",
+    "| node | reading | threshold | gap |",
+    "|---|---|---|---|",
+  ];
+
+  const measured = input.nodes
+    .filter(
+      (n) =>
+        n.success_signal !== null &&
+        input.registeredSensors.has(n.success_signal.sensor),
+    )
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  for (const node of measured) {
+    const gap = deriveGap(node);
+    if (node.reading === null) {
+      flags.push({
+        kind: "unread-sensor",
+        subject: node.id,
+        detail: `registered sensor has never been read — run read-sensors.ts`,
+      });
+    } else if (gap !== null) {
+      flags.push({
+        kind: "threshold-breach",
+        subject: node.id,
+        detail: gap,
+      });
+    }
+    out.push(
+      `| \`${node.id}\` | ${clip(node.reading ?? "*(unread)*", 220)} | ` +
+        `${clip(node.success_signal!.threshold, 180)} | ${gap === null ? "**met**" : "shortfall"} |`,
+    );
+  }
+  if (measured.length === 0) out.push("| — | no registered sensor resolves to a node | — | — |");
+  out.push("");
+
+  out.push(...renderSpend(input, flags));
+  return out;
+}
+
+function renderSpend(input: RsiRenderInput, flags: StalenessFlag[]): string[] {
+  if (input.spend === null) {
+    return [
+      "**Per-workflow token attribution** — *unavailable.* No usage aggregate was",
+      "read for this render. `/rsi-plan` produces one with",
+      "`.claude/skills/dispatch-token-audit/scripts/aggregate-usage.sh --days 7",
+      "--json-out tmp/usage-audit.json` before rendering. An absent aggregate is",
+      "reported, never rendered as zero spend.",
+      "",
+    ];
+  }
+  const out = [
+    `**Per-workflow token attribution** (window ${input.spendWindow}, from`,
+    "`aggregate-usage.sh`'s per-skill `by_phase` buckets folded by `WORKFLOW_SKILLS`,",
+    "`src/rsi.ts`). `price_proxy_usd` holds price constant to compare token volume;",
+    "`cost_usd` is the truthful per-model bill.",
+    "",
+    "| workflow | share | price proxy (USD) | cost (USD) | turns |",
+    "|---|---|---|---|---|",
+  ];
+  for (const s of input.spend) {
+    out.push(
+      `| ${s.workflow} | ${pct(s.share)} | ${num(s.priceProxyUsd, 2)} | ` +
+        `${num(s.costUsd, 2)} | ${s.turns} |`,
+    );
+  }
+  out.push("");
+
+  // The fitness function's recorded expectation, checked mechanically: dispatch
+  // is expected to dominate. It failing to is a review trigger, so it is a flag
+  // rather than a line of prose the reader has to notice.
+  const dispatch = input.spend.find((s) => s.workflow === "dispatch");
+  const rivals = input.spend.filter((s) => s.workflow !== "dispatch" && s.workflow !== "other");
+  const measured = input.spend.some((s) => s.priceProxyUsd > 0);
+  if (measured && dispatch !== undefined) {
+    const bigger = rivals.filter((r) => r.priceProxyUsd >= dispatch.priceProxyUsd);
+    if (bigger.length > 0) {
+      flags.push({
+        kind: "spend-deviation",
+        subject: "dispatch",
+        detail:
+          `dispatch (${pct(dispatch.share)}) does not outpace ` +
+          bigger.map((r) => `${r.workflow} (${pct(r.share)})`).join(", ") +
+          " — the fitness function's recorded expectation is that it dominates; review",
+      });
+    }
+  }
+  return out;
+}
+
+// --- §5 ---------------------------------------------------------------------
+
+function renderTelemetry(nodes: IntentionNode[]): string[] {
+  const out = [
+    "## 5. Recommended additional telemetry",
+    "",
+    "The graph's own record of instrumentation it wants and does not yet have:",
+    "every `tooling_goals` entry of `kind: sensor`, with its owning node. A gap",
+    "belongs here by being authored on the node that feels it — not by being",
+    "listed here.",
+    "",
+    "| owning node | sensor goal |",
+    "|---|---|",
+  ];
+  const rows: string[] = [];
+  for (const node of [...nodes].sort((a, b) => a.id.localeCompare(b.id))) {
+    for (const goal of node.tooling_goals) {
+      if (goal.kind !== "sensor") continue;
+      rows.push(`| \`${node.id}\` | ${clip(goal.statement, 240)} |`);
+    }
+  }
+  out.push(...(rows.length > 0 ? rows : ["| — | no sensor-kind tooling goals authored |"]));
+  out.push("");
+  return out;
+}
+
+// --- §6 ---------------------------------------------------------------------
+
+function renderTaskPlan(
+  nodes: IntentionNode[],
+  byId: Map<string, IntentionNode>,
+  today: string,
+  flags: StalenessFlag[],
+): string[] {
+  const tasks = nodes
+    .filter((n) => n.kind === "tactic" && n.serves.includes(RSI_STRATEGY_ID))
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  const rows: string[] = [];
+  for (const task of tasks) {
+    const state = classifyTactic(task);
+    if (state === "done") {
+      flags.push({
+        kind: "task-done",
+        subject: task.id,
+        detail: "task node is `phase: done` — drop it from the plan and re-derive the sequence",
+      });
+    }
+    if (task.office_hours !== null) {
+      flags.push({
+        kind: "task-parked",
+        subject: task.id,
+        detail: `task is parked for office-hours (${task.office_hours.reason})`,
+      });
+    }
+    rows.push(
+      `| \`${task.id}\` | ${rsiTaskCost(task)} | ${task.phase ?? "—"} | ${state}` +
+        `${task.office_hours !== null ? " (parked)" : ""} | ${clip(task.statement, 110)} |`,
+    );
+  }
+  if (rows.length === 0) rows.push("| — | — | — | — | no tasks serve the rsi strategy |");
+
+  return [
+    "## 6. RSI task plan",
+    "",
+    ...renderQueueSummary("rsi", RSI_STRATEGY_ID, byId, today, flags),
+    "Every task is a graph node serving `" + RSI_STRATEGY_ID + "` — the graph is the",
+    "sole tracker, so a task that is not a node does not exist. Budget: a session's",
+    "default is 1; a task costs what its `attributes.rsi_cost` says (default 0).",
+    "Execution continues until the budget is exhausted.",
+    "",
+    "| task | cost | phase | state | statement |",
+    "|---|---|---|---|---|",
+    ...rows,
+    "",
+  ];
+}

--- a/packages/intentionsutil/src/rsi.ts
+++ b/packages/intentionsutil/src/rsi.ts
@@ -59,13 +59,6 @@ export const DISPATCH_STRATEGY_ID = "strategy-graph-native-dispatch";
 /** Owner of the office-hours queue summary. */
 export const OFFICE_HOURS_STRATEGY_ID = "strategy-attention-surface";
 
-/** The three queues, in render order, each keyed to the strategy that owns it. */
-export const QUEUE_OWNERS: ReadonlyArray<{ queue: string; strategyId: string }> = [
-  { queue: "dispatch", strategyId: DISPATCH_STRATEGY_ID },
-  { queue: "office-hours", strategyId: OFFICE_HOURS_STRATEGY_ID },
-  { queue: "rsi", strategyId: RSI_STRATEGY_ID },
-];
-
 /**
  * How many days a queue summary may age before the render flags it. An /rsi
  * iteration re-drafts all three, so anything older than a week means either no
@@ -287,10 +280,14 @@ export function workflowOfSkill(skill: string): string {
  * alongside as the truthful bill.
  */
 export function attributeSpend(byPhase: Record<string, SpendBucket>): WorkflowSpend[] {
-  const order = ["dispatch", "office-hours", "rsi", "other"];
-  const totals = new Map<string, { proxy: number; cost: number; turns: number }>(
-    order.map((w) => [w, { proxy: 0, cost: 0, turns: 0 }]),
-  );
+  // Insertion order IS render order, so iterating the map at the end needs no
+  // second ordered list to look values back up through.
+  const totals = new Map<string, { proxy: number; cost: number; turns: number }>([
+    ["dispatch", { proxy: 0, cost: 0, turns: 0 }],
+    ["office-hours", { proxy: 0, cost: 0, turns: 0 }],
+    ["rsi", { proxy: 0, cost: 0, turns: 0 }],
+    ["other", { proxy: 0, cost: 0, turns: 0 }],
+  ]);
   for (const [skill, bucket] of Object.entries(byPhase)) {
     const acc = totals.get(workflowOfSkill(skill));
     if (acc === undefined) continue;
@@ -299,16 +296,45 @@ export function attributeSpend(byPhase: Record<string, SpendBucket>): WorkflowSp
     acc.turns += bucket.turns ?? 0;
   }
   const grandProxy = [...totals.values()].reduce((sum, t) => sum + t.proxy, 0);
-  return order.map((workflow) => {
-    const t = totals.get(workflow)!;
-    return {
-      workflow,
-      priceProxyUsd: t.proxy,
-      costUsd: t.cost,
-      turns: t.turns,
-      share: grandProxy === 0 ? 0 : t.proxy / grandProxy,
+  return [...totals.entries()].map(([workflow, t]) => ({
+    workflow,
+    priceProxyUsd: t.proxy,
+    costUsd: t.cost,
+    turns: t.turns,
+    share: grandProxy === 0 ? 0 : t.proxy / grandProxy,
+  }));
+}
+
+/**
+ * The per-skill spend buckets inside an `aggregate-usage.sh --json-out`
+ * document, or `null` when the document is not one.
+ *
+ * Validates rather than asserts: the document comes off disk and may be
+ * truncated, from an older schema, or another file entirely, so each bucket's
+ * fields are re-derived as numbers instead of being cast into shape. A bucket
+ * that is not an object is skipped rather than defaulted to zeros — the
+ * difference between "this skill spent nothing" and "this row was unreadable"
+ * is exactly what the dispatch-dominance check turns on.
+ *
+ * Shared by `render-rsi-plan.ts` and the rsi sensor in `read-sensors.ts` so the
+ * two cannot drift on what counts as a readable aggregate.
+ */
+export function spendBucketsFrom(doc: unknown): Record<string, SpendBucket> | null {
+  if (!isPlainObject(doc)) return null;
+  const byPhase = doc.by_phase;
+  if (!isPlainObject(byPhase)) return null;
+  const finite = (value: unknown): number =>
+    typeof value === "number" && Number.isFinite(value) ? value : 0;
+  const out: Record<string, SpendBucket> = {};
+  for (const [skill, bucket] of Object.entries(byPhase)) {
+    if (!isPlainObject(bucket)) continue;
+    out[skill] = {
+      price_proxy_usd: finite(bucket.price_proxy_usd),
+      cost_usd: finite(bucket.cost_usd),
+      turns: finite(bucket.turns),
     };
-  });
+  }
+  return out;
 }
 
 // --- Render helpers ---------------------------------------------------------
@@ -488,8 +514,10 @@ function renderDispatchQueue(
     "| phase | count | nodes |",
     "|---|---|---|",
   );
-  for (const phase of [...byPhase.keys()].sort()) {
-    const ids = byPhase.get(phase)!.map((t) => t.id).sort();
+  for (const [phase, tactics] of [...byPhase.entries()].sort(([a], [b]) =>
+    a.localeCompare(b),
+  )) {
+    const ids = tactics.map((t) => t.id).sort();
     out.push(
       `| \`${phase}\` | ${ids.length} | ${clip(ids.map((i) => `\`${i}\``).join(", "), 220)} |`,
     );
@@ -618,15 +646,19 @@ function renderMetrics(input: RsiRenderInput, flags: StalenessFlag[]): string[] 
     "|---|---|---|---|",
   ];
 
+  // Carry the signal alongside the node rather than re-reaching for it below:
+  // the filter narrows `success_signal` but the narrowing does not survive into
+  // the loop, and re-asserting it there would assert what this flatMap already
+  // proved.
   const measured = input.nodes
-    .filter(
-      (n) =>
-        n.success_signal !== null &&
-        input.registeredSensors.has(n.success_signal.sensor),
-    )
-    .sort((a, b) => a.id.localeCompare(b.id));
+    .flatMap((node) => {
+      const signal = node.success_signal;
+      if (signal === null || !input.registeredSensors.has(signal.sensor)) return [];
+      return [{ node, signal }];
+    })
+    .sort((a, b) => a.node.id.localeCompare(b.node.id));
 
-  for (const node of measured) {
+  for (const { node, signal } of measured) {
     const gap = deriveGap(node);
     if (node.reading === null) {
       flags.push({
@@ -643,7 +675,7 @@ function renderMetrics(input: RsiRenderInput, flags: StalenessFlag[]): string[] 
     }
     out.push(
       `| \`${node.id}\` | ${clip(node.reading ?? "*(unread)*", 220)} | ` +
-        `${clip(node.success_signal!.threshold, 180)} | ${gap === null ? "**met**" : "shortfall"} |`,
+        `${clip(signal.threshold, 180)} | ${gap === null ? "**met**" : "shortfall"} |`,
     );
   }
   if (measured.length === 0) out.push("| — | no registered sensor resolves to a node | — | — |");

--- a/packages/intentionsutil/src/rsi.ts
+++ b/packages/intentionsutil/src/rsi.ts
@@ -310,8 +310,8 @@ export function attributeSpend(byPhase: Record<string, SpendBucket>): WorkflowSp
  * document, or `null` when the document is not one.
  *
  * Validates rather than asserts: the document comes off disk and may be
- * truncated, from an older schema, or another file entirely, so each bucket's
- * fields are re-derived as numbers instead of being cast into shape. A bucket
+ * truncated, from an older schema, or another file entirely, so every bucket
+ * field is re-derived numerically instead of being cast into shape. A bucket
  * that is not an object is skipped rather than defaulted to zeros — the
  * difference between "this skill spent nothing" and "this row was unreadable"
  * is exactly what the dispatch-dominance check turns on.

--- a/packages/intentionsutil/test/rsi.test.ts
+++ b/packages/intentionsutil/test/rsi.test.ts
@@ -1,0 +1,423 @@
+import { describe, expect, it } from "vitest";
+import type { IntentionNode, OfficeHours } from "../src/schema.js";
+import {
+  DISPATCH_STRATEGY_ID,
+  OFFICE_HOURS_STRATEGY_ID,
+  PARKED_UNLIFTED_SHOWN,
+  RSI_STRATEGY_ID,
+  SUMMARY_STALE_DAYS,
+  attributeSpend,
+  daysBetween,
+  queueSummaryOf,
+  renderRsiPlan,
+  rsiTaskCost,
+  workflowOfSkill,
+  type ParkedItem,
+  type RsiRenderInput,
+} from "../src/rsi.js";
+import { parseParkedList } from "../scripts/render-rsi-plan.js";
+
+/** A well-formed office_hours record for a parked fixture node. */
+function parked(reason: string): OfficeHours {
+  return { reason, since: "2026-07-01", recommendation: null, session_type: "other" };
+}
+
+/** Build an IntentionNode fixture, filling required/default fields. */
+function node(partial: Partial<IntentionNode> & { id: string }): IntentionNode {
+  return {
+    id: partial.id,
+    kind: partial.kind ?? "tactic",
+    statement: partial.statement ?? `Statement for ${partial.id}`,
+    owner: partial.owner ?? "human",
+    status: partial.status ?? "codified",
+    parent: partial.parent ?? null,
+    serves: partial.serves ?? [],
+    recovers: partial.recovers ?? [],
+    rationale: partial.rationale ?? null,
+    reading: partial.reading ?? null,
+    clarifications: partial.clarifications ?? [],
+    tooling_goals: partial.tooling_goals ?? [],
+    success_signal: partial.success_signal ?? null,
+    attention: partial.attention ?? null,
+    phase: partial.phase ?? null,
+    execution: partial.execution ?? null,
+    validates: partial.validates ?? [],
+    blocked_by: partial.blocked_by ?? [],
+    office_hours: partial.office_hours ?? null,
+    pace_exempt: partial.pace_exempt ?? false,
+    rounds: partial.rounds ?? null,
+    attributes: partial.attributes ?? {},
+  };
+}
+
+/**
+ * The minimum graph a render needs: the `kind-*` nodes (`resolveAttention`
+ * treats only kinds whose node sets `goal_layer: true` as eligible) plus the
+ * three queue-owning strategies.
+ */
+function baseNodes(overrides: IntentionNode[] = []): IntentionNode[] {
+  const base = [
+    node({ id: "kind-strategy", kind: "kind", attributes: { goal_layer: true } }),
+    node({ id: "kind-tactic", kind: "kind", attributes: { goal_layer: true } }),
+    node({ id: DISPATCH_STRATEGY_ID, kind: "strategy" }),
+    node({ id: OFFICE_HOURS_STRATEGY_ID, kind: "strategy" }),
+    node({ id: RSI_STRATEGY_ID, kind: "strategy" }),
+  ];
+  const byId = new Map(base.map((n) => [n.id, n]));
+  for (const o of overrides) byId.set(o.id, o);
+  return [...byId.values()];
+}
+
+function input(partial: Partial<RsiRenderInput> = {}): RsiRenderInput {
+  return {
+    nodes: partial.nodes ?? baseNodes(),
+    parked: partial.parked ?? [],
+    spend: partial.spend ?? null,
+    spendWindow: partial.spendWindow ?? "7d",
+    registeredSensors: partial.registeredSensors ?? new Set<string>(),
+    ref: partial.ref ?? "origin/main",
+    sha: partial.sha ?? "abcdef1234567890",
+    generatedAt: partial.generatedAt ?? "2026-08-10",
+  };
+}
+
+function parkedRow(partial: Partial<ParkedItem> & { id: string }): ParkedItem {
+  return {
+    rank: partial.rank ?? 1,
+    sessionType: partial.sessionType ?? "other",
+    id: partial.id,
+    since: partial.since ?? "2026-08-01",
+    note: partial.note ?? null,
+  };
+}
+
+describe("queueSummaryOf", () => {
+  it("reads a well-formed dated summary", () => {
+    const n = node({
+      id: "s",
+      kind: "strategy",
+      attributes: { queue_summary: { date: "2026-08-10", summary: "  all clear  " } },
+    });
+    expect(queueSummaryOf(n)).toEqual({ date: "2026-08-10", summary: "all clear" });
+  });
+
+  it("returns null for an absent, malformed, or undated summary", () => {
+    expect(queueSummaryOf(undefined)).toBeNull();
+    expect(queueSummaryOf(node({ id: "s" }))).toBeNull();
+    expect(
+      queueSummaryOf(node({ id: "s", attributes: { queue_summary: "just a string" } })),
+    ).toBeNull();
+    expect(
+      queueSummaryOf(
+        node({ id: "s", attributes: { queue_summary: { date: "yesterday", summary: "x" } } }),
+      ),
+    ).toBeNull();
+    expect(
+      queueSummaryOf(
+        node({ id: "s", attributes: { queue_summary: { date: "2026-08-10", summary: "  " } } }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("rsiTaskCost", () => {
+  it("defaults to 0 and reads a declared cost", () => {
+    expect(rsiTaskCost(node({ id: "t" }))).toBe(0);
+    expect(rsiTaskCost(node({ id: "t", attributes: { rsi_cost: 1 } }))).toBe(1);
+  });
+
+  it("ignores a non-numeric or negative declared cost rather than trusting it", () => {
+    expect(rsiTaskCost(node({ id: "t", attributes: { rsi_cost: "1" } }))).toBe(0);
+    expect(rsiTaskCost(node({ id: "t", attributes: { rsi_cost: -3 } }))).toBe(0);
+  });
+});
+
+describe("daysBetween", () => {
+  it("counts whole days forward", () => {
+    expect(daysBetween("2026-08-01", "2026-08-10")).toBe(9);
+    expect(daysBetween("2026-08-10", "2026-08-10")).toBe(0);
+  });
+});
+
+describe("workflowOfSkill / attributeSpend", () => {
+  it("maps each workflow's skills, and unknown skills to other", () => {
+    expect(workflowOfSkill("qa-fix")).toBe("dispatch");
+    expect(workflowOfSkill("office-hours")).toBe("office-hours");
+    expect(workflowOfSkill("rsi")).toBe("rsi");
+    expect(workflowOfSkill("some-future-skill")).toBe("other");
+  });
+
+  it("folds per-skill buckets into shares over the four workflows", () => {
+    const spend = attributeSpend({
+      "qa-fix": { price_proxy_usd: 60, cost_usd: 20, turns: 6 },
+      implement: { price_proxy_usd: 20, cost_usd: 10, turns: 2 },
+      "office-hours": { price_proxy_usd: 10, cost_usd: 5, turns: 1 },
+      rsi: { price_proxy_usd: 10, cost_usd: 5, turns: 1 },
+    });
+    expect(spend.map((s) => s.workflow)).toEqual(["dispatch", "office-hours", "rsi", "other"]);
+    expect(spend[0]).toMatchObject({ priceProxyUsd: 80, costUsd: 30, turns: 8, share: 0.8 });
+    expect(spend[1].share).toBeCloseTo(0.1);
+    expect(spend[3]).toMatchObject({ priceProxyUsd: 0, share: 0 });
+  });
+
+  it("does not divide by zero on an empty window", () => {
+    expect(attributeSpend({}).every((s) => s.share === 0)).toBe(true);
+  });
+});
+
+describe("parseParkedList", () => {
+  it("parses tab-separated rows and binds a following NOTE to the row above", () => {
+    const rows = parseParkedList(
+      [
+        "55.3\tother\ttactic-a\t2026-08-05",
+        "NOTE — tactic-a ranks at tier 1/55.3 inherited from blocked source tactic-b (own: tier 1/5)",
+        "1\trequirement-discovery\ttactic-c\t2026-08-01",
+        "",
+      ].join("\n"),
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ rank: 55.3, id: "tactic-a", sessionType: "other" });
+    expect(rows[0].note).toContain("blocked source tactic-b");
+    expect(rows[1]).toMatchObject({ id: "tactic-c", note: null });
+  });
+
+  it("skips malformed rows rather than inventing ranks for them", () => {
+    expect(parseParkedList("not-a-rank\tother\ttactic-a\t2026-08-05")).toHaveLength(0);
+    expect(parseParkedList("1\tother\ttactic-a")).toHaveLength(0);
+  });
+});
+
+describe("renderRsiPlan", () => {
+  it("is deterministic for identical inputs", () => {
+    expect(renderRsiPlan(input()).markdown).toBe(renderRsiPlan(input()).markdown);
+  });
+
+  it("declares itself generated, naming the ref and short sha", () => {
+    const md = renderRsiPlan(input()).markdown;
+    expect(md).toContain("**Generated file — do not hand-edit.**");
+    expect(md).toContain("`origin/main` (`abcdef12`)");
+    expect(md).toContain("a hand-edited section is a defect");
+  });
+
+  it("renders all six sections", () => {
+    const md = renderRsiPlan(input()).markdown;
+    for (const heading of [
+      "## 1. Top author priorities",
+      "## 2. Dispatch queue",
+      "## 3. Office-hours queue",
+      "## 4. Metrics",
+      "## 5. Recommended additional telemetry",
+      "## 6. RSI task plan",
+    ]) {
+      expect(md).toContain(heading);
+    }
+  });
+
+  it("flags each missing queue summary, one per owning strategy", () => {
+    const flags = renderRsiPlan(input()).flags.filter((f) => f.kind === "summary-missing");
+    expect(flags.map((f) => f.subject).sort()).toEqual(
+      [DISPATCH_STRATEGY_ID, OFFICE_HOURS_STRATEGY_ID, RSI_STRATEGY_ID].sort(),
+    );
+  });
+
+  it("renders a fresh summary verbatim and does not flag it", () => {
+    const nodes = baseNodes([
+      node({
+        id: DISPATCH_STRATEGY_ID,
+        kind: "strategy",
+        attributes: {
+          queue_summary: { date: "2026-08-09", summary: "REAPGATE is one merge from clearing." },
+        },
+      }),
+    ]);
+    const { markdown, flags } = renderRsiPlan(input({ nodes }));
+    expect(markdown).toContain("REAPGATE is one merge from clearing.");
+    expect(flags.some((f) => f.subject === DISPATCH_STRATEGY_ID)).toBe(false);
+  });
+
+  it("flags a summary older than the staleness window", () => {
+    const nodes = baseNodes([
+      node({
+        id: RSI_STRATEGY_ID,
+        kind: "strategy",
+        attributes: { queue_summary: { date: "2026-07-01", summary: "stale news" } },
+      }),
+    ]);
+    const flag = renderRsiPlan(input({ nodes })).flags.find(
+      (f) => f.kind === "summary-stale" && f.subject === RSI_STRATEGY_ID,
+    );
+    expect(flag).toBeDefined();
+    expect(flag!.detail).toContain(`limit ${SUMMARY_STALE_DAYS}d`);
+  });
+
+  it("renders only registered sensors as metrics, and flags unread ones and breaches", () => {
+    const signal = (sensor: string, threshold: string) => ({
+      observable: "o",
+      sensor,
+      threshold,
+      is_proxy: false,
+    });
+    const nodes = baseNodes([
+      node({
+        id: "strategy-measured",
+        kind: "strategy",
+        success_signal: signal("live-sensor", "green"),
+        reading: "red",
+      }),
+      node({
+        id: "strategy-unread",
+        kind: "strategy",
+        success_signal: signal("live-sensor", "green"),
+        reading: null,
+      }),
+      node({
+        id: "strategy-unregistered",
+        kind: "strategy",
+        success_signal: signal("aspirational-sensor", "green"),
+        reading: "red",
+      }),
+    ]);
+    const { markdown, flags } = renderRsiPlan(
+      input({ nodes, registeredSensors: new Set(["live-sensor"]) }),
+    );
+    // Scope the assertions to §4 — §1 lists every strategy by name, so a
+    // whole-document match would pass regardless of what the metrics table holds.
+    const metrics = markdown.slice(markdown.indexOf("## 4."), markdown.indexOf("## 5."));
+    expect(metrics).toContain("`strategy-measured`");
+    expect(metrics).toContain("`strategy-unread`");
+    // A node naming an UNREGISTERED sensor is not a metric: nothing measures it,
+    // so rendering its stale reading beside measured ones would be a false claim.
+    expect(metrics).not.toContain("`strategy-unregistered`");
+    expect(flags).toContainEqual(
+      expect.objectContaining({ kind: "threshold-breach", subject: "strategy-measured" }),
+    );
+    expect(flags).toContainEqual(
+      expect.objectContaining({ kind: "unread-sensor", subject: "strategy-unread" }),
+    );
+  });
+
+  it("reports absent token attribution instead of rendering it as zero spend", () => {
+    const md = renderRsiPlan(input({ spend: null })).markdown;
+    expect(md).toContain("*unavailable.*");
+    expect(md).toContain("aggregate-usage.sh");
+  });
+
+  it("flags a window where dispatch does not outpace the other workflows", () => {
+    const spend = attributeSpend({
+      "qa-fix": { price_proxy_usd: 10, cost_usd: 1, turns: 1 },
+      rsi: { price_proxy_usd: 90, cost_usd: 9, turns: 9 },
+    });
+    const flag = renderRsiPlan(input({ spend })).flags.find(
+      (f) => f.kind === "spend-deviation",
+    );
+    expect(flag).toBeDefined();
+    expect(flag!.detail).toContain("rsi");
+  });
+
+  it("does not flag a window where dispatch dominates", () => {
+    const spend = attributeSpend({
+      "qa-fix": { price_proxy_usd: 90, cost_usd: 9, turns: 9 },
+      rsi: { price_proxy_usd: 10, cost_usd: 1, turns: 1 },
+    });
+    expect(
+      renderRsiPlan(input({ spend })).flags.some((f) => f.kind === "spend-deviation"),
+    ).toBe(false);
+  });
+
+  it("shows every rank-lifted park, caps unlifted ones, and states what it dropped", () => {
+    const lifted = parkedRow({
+      id: "tactic-hold-x",
+      rank: 2,
+      note: "tactic-hold-x ranks at tier 1/2 inherited from blocked source tactic-source (own: tier 1/0)",
+    });
+    const unlifted = Array.from({ length: PARKED_UNLIFTED_SHOWN + 5 }, (_, i) =>
+      parkedRow({ id: `tactic-park-${String(i).padStart(2, "0")}`, rank: 100 - i }),
+    );
+    const md = renderRsiPlan(input({ parked: [...unlifted, lifted] })).markdown;
+    expect(md).toContain("`tactic-hold-x`");
+    // The lift's blocked SOURCE is what the column carries — not the park's own id.
+    expect(md).toContain("| `tactic-source` |");
+    expect(md).toContain("`tactic-park-00`");
+    expect(md).not.toContain("`tactic-park-14`");
+    expect(md).toContain("The remaining **5** are not shown here");
+  });
+
+  it("counts open nodes held by a blocked_by edge onto a parked node", () => {
+    const nodes = baseNodes([
+      node({ id: "tactic-parked", office_hours: parked("needs a ruling") }),
+      node({ id: "tactic-held", phase: "qa", blocked_by: ["tactic-parked"] }),
+      node({ id: "tactic-done-held", phase: "done", blocked_by: ["tactic-parked"] }),
+    ]);
+    const md = renderRsiPlan(input({ nodes })).markdown;
+    expect(md).toContain("onto a parked node: **1**");
+  });
+
+  it("renders every sensor-kind tooling goal, and no actuator ones", () => {
+    const nodes = baseNodes([
+      node({
+        id: "strategy-wants-telemetry",
+        kind: "strategy",
+        tooling_goals: [
+          { kind: "sensor", statement: "a conflict-encounter counter" },
+          { kind: "actuator", statement: "a merge driver" },
+        ],
+      }),
+    ]);
+    const md = renderRsiPlan(input({ nodes })).markdown;
+    expect(md).toContain("a conflict-encounter counter");
+    expect(md).not.toContain("a merge driver");
+  });
+
+  it("renders the task plan from nodes with their declared costs", () => {
+    const nodes = baseNodes([
+      node({
+        id: "tactic-rsi-costly",
+        serves: [RSI_STRATEGY_ID],
+        phase: "implement",
+        attributes: { rsi_cost: 1 },
+      }),
+      node({ id: "tactic-rsi-free", serves: [RSI_STRATEGY_ID] }),
+      node({ id: "tactic-elsewhere", serves: [DISPATCH_STRATEGY_ID] }),
+    ]);
+    const md = renderRsiPlan(input({ nodes })).markdown;
+    const taskPlan = md.slice(md.indexOf("## 6."));
+    expect(taskPlan).toContain("| `tactic-rsi-costly` | 1 | implement | open");
+    expect(taskPlan).toContain("| `tactic-rsi-free` | 0 | — | draft");
+    expect(taskPlan).not.toContain("tactic-elsewhere");
+  });
+
+  it("flags a completed or parked task still carried in the plan", () => {
+    const nodes = baseNodes([
+      node({ id: "tactic-rsi-done", serves: [RSI_STRATEGY_ID], phase: "done" }),
+      node({
+        id: "tactic-rsi-parked",
+        serves: [RSI_STRATEGY_ID],
+        office_hours: parked("awaits an author ruling"),
+      }),
+    ]);
+    const flags = renderRsiPlan(input({ nodes })).flags;
+    expect(flags).toContainEqual(
+      expect.objectContaining({ kind: "task-done", subject: "tactic-rsi-done" }),
+    );
+    expect(flags).toContainEqual(
+      expect.objectContaining({ kind: "task-parked", subject: "tactic-rsi-parked" }),
+    );
+  });
+
+  it("orders priorities by effective tier before rank", () => {
+    const nodes = baseNodes([
+      node({
+        id: "strategy-tier-three",
+        kind: "strategy",
+        attributes: { tier: 3 },
+      }),
+      node({
+        id: "strategy-boosted",
+        kind: "strategy",
+        attention: { boost: 50, override: null, rationale: "urgent", tier: 1 },
+      }),
+    ]);
+    const md = renderRsiPlan(input({ nodes })).markdown;
+    expect(md.indexOf("strategy-tier-three")).toBeLessThan(md.indexOf("strategy-boosted"));
+  });
+});

--- a/packages/intentionsutil/test/rsi.test.ts
+++ b/packages/intentionsutil/test/rsi.test.ts
@@ -11,6 +11,7 @@ import {
   queueSummaryOf,
   renderRsiPlan,
   rsiTaskCost,
+  spendBucketsFrom,
   workflowOfSkill,
   type ParkedItem,
   type RsiRenderInput,
@@ -165,6 +166,32 @@ describe("workflowOfSkill / attributeSpend", () => {
   });
 });
 
+describe("spendBucketsFrom", () => {
+  it("extracts by_phase buckets, coercing each field to a finite number", () => {
+    expect(
+      spendBucketsFrom({
+        by_phase: { "qa-fix": { price_proxy_usd: 5, cost_usd: 1, turns: 2 } },
+      }),
+    ).toEqual({ "qa-fix": { price_proxy_usd: 5, cost_usd: 1, turns: 2 } });
+  });
+
+  it("zeroes a missing or non-finite field rather than propagating NaN", () => {
+    expect(
+      spendBucketsFrom({ by_phase: { "qa-fix": { price_proxy_usd: "5", turns: null } } }),
+    ).toEqual({ "qa-fix": { price_proxy_usd: 0, cost_usd: 0, turns: 0 } });
+  });
+
+  it("skips an unreadable bucket instead of inventing a zero-spend row for it", () => {
+    expect(spendBucketsFrom({ by_phase: { "qa-fix": "not-a-bucket" } })).toEqual({});
+  });
+
+  it("returns null — not an empty map — for a document that is not an aggregate", () => {
+    expect(spendBucketsFrom(null)).toBeNull();
+    expect(spendBucketsFrom("[]")).toBeNull();
+    expect(spendBucketsFrom({ totals: {} })).toBeNull();
+  });
+});
+
 describe("parseParkedList", () => {
   it("parses tab-separated rows and binds a following NOTE to the row above", () => {
     const rows = parseParkedList(
@@ -246,8 +273,7 @@ describe("renderRsiPlan", () => {
     const flag = renderRsiPlan(input({ nodes })).flags.find(
       (f) => f.kind === "summary-stale" && f.subject === RSI_STRATEGY_ID,
     );
-    expect(flag).toBeDefined();
-    expect(flag!.detail).toContain(`limit ${SUMMARY_STALE_DAYS}d`);
+    expect(flag?.detail).toContain(`limit ${SUMMARY_STALE_DAYS}d`);
   });
 
   it("renders only registered sensors as metrics, and flags unread ones and breaches", () => {
@@ -310,8 +336,7 @@ describe("renderRsiPlan", () => {
     const flag = renderRsiPlan(input({ spend })).flags.find(
       (f) => f.kind === "spend-deviation",
     );
-    expect(flag).toBeDefined();
-    expect(flag!.detail).toContain("rsi");
+    expect(flag?.detail).toContain("rsi");
   });
 
   it("does not flag a window where dispatch dominates", () => {


### PR DESCRIPTION
Bootstrap task **R2** of `rsi-plan.md`, implementing the design recorded in
`intentions/strategy-recursive-self-improvement.md` (the 2026-08-10 `/align`
round and its same-day review round).

## What lands

| file | role |
|---|---|
| `packages/intentionsutil/src/rsi.ts` | pure render of every `rsi-plan.md` section from graph state, plus the mechanical staleness flags the `/rsi` judgment step reads |
| `packages/intentionsutil/scripts/render-rsi-plan.ts` | the CLI — reads the store at a git ref, gathers parked rows and token attribution, writes the file |
| `packages/intentionsutil/scripts/read-sensors.ts` | registers the rsi sensor; exports `registeredSensorNames()` |
| `.claude/skills/rsi-plan/SKILL.md` | the rendering half of the loop |
| `.claude/skills/rsi/SKILL.md` | the iteration loop |
| `.claude/skills/rsi/scripts/rsi-claim` | the serialization primitive |

## Design notes worth reviewing

**Rendering and judgment are split.** `/rsi-plan` renders and reports flags and
decides nothing; `/rsi`'s main thread judges. That split is the review round's
resolution, and it is why `/rsi-plan` is safe to run in a subagent while the
judgment step is not.

**The store is read at `origin/main`, never the working tree.** Same reason
`office-hours-select.ts` does it: a renderer that reads its own checkout
publishes whatever that worktree last synced, and this file is then pushed to
main as current.

**The queue summaries live in `attributes.queue_summary`, not `reading`.** The
record says the model-drafted summaries land "as dated readings on their owning
strategy nodes". The top-level `reading` field cannot carry them — it is
sensor-owned, and `read-sensors.ts` overwrites it on every batch run, so a
drafted summary parked there would be silently clobbered (two of the three
owners now name registered sensors). `attributes.queue_summary` is a dated
record on the owning node, which is what the design asked for, in the one place
a non-sensor writer may own. It sits outside `strategyFingerprint`'s substance
hash, so re-drafting a summary each iteration invalidates no open child's
strategy stamp.

**`§4 Metrics` renders only REGISTERED sensors.** A node naming an unregistered
sensor is not a metric — nothing measures it, so rendering its stale reading
beside measured ones would be a false claim. The registered set is derived from
the registry, never hand-listed.

**`§5 Telemetry` renders `tooling_goals` of `kind: sensor`.** The graph already
has a home for "instrumentation we want and don't have"; this section is that
field, rendered. No new registry.

**`rsi-claim` fails closed.** A sandboxed `claude agents --json` returns `[]`
indistinguishably from a genuine no-sessions answer, so an unanswerable probe
exits 12 (held), never 0. It adds no detection of its own — it asks
`lib-claude-agents.sh`'s own probe about one path. The caller's own session is
excluded by pid ancestry, so `/rsi` can run from inside its own worktree.

**Two absent-data paths report rather than substitute.** No usage aggregate
renders an explicit *unavailable* line, not zeros — a fabricated 0% for rsi
would silently satisfy the recorded dispatch-dominates-spend expectation, which
is a review trigger. A failed park probe is fatal, because an empty parked list
is itself a meaningful answer.

## What is deliberately NOT here

- **The rsi-implement orchestration loop** — that is R3
  (`tactic-rsi-implement-skill`). `/rsi`'s step 4b says so plainly and describes
  the hand-orchestrated path until it lands, rather than implying a capability
  that does not exist.
- **A `read-sensors.ts` run.** The new sensor will populate
  `strategy-recursive-self-improvement.reading` on the next batch run; doing it
  here would rewrite readings across many unrelated nodes in a code PR.

## Verification

- 939 unit tests pass — 26 new in `test/rsi.test.ts` covering the render,
  every flag kind, spend attribution, and the parked-list parse.
- 11 new shell tests cover `rsi-claim`'s fail-closed paths, self-exclusion, and
  the uncorroborated-empty fold; wired into `run-unit-tests.sh` behind
  `--rsi-scripts` and the `.claude/skills/rsi/scripts/*` changed-file trigger.
  They caught a real bug: the held branch read a variable set inside a command
  substitution, so a correct refusal exited 1 instead of 11.
- Typecheck and lint clean.
- Rendered end-to-end against `origin/main` with a real usage aggregate:
  dispatch 90.6% / office-hours 0.3% / rsi 0.0%, no spend-deviation flag.

```verify
npx tsc --noEmit -p packages/intentionsutil
npx vitest run --root packages/intentionsutil
.claude/skills/rsi/scripts/test-rsi-claim.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
