### PR TITLE
rsi: build the rsi-implement orchestration loop (rsi-advance + rsi-await)

### DIFF
--- a/.claude/skills/rsi/SKILL.md
+++ b/.claude/skills/rsi/SKILL.md
@@ -116,22 +116,60 @@ verify by parsing `origin/main`, never by exit code. Most iterations should be
 mostly this: the harness does the work, rsi decides what the work is.
 
 **4b — Execute (cost 1 each).** Drive a claimed node through the dispatch phase
-skills. **The orchestration loop for this lands in R3
-(`tactic-rsi-implement-skill`) and is not built yet** — until it is, an
-execute-class task is hand-orchestrated in this attended session using the
-monitor's proven path: claim the node's worktree, spawn the phase skill for its
-persisted phase as a **session** via `dispatch-graph-execute` /
-`dispatch-spawn-job`, await the terminal disposition, verify the transition off
-`origin/main`, repeat. Two rules hold either way:
+skills, one phase at a time, with two scripts:
+
+```bash
+.claude/skills/rsi/scripts/rsi-advance <node-id>          # launch one phase
+.claude/skills/rsi/scripts/rsi-await   <node-id> <phase>  # wait, then verify
+```
+
+Both need `dangerouslyDisableSandbox: true` (gh, the Claude daemon socket, git,
+direnv — `.claude/rules/sandbox.md`). `rsi-advance` prints
+`launched <id> <kind> <phase> <skill>`; hand that `<phase>` to `rsi-await` as the
+from-phase. The loop is:
+
+1. `rsi-advance <id>`. Exit **0** means a session is running — go to 2. Exit
+   **10** means there is nothing to launch (not selectable, CI still pending, a
+   stale selection); stop the loop and read its stderr. Exit **11** means throw
+   — go to step 5 below. Exit **13** means another session holds the node;
+   **stop**, and never work around it.
+2. `rsi-await <id> <phase>`. Exit **20** means still working — call it again with
+   the same arguments, as many times as it takes. Exit **0** means the node
+   advanced (or was pruned, and the loop is done). Exit **11**, **12** or **14**
+   go to step 5.
+3. On exit 0, return to 1. The next `rsi-advance` re-reads the phase from
+   `origin/main`, so nothing needs to be threaded between iterations.
+4. Stop when `rsi-advance` reports `idle` or `rsi-await` reports `pruned`. A
+   node that reaches `main-qa` and merges leaves the loop through `idle` — the
+   tick's merge lane, not this loop, finishes it.
+5. On any throw: **do not push through and do not retry blindly.** Conduct the
+   office-hours engagement here, attended, and record the outcome in the graph.
+   A `stalled` (12) in particular means the worker stopped having changed
+   nothing — read its transcript before spending budget on a repeat.
+
+**What the scripts do and do not decide.** They decide nothing about
+eligibility. `rsi-advance` delegates the phase directive to
+`graph-select-target --node <id>` — every environmental gate applied verbatim,
+including the CI and PR sensor gates and the fix/conflict interrupts — and the
+launch to `dispatch-graph-execute`, which owns provisioning, the phase-skill
+mapping, the reservation handoff, and every park/hold disposition. `rsi-await`
+takes its verdict from `verify-landed` against `origin/main`, never from a
+session's exit status. **If a rule about when a node may run ever appears in
+these scripts, it is in the wrong place** — that is the second-orchestration-
+surface divergence the record forbids.
+
+Three rules hold, and none of them is negotiable:
 
 - **Never hand-merge.** The tick's merge lane runs even while dispatch is
-  paused. Let it.
+  paused. Let it. Neither script makes a merge, a graph write, or a `gh` call.
 - **Never run a phase skill in an Agent-tool subagent.** `/qa-fix`,
   `/review-fix` and `/align-tactics` depend on the Workflow tool, which a
-  subagent cannot use. They must be spawned sessions.
-
-On a park or a non-mechanical blocker, do not push through: conduct the
-office-hours engagement here, attended, and record the outcome in the graph.
+  subagent cannot use. They must be spawned sessions — which is what
+  `dispatch-graph-execute` does.
+- **Never work a node dispatch is working.** `rsi-advance` refuses on exit 13
+  when a live session or an unreleased ledger marker claims the node, and it
+  writes its own marker before spawning so the boot window is covered. Exit 13
+  is the mutual exclusion, not an obstacle to route around.
 
 ## Pause and resume authority
 

--- a/.claude/skills/rsi/scripts/rsi-advance
+++ b/.claude/skills/rsi/scripts/rsi-advance
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# rsi-advance — kick ONE phase step of ONE node, through the dispatch lane.
+#
+# Half of the rsi-implement loop (`intentions/tactic-rsi-implement-skill.md`).
+# `rsi-advance` launches a phase; `rsi-await` waits for it and verifies the
+# transition off `origin/main`. The /rsi skill alternates them until the node
+# is done or throws.
+#
+# WHAT THIS IS NOT. It is not a scheduler, not a selector, and not a second
+# orchestration surface — `strategy-recursive-self-improvement`'s standing
+# constraint is that rsi reuses the dispatch skills VERBATIM and maintains no
+# orchestration rule dispatch does not already have. So this script decides
+# nothing about eligibility. It delegates:
+#
+#   graph-select-target --node <id>   the phase directive, read at origin/main,
+#                                     with EVERY environmental gate applied —
+#                                     claim safety, the per-phase CI/PR sensor
+#                                     gates, the fix and conflict interrupts.
+#                                     `--node` is documented as a selection-ORDER
+#                                     override, not a gate bypass, which is
+#                                     exactly the property rsi needs.
+#   dispatch-graph-execute <spec>     provisioning, the phase-skill mapping, the
+#                                     spawn, the reservation handoff, and every
+#                                     park/hold disposition.
+#
+# Everything below those two calls is argument marshalling and exit-code
+# mapping. If a rule about WHEN a node may run ever appears in this file, it is
+# in the wrong file.
+#
+# NO --standalone, DELIBERATELY. `graph-select-target --standalone` would fold
+# in the lock, the ledger claim, and the headroom cap — but it also applies the
+# pace curve, and its header says so plainly: a --standalone caller is treated
+# as unattended and degrades to `empty` at the ceiling. /rsi is attended
+# (strategy condition 9) and pace-exempt (condition 7 — "the budget and the
+# serialization are the throttle, not the pace curve"). More concretely: rsi's
+# execute lane exists FOR the bootstrap-deadlock case, where dispatch is paused
+# and the fix is what would unpause it. Under a pause the worker target is 0,
+# so --standalone would print `empty` on every call and the lane would be dead
+# in precisely the situation it was built for. The ledger claim --standalone
+# would have written is made explicitly below instead.
+#
+# CLAIM DISCIPLINE. A node must never be worked by dispatch and rsi at once.
+# Three things enforce that, none of them new:
+#   1. The pre-launch refusal below — `worktree_has_live_session`, fail-safe
+#      (unknown counts as occupied), plus an existing reservation marker.
+#   2. The reservation marker this script writes before executing, with
+#      `origin=explicit` — the origin dispatch-select-tick's own explicit
+#      named-node lane uses, so reservation_sweep's TTL rule already reclaims
+#      it if this script dies before the worker registers. NOT a new origin:
+#      a new one would need a new branch in the sweep, and this claim has the
+#      same lifecycle as that lane's.
+#   3. dispatch-graph-execute's spawn handoff, which re-stamps the marker
+#      `origin=spawned` and lets the sweep release it once the worker's own
+#      live session registers. From that moment the worktree IS the claim and
+#      graph-select-target skips the node for the router.
+#
+# Usage: rsi-advance <node-id>
+#
+# Stdout, one line:
+#   launched <id> <kind> <phase> <skill>   a session is running; call rsi-await
+#                                          with <phase> as the from-phase.
+#   idle <id> <reason>                     nothing to launch right now.
+#   throw <id> <reason>                    the node needs the attended thread.
+#   claimed <id> <holder>                  another session holds it.
+#
+# Exit codes:
+#   0   launched — a phase session is running.
+#   10  idle: not selectable, ci-waiting, stale-selection, or scope-stale. Not
+#       an error; the loop stops or retries later. The graph-select-target
+#       event lines on stderr say which.
+#   11  throw: parked, held, or a failed launch. The /rsi main thread conducts
+#       the office-hours engagement — this script never pushes through one.
+#   13  claimed: a live session or an unreclaimed marker holds the node.
+#       NEVER proceed past this; it is the dispatch/rsi mutual exclusion.
+#   2   usage or environment error.
+#
+# Requires `dangerouslyDisableSandbox: true`: the selector's sensor gates call
+# `gh`, the liveness read reaches the Claude daemon over a Unix socket, and
+# dispatch-graph-execute runs git/direnv and spawns `claude --bg`
+# (.claude/rules/sandbox.md).
+#
+# NOT set -e — exits are handled explicitly, matching the dispatch siblings.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# .claude/skills/rsi/scripts → the checkout root is four levels up. Used only to
+# locate sibling scripts and libraries; the PROJECT root is resolved from git
+# below, because this checkout may itself be a worktree.
+CHECKOUT_ROOT="$(cd -- "$SCRIPT_DIR/../../../.." && pwd)"
+DISPATCH_SCRIPTS="$CHECKOUT_ROOT/.claude/skills/dispatch-propagate/scripts"
+
+# shellcheck source=/dev/null
+source "$DISPATCH_SCRIPTS/lib-claude-agents.sh"
+# shellcheck source=/dev/null
+source "$DISPATCH_SCRIPTS/lib-reservation-ledger.sh"
+# shellcheck source=/dev/null
+source "$DISPATCH_SCRIPTS/lib-graph-worktree.sh"
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: rsi-advance <node-id>" >&2
+  exit 2
+fi
+
+NODE_ID="$1"
+
+# Validate before the id reaches a spawn prompt or a worktree path — the same
+# slug regex dispatch-graph-execute and provision-node-worktree apply.
+if [[ ! "$NODE_ID" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]]; then
+  echo "rsi-advance: invalid node id '$NODE_ID'" >&2
+  exit 2
+fi
+
+PROJECT_ROOT=$(resolve_main_worktree 2>/dev/null)
+if [[ -z "$PROJECT_ROOT" || ! -d "$PROJECT_ROOT" ]]; then
+  echo "rsi-advance: cannot resolve the project root (no worktree with 'main' checked out)" >&2
+  exit 2
+fi
+
+# Freshness. Every read below answers about origin/main, so fetch first — a
+# stale remote-tracking ref would let this launch a phase the graph has already
+# advanced past.
+if ! git -C "$PROJECT_ROOT" fetch origin main --quiet 1>&2; then
+  echo "rsi-advance: git fetch origin main failed; refusing to act on unverified graph state" >&2
+  exit 2
+fi
+
+# --- Claim safety ----------------------------------------------------------
+# Checked HERE as well as inside the selector, for the message: the selector
+# folds a claimed node into a bare `empty`, and "another session is working
+# this node" is the one disposition the rsi loop must never mistake for
+# "nothing to do".
+NODE_WT="$PROJECT_ROOT/.claude/worktrees/$NODE_ID"
+if worktree_has_live_session "$NODE_WT"; then
+  echo "claimed $NODE_ID live-session"
+  echo "rsi-advance: REFUSED — a live session is registered on $NODE_WT (or the liveness probe could not answer, which counts as occupied)." >&2
+  echo "rsi-advance: a node is never worked by dispatch and rsi at once. Wait for that session, or release a terminal holder with 'claude rm <session-id>'." >&2
+  exit 13
+fi
+
+if reservation_exists "$NODE_ID"; then
+  RES_OWNER=$(reservation_owner "$NODE_ID" 2>/dev/null || echo "unknown")
+  echo "claimed $NODE_ID reservation:$RES_OWNER"
+  echo "rsi-advance: REFUSED — an unreleased reservation-ledger marker claims $NODE_ID (owner $RES_OWNER)." >&2
+  echo "rsi-advance: if that claim is stale, reservation_sweep reclaims it on the next dispatch heartbeat; do not clear it by hand while a worker may still be booting." >&2
+  exit 13
+fi
+
+# --- Selection: the directive, with every gate applied ---------------------
+# stderr flows through — its event lines are the record of WHY a node was not
+# selectable, and the rsi main thread reads them.
+SELECTION=$("$DISPATCH_SCRIPTS/graph-select-target" --node "$NODE_ID")
+select_rc=$?
+if (( select_rc != 0 )); then
+  echo "throw $NODE_ID selector-failed"
+  echo "rsi-advance: graph-select-target exited $select_rc for $NODE_ID" >&2
+  exit 11
+fi
+
+# Protocol: `node <id> <kind> <phase>` or `empty`.
+SPEC_LINE=$(grep -E "^node ${NODE_ID} " <<<"$SELECTION" | head -n1)
+if [[ -z "$SPEC_LINE" ]]; then
+  echo "idle $NODE_ID not-selectable"
+  echo "rsi-advance: graph-select-target selected nothing for $NODE_ID — the event lines above name the gate that held it (phase null with no align route, a CI verdict still pending, a park, a blocked_by edge, a stale strategy fingerprint)." >&2
+  exit 10
+fi
+
+read -r _ _ KIND PHASE <<<"$SPEC_LINE"
+if [[ -z "$KIND" || -z "$PHASE" ]]; then
+  echo "throw $NODE_ID malformed-selection"
+  echo "rsi-advance: could not parse the selector line '$SPEC_LINE'" >&2
+  exit 11
+fi
+
+# --- Claim, then execute ---------------------------------------------------
+# Written BEFORE the spawn so the boot window is covered: between this line and
+# the worker's own session registering, the marker is what keeps a concurrent
+# dispatch tick from selecting the same node. dispatch-graph-execute re-stamps
+# it `origin=spawned` on a successful kick (its hand_off_reservation), after
+# which reservation_sweep owns its release.
+#
+# The `issue-N` slot carries the node id: graph nodes have no issue number, and
+# the slot is rejected empty, so the graph lane puts the id there —
+# `reservation_write "$id" "$id" ...`, exactly as graph-select-target's own
+# --standalone claim does. The session-id slot falls back to a literal `rsi`
+# rather than an empty string for the same reason: empty is rejected, and a
+# claim that silently failed to write is the boot-window hole this line exists
+# to close.
+if ! reservation_write "$NODE_ID" "$NODE_ID" "${CLAUDE_CODE_SESSION_ID:-rsi}" explicit; then
+  echo "throw $NODE_ID reservation-write-failed"
+  echo "rsi-advance: could not write the reservation marker for $NODE_ID; refusing to spawn a worker whose claim is unrecorded (a concurrent dispatch tick could select the same node)." >&2
+  exit 11
+fi
+
+EXEC_OUT=$("$DISPATCH_SCRIPTS/dispatch-graph-execute" "$NODE_ID:$KIND:$PHASE")
+exec_rc=$?
+
+DISPOSITION=$(awk '{print $1; exit}' <<<"$EXEC_OUT")
+case "$DISPOSITION" in
+  launched)
+    SKILL=$(awk '{print $3; exit}' <<<"$EXEC_OUT")
+    echo "launched $NODE_ID $KIND $PHASE $SKILL"
+    exit 0
+    ;;
+  conflict-lane)
+    # A session WAS launched — /dispatch-conflict, in the primary checkout,
+    # named for this node. It is awaited exactly like a phase session, and it
+    # declares its own terminal disposition on both of its exit paths. The
+    # from-phase reported is the node's ladder phase: Lane 3 resolves the
+    # conflict and the node re-enters at that phase, so a plain phase-changed
+    # check would read as `stalled`. rsi-await's absent/park checks still fire,
+    # and the attended thread reads the lane's own report.
+    echo "launched $NODE_ID $KIND $PHASE /dispatch-conflict"
+    exit 0
+    ;;
+  waiting)
+    reservation_clear "$NODE_ID" || true
+    echo "idle $NODE_ID ci-waiting"
+    exit 10
+    ;;
+  skipped)
+    # dispatch-graph-execute already cleared the marker on this path.
+    echo "idle $NODE_ID stale-selection"
+    exit 10
+    ;;
+  scope-stale)
+    # Likewise cleared; the node was demoted to implement and is re-runnable.
+    echo "idle $NODE_ID scope-stale-demoted"
+    exit 10
+    ;;
+  parked|held)
+    # A mechanical producer parked the node or born a tracked hold. Both need
+    # the attended thread — never pushed through here.
+    echo "throw $NODE_ID $DISPOSITION"
+    echo "$EXEC_OUT" >&2
+    exit 11
+    ;;
+  failed|*)
+    reservation_clear "$NODE_ID" || true
+    echo "throw $NODE_ID execute-failed"
+    echo "rsi-advance: dispatch-graph-execute exited $exec_rc with '$EXEC_OUT'" >&2
+    exit 11
+    ;;
+esac

--- a/.claude/skills/rsi/scripts/rsi-await
+++ b/.claude/skills/rsi/scripts/rsi-await
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# rsi-await — wait for one node's phase session to finish, then ask origin/main
+# what actually happened.
+#
+# The other half of the rsi-implement loop (`intentions/tactic-rsi-implement-skill.md`);
+# `rsi-advance` launches, this waits and verifies. It makes no graph writes, no
+# merges, and no decisions — it reports one of five outcomes and lets the /rsi
+# main thread judge.
+#
+# NEVER MERGES. The tick's merge lane runs even while dispatch is paused and it
+# owns every merge (strategy condition, and the node's own plan). A wait loop is
+# the one place it would be tempting to "just merge it and move on"; this script
+# has no gh call and no git write at all.
+#
+# THE VERDICT COMES FROM origin/main, NOT FROM THE SESSION. A phase worker's
+# exit status is not evidence that its transition landed — that is the whole
+# premise of `verify-landed` (tactic-graph-commit-landing-signal-unreliable), and
+# this script reuses it rather than re-deriving a second landing signal. The
+# session poll answers only "has the worker stopped?"; the graph answers "did
+# anything change?", and the two disagreeing is a real and reportable state
+# (`stalled`).
+#
+# HOW A FINISHED SESSION LOOKS. Graph node workers declare a terminal
+# disposition with `mark-node-terminal`, and dispatch-stop.sh's discriminator
+# hands that to `dispatch-self-close`, which reaps the job — so the registry row
+# DISAPPEARS. A worker that never declares one is HELD alive by that same hook:
+# its row survives with `state: done`. The two are therefore distinguishable and
+# mean different things:
+#   row gone            — declared terminal and reaped. The normal path.
+#   row present, done   — stopped WITHOUT declaring terminal. The session is
+#                         holding a worker slot and keeping the node
+#                         unselectable until a human runs `claude rm`. Reported
+#                         as `held-session`, because it needs that human act.
+#   row present, other  — still working. Keep polling.
+#
+# BOOT GRACE. `dispatch-graph-execute` returns as soon as the spawn kick
+# succeeds, before the worker's session registers with the daemon. Polling
+# immediately would see no row and misread the boot window as a completed
+# session, so the wait has two stages: first wait for the row to APPEAR (up to
+# --boot-grace-s), then wait for it to leave. A row that never appears is not
+# assumed dead — the graph is consulted first, because a very short phase can
+# genuinely start, transition, and reap inside the grace window.
+#
+# The grace is a CEILING, not a delay: the ordinary case breaks out of stage 1
+# on the first poll that sees the worker, and the full window is only ever spent
+# when no session appears at all. It defaults to 90s — three times the
+# reservation ledger's own 30s boot grace
+# (DISPATCH_RESERVATION_BOOT_GRACE_S, lib-reservation-ledger.sh), because that
+# sweep is reclaiming a slot and should be impatient, while this wait is about
+# to declare a phase dead and should not be.
+#
+# UNKNOWN IS NOT DONE. `claude_sessions_with_name_all` returns non-zero when the
+# daemon cannot be queried (missing binary, sandboxed socket read). That is
+# treated as "still running" and keeps polling — never as "finished", which
+# would send the loop on to the next phase while a worker is live.
+#
+# Usage: rsi-await <node-id> <from-phase>
+#                  [--timeout-s <n>] [--poll-s <n>] [--boot-grace-s <n>]
+#
+#   <from-phase>       the phase rsi-advance printed. The transition check asks
+#                      whether the node has moved off it.
+#   --timeout-s <n>    give up waiting after n seconds (default 540). The
+#                      default sits under the Bash tool's 600s ceiling on
+#                      purpose, so a call from a Claude session returns a real
+#                      answer rather than being killed mid-poll. A phase that
+#                      outlives it is NOT an error — exit 20 says "still
+#                      running, call again".
+#   --poll-s <n>       seconds between daemon reads (default 15).
+#   --boot-grace-s <n> how long to wait for the worker to REGISTER before
+#                      concluding none exists (default 90 — see BOOT GRACE).
+#
+# Stdout, one line:
+#   advanced <id> <from> -> <to-known-via>   the node moved off <from>.
+#   pruned <id>                              the node is gone from origin/main —
+#                                            completed and pruned.
+#   throw <id> <reason>                      parked, or a held session.
+#   stalled <id> <from>                      the worker stopped and NOTHING
+#                                            changed at origin/main.
+#   running <id> <from>                      still working at the timeout.
+#
+# Exit codes:
+#   0   advanced or pruned — the loop may take another step.
+#   11  throw: the node is parked, or a session is held un-reaped. Both need the
+#       attended /rsi thread; neither is retried here.
+#   12  stalled: the session ended with no graph change. Needs judgment — it is
+#       the shape a silently-failed phase takes, and retrying blindly would
+#       spend budget on a repeat.
+#   14  unknown: origin/main could not be read (verify-landed's third answer).
+#       Nothing is claimed either way; re-run once the read works.
+#   20  still running at the timeout. Call again — this is the expected result
+#       for any phase longer than --timeout-s, not a failure.
+#   2   usage or environment error.
+#
+# Requires `dangerouslyDisableSandbox: true` — the liveness read reaches the
+# Claude daemon over a Unix socket the sandbox blocks silently, and
+# `verify-landed` fetches (.claude/rules/sandbox.md).
+#
+# NOT set -e — exits are handled explicitly, matching the dispatch siblings.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+CHECKOUT_ROOT="$(cd -- "$SCRIPT_DIR/../../../.." && pwd)"
+DISPATCH_SCRIPTS="$CHECKOUT_ROOT/.claude/skills/dispatch-propagate/scripts"
+
+# shellcheck source=/dev/null
+source "$DISPATCH_SCRIPTS/lib-claude-agents.sh"
+# shellcheck source=/dev/null
+source "$DISPATCH_SCRIPTS/lib-graph-worktree.sh"
+
+TIMEOUT_S=540
+POLL_S=15
+BOOT_GRACE_S=90
+NODE_ID=""
+FROM_PHASE=""
+
+usage() {
+  echo "usage: rsi-await <node-id> <from-phase> [--timeout-s <n>] [--poll-s <n>] [--boot-grace-s <n>]" >&2
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --timeout-s)    [[ $# -ge 2 ]] || usage; TIMEOUT_S="$2"; shift 2 ;;
+    --poll-s)       [[ $# -ge 2 ]] || usage; POLL_S="$2"; shift 2 ;;
+    --boot-grace-s) [[ $# -ge 2 ]] || usage; BOOT_GRACE_S="$2"; shift 2 ;;
+    --*)            echo "rsi-await: unknown flag $1" >&2; usage ;;
+    *)
+      if [[ -z "$NODE_ID" ]]; then NODE_ID="$1"
+      elif [[ -z "$FROM_PHASE" ]]; then FROM_PHASE="$1"
+      else echo "rsi-await: unexpected argument $1" >&2; usage
+      fi
+      shift ;;
+  esac
+done
+
+[[ -n "$NODE_ID" && -n "$FROM_PHASE" ]] || usage
+[[ "$NODE_ID" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]] || {
+  echo "rsi-await: invalid node id '$NODE_ID'" >&2; exit 2; }
+[[ "$TIMEOUT_S" =~ ^[0-9]+$ && "$BOOT_GRACE_S" =~ ^[0-9]+$ && "$POLL_S" =~ ^[1-9][0-9]*$ ]] || {
+  echo "rsi-await: --timeout-s, --poll-s and --boot-grace-s must be integers (--poll-s positive)" >&2; exit 2; }
+
+PROJECT_ROOT=$(resolve_main_worktree 2>/dev/null)
+if [[ -z "$PROJECT_ROOT" || ! -d "$PROJECT_ROOT" ]]; then
+  echo "rsi-await: cannot resolve the project root (no worktree with 'main' checked out)" >&2
+  exit 2
+fi
+
+VERIFY_LANDED="$PROJECT_ROOT/packages/intentionsutil/scripts/verify-landed"
+[[ -x "$VERIFY_LANDED" ]] || {
+  echo "rsi-await: verify-landed not found or not executable at $VERIFY_LANDED" >&2; exit 2; }
+
+# --- Session state ---------------------------------------------------------
+# Echoes one of: working | done-held | absent | unknown.
+session_state() {
+  local rows
+  if ! rows="$(claude_sessions_with_name_all "$NODE_ID")"; then
+    printf 'unknown\n'; return 0
+  fi
+  if [[ -z "${rows//[[:space:]]/}" ]]; then
+    printf 'absent\n'; return 0
+  fi
+  # Column 2 is the granular state. ANY row not yet `done` means work is live.
+  if awk -F'\t' '$2 != "done" { found = 1 } END { exit found ? 0 : 1 }' <<<"$rows"; then
+    printf 'working\n'
+  else
+    printf 'done-held\n'
+  fi
+}
+
+# --- Graph verdict ---------------------------------------------------------
+# Every question is asked of origin/main through verify-landed, whose three
+# answers (landed / not-landed / unknown) are never collapsed into two.
+#
+# Order matters. `absent` is checked FIRST because an absent node satisfies
+# `.phase != "<from>"` — a pruned node and an advanced node would otherwise be
+# indistinguishable, and they call for different reports.
+graph_verdict() {
+  local rc
+
+  "$VERIFY_LANDED" -C "$PROJECT_ROOT" --node "$NODE_ID" --blob absent >/dev/null 2>&1
+  rc=$?
+  case "$rc" in
+    0) printf 'pruned\n'; return 0 ;;
+    4) ;;                        # present — the expected case, fall through
+    *) printf 'unknown\n'; return 0 ;;
+  esac
+
+  # Park before phase: a parked node may ALSO have advanced, and the park is the
+  # disposition that needs the attended thread.
+  "$VERIFY_LANDED" -C "$PROJECT_ROOT" --no-fetch --node "$NODE_ID" \
+    --jq '.office_hours != null' >/dev/null 2>&1
+  rc=$?
+  case "$rc" in
+    0) printf 'parked\n'; return 0 ;;
+    4) ;;
+    *) printf 'unknown\n'; return 0 ;;
+  esac
+
+  "$VERIFY_LANDED" -C "$PROJECT_ROOT" --no-fetch --node "$NODE_ID" \
+    --jq ".blocked_by | length > 0" >/dev/null 2>&1
+  rc=$?
+  case "$rc" in
+    0) printf 'blocked\n'; return 0 ;;
+    4) ;;
+    *) printf 'unknown\n'; return 0 ;;
+  esac
+
+  "$VERIFY_LANDED" -C "$PROJECT_ROOT" --no-fetch --node "$NODE_ID" \
+    --jq ".phase != \"$FROM_PHASE\"" >/dev/null 2>&1
+  rc=$?
+  case "$rc" in
+    0) printf 'advanced\n' ;;
+    4) printf 'unchanged\n' ;;
+    *) printf 'unknown\n' ;;
+  esac
+}
+
+report_graph_verdict() { # <session-note>
+  local note="$1" verdict
+  verdict=$(graph_verdict)
+  case "$verdict" in
+    pruned)
+      echo "pruned $NODE_ID"
+      echo "rsi-await: $NODE_ID is absent from origin/main — it completed and was pruned ($note)." >&2
+      exit 0 ;;
+    parked)
+      echo "throw $NODE_ID parked"
+      echo "rsi-await: $NODE_ID carries office_hours at origin/main ($note). The attended /rsi thread conducts the engagement; this script never clears a park." >&2
+      exit 11 ;;
+    blocked)
+      echo "throw $NODE_ID blocked-by"
+      echo "rsi-await: $NODE_ID has a non-empty blocked_by at origin/main ($note) — most likely a tracked hold born by a mechanical producer. Resolve the hold, not the source." >&2
+      exit 11 ;;
+    advanced)
+      echo "advanced $NODE_ID $FROM_PHASE -> origin/main"
+      exit 0 ;;
+    unchanged)
+      echo "stalled $NODE_ID $FROM_PHASE"
+      echo "rsi-await: the worker stopped ($note) but $NODE_ID is still at phase '$FROM_PHASE' on origin/main, unparked and unblocked. Read the session transcript before re-running — a blind retry spends budget on a repeat of whatever failed silently." >&2
+      exit 12 ;;
+    *)
+      echo "throw $NODE_ID unknown-graph-read"
+      echo "rsi-await: could not read $NODE_ID at origin/main (verify-landed's 'unknown'). Nothing is claimed either way — re-run once the read works." >&2
+      exit 14 ;;
+  esac
+}
+
+# --- Stage 1: wait for the worker to register ------------------------------
+DEADLINE=$(( SECONDS + TIMEOUT_S ))
+BOOT_DEADLINE=$(( SECONDS + BOOT_GRACE_S ))
+SAW_SESSION=0
+GOT_ANSWER=0
+
+while (( SECONDS < BOOT_DEADLINE && SECONDS < DEADLINE )); do
+  case "$(session_state)" in
+    working|done-held) SAW_SESSION=1; GOT_ANSWER=1; break ;;
+    absent)            GOT_ANSWER=1 ;;
+    # `unknown` deliberately does NOT set GOT_ANSWER — see below.
+  esac
+  sleep "$POLL_S"
+done
+
+if (( SAW_SESSION == 0 && GOT_ANSWER == 0 )); then
+  # Every read in the grace window was UNANSWERABLE — not one of them said
+  # "no session". Falling through to the graph here would let an unreadable
+  # registry produce a real verdict: a node whose phase had not landed YET would
+  # be reported `stalled` while its worker was alive and simply invisible. That
+  # is the same "trust an unanswerable probe" failure rsi-claim refuses to make.
+  # Report `running` instead — the caller re-runs, and nothing is claimed.
+  echo "running $NODE_ID $FROM_PHASE"
+  echo "rsi-await: the Claude session registry could not be read at all during the ${BOOT_GRACE_S}s boot window, so nothing is known about $NODE_ID's worker — and an unanswerable probe is never read as 'finished'." >&2
+  echo "rsi-await: the usual cause is running sandboxed, which blocks the daemon's Unix socket silently (.claude/rules/sandbox.md). Re-run with dangerouslyDisableSandbox: true." >&2
+  exit 20
+fi
+
+if (( SAW_SESSION == 0 )); then
+  # The registry answered, and it said there is no session. That is NOT proof
+  # the worker died: a short phase can start, transition, and reap before the
+  # first poll. Ask the graph — if it moved, the phase simply ran fast.
+  report_graph_verdict "no session registered within ${BOOT_GRACE_S}s"
+fi
+
+# --- Stage 2: wait for it to finish ----------------------------------------
+while (( SECONDS < DEADLINE )); do
+  case "$(session_state)" in
+    absent)
+      report_graph_verdict "session reaped after declaring terminal"
+      ;;
+    done-held)
+      # Stopped without declaring a terminal disposition, so the Stop hook is
+      # holding the job. The graph may still have advanced (the transition can
+      # land before the marker is written), so report that first — but a held
+      # session is a throw either way: it occupies a worker slot and keeps the
+      # node unselectable until a human releases it.
+      echo "throw $NODE_ID held-session"
+      echo "rsi-await: the session named $NODE_ID has state 'done' but was NOT reaped — it stopped without writing a node-terminal marker, so dispatch-stop.sh is holding the job alive." >&2
+      echo "rsi-await: it occupies a worker slot AND keeps $NODE_ID unselectable (worktree_has_live_session is name-keyed) until released with 'claude rm <session-id>'. Read its transcript first — the missing marker usually means it stopped mid-phase." >&2
+      "$VERIFY_LANDED" -C "$PROJECT_ROOT" --node "$NODE_ID" \
+        --jq ".phase != \"$FROM_PHASE\"" >/dev/null 2>&1 && \
+        echo "rsi-await: NOTE — $NODE_ID HAS moved off '$FROM_PHASE' at origin/main despite the missing marker; the phase work may be complete." >&2
+      exit 11
+      ;;
+  esac
+  sleep "$POLL_S"
+done
+
+echo "running $NODE_ID $FROM_PHASE"
+echo "rsi-await: $NODE_ID is still working after ${TIMEOUT_S}s. This is the expected result for a long phase — call rsi-await again with the same arguments." >&2
+exit 20

--- a/.claude/skills/rsi/scripts/test-rsi-advance.sh
+++ b/.claude/skills/rsi/scripts/test-rsi-advance.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Unit tests for rsi-advance — the launch half of the rsi-implement loop.
+#
+# What is worth testing here is the DISPOSITION MAPPING and the REFUSALS, not
+# the dispatch machinery: rsi-advance's whole design is that it delegates
+# selection and execution verbatim, so the tests stub both siblings and assert
+# that every line they can emit maps to the documented exit code. A mapping
+# regression is silent in production — an unmapped `parked` that fell through to
+# `launched` would send the loop into a wait for a session that does not exist.
+#
+# Both stubs and the Claude daemon are replaced: CLAUDE_AGENTS_CMD for liveness,
+# DISPATCH_RESERVATION_DIR for the ledger, DISPATCH_GRAPH_MAIN_WORKTREE for the
+# project root. No network, no daemon, no gh.
+#
+# Runs from anywhere; creates and removes its own temp tree.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+PASS=0
+FAIL=0
+fail() { printf 'FAIL: %s\n' "$1" >&2; FAIL=$((FAIL + 1)); }
+ok()   { printf 'ok: %s\n' "$1"; PASS=$((PASS + 1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- Fixture ---------------------------------------------------------------
+# A real checkout layout, because rsi-advance resolves its siblings from its own
+# on-disk location (four levels up) — a resolution that is itself a regression
+# risk.
+PROJECT="$TMP/project"
+RSI_SCRIPTS="$PROJECT/.claude/skills/rsi/scripts"
+DISPATCH="$PROJECT/.claude/skills/dispatch-propagate/scripts"
+mkdir -p "$RSI_SCRIPTS" "$DISPATCH"
+
+cp "$SCRIPT_DIR/rsi-advance" "$RSI_SCRIPTS/rsi-advance"
+chmod +x "$RSI_SCRIPTS/rsi-advance"
+for lib in lib-claude-agents.sh lib-reservation-ledger.sh lib-graph-worktree.sh lib.sh; do
+  src="$SCRIPT_DIR/../../dispatch-propagate/scripts/$lib"
+  [[ -f "$src" ]] && cp "$src" "$DISPATCH/$lib"
+done
+
+git -C "$PROJECT" init -q
+git -C "$PROJECT" config user.email test@example.com
+git -C "$PROJECT" config user.name Test
+git -C "$PROJECT" add -A >/dev/null 2>&1
+git -C "$PROJECT" commit -qm init >/dev/null 2>&1
+
+ADVANCE="$RSI_SCRIPTS/rsi-advance"
+
+export DISPATCH_GRAPH_MAIN_WORKTREE="$PROJECT"
+export DISPATCH_RESERVATION_DIR="$TMP/reservations"
+mkdir -p "$DISPATCH_RESERVATION_DIR"
+
+# `git fetch origin main` must succeed — rsi-advance refuses to act on an
+# unverified graph otherwise. Give the fixture a real local "remote".
+REMOTE="$TMP/remote.git"
+git init -q --bare "$REMOTE"
+git -C "$PROJECT" remote add origin "$REMOTE"
+git -C "$PROJECT" push -q origin HEAD:main
+
+# lib-claude-agents' empty-read corroboration only accepts an empty registry as
+# a definite "no sessions" when a `claude daemon` process is visible — otherwise
+# every liveness read is UNKNOWN, which folds to occupied, and every case below
+# would exit 13. CI has no daemon, so stub the probe rather than the process.
+# Without this the suite passes on a developer machine (a real daemon is running)
+# and fails in CI — the exact environment-dependent test this repo does not want.
+PGREP_STUB="$TMP/pgrep-stub"
+cat >"$PGREP_STUB" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$PGREP_STUB"
+export CLAUDE_AGENTS_PGREP_CMD="$PGREP_STUB"
+
+# --- Stubs -----------------------------------------------------------------
+# `claude agents --json[ --all]` — the registry. Body controlled per case.
+AGENTS_JSON="$TMP/agents.json"
+echo '[]' >"$AGENTS_JSON"
+CLAUDE_STUB="$TMP/claude-stub"
+cat >"$CLAUDE_STUB" <<STUB
+#!/usr/bin/env bash
+cat "$AGENTS_JSON"
+STUB
+chmod +x "$CLAUDE_STUB"
+export CLAUDE_AGENTS_CMD="$CLAUDE_STUB"
+
+# graph-select-target and dispatch-graph-execute — each echoes the contents of a
+# file the case under test writes, so one stub covers every protocol line.
+SELECT_OUT="$TMP/select.out"
+EXEC_OUT="$TMP/exec.out"
+EXEC_RC="$TMP/exec.rc"
+echo 0 >"$EXEC_RC"
+
+cat >"$DISPATCH/graph-select-target" <<STUB
+#!/usr/bin/env bash
+cat "$SELECT_OUT"
+STUB
+cat >"$DISPATCH/dispatch-graph-execute" <<STUB
+#!/usr/bin/env bash
+echo "\$@" > "$TMP/exec.args"
+cat "$EXEC_OUT"
+exit "\$(cat "$EXEC_RC")"
+STUB
+chmod +x "$DISPATCH/graph-select-target" "$DISPATCH/dispatch-graph-execute"
+
+# --- Helpers ---------------------------------------------------------------
+run_case() { # <label> <select-line> <exec-line> <want-exit> <want-stdout-prefix>
+  local label="$1" sel="$2" ex="$3" want_rc="$4" want_out="$5"
+  printf '%s\n' "$sel" >"$SELECT_OUT"
+  printf '%s\n' "$ex" >"$EXEC_OUT"
+  rm -f "$DISPATCH_RESERVATION_DIR"/* 2>/dev/null
+  local out rc
+  out=$("$ADVANCE" tactic-fixture-node 2>/dev/null)
+  rc=$?
+  if [[ "$rc" != "$want_rc" ]]; then
+    fail "$label — expected exit $want_rc, got $rc (stdout: $out)"
+    return
+  fi
+  if [[ "$out" != "$want_out"* ]]; then
+    fail "$label — expected stdout starting '$want_out', got '$out'"
+    return
+  fi
+  ok "$label (exit=$rc, '$out')"
+}
+
+SPEC="node tactic-fixture-node tactic qa"
+
+# --- Usage and validation --------------------------------------------------
+"$ADVANCE" >/dev/null 2>&1
+[[ $? == 2 ]] && ok "no argument is a usage error (exit 2)" || fail "no argument should exit 2"
+
+"$ADVANCE" tactic-a tactic-b >/dev/null 2>&1
+[[ $? == 2 ]] && ok "two arguments are a usage error (exit 2)" || fail "two arguments should exit 2"
+
+"$ADVANCE" "Tactic_Bad Id" >/dev/null 2>&1
+[[ $? == 2 ]] && ok "malformed node id is rejected before any work (exit 2)" \
+  || fail "malformed node id should exit 2"
+
+# An id the slug regex rejects must never reach a spawn prompt or a worktree
+# path — the same validation dispatch-graph-execute applies.
+"$ADVANCE" "123-legacy-issue-slug" >/dev/null 2>&1
+[[ $? == 2 ]] && ok "numeric-prefixed legacy slug is rejected (exit 2)" \
+  || fail "numeric-prefixed slug should exit 2"
+
+# --- Disposition mapping ---------------------------------------------------
+run_case "launched maps to exit 0" \
+  "$SPEC" "launched tactic-fixture-node /qa-fix" 0 "launched tactic-fixture-node tactic qa"
+
+# The spec handed to dispatch-graph-execute must be <id>:<kind>:<phase>, built
+# from the SELECTOR's answer — never re-derived. A wrong spec would silently run
+# the wrong phase skill.
+if [[ "$(cat "$TMP/exec.args")" == "tactic-fixture-node:tactic:qa" ]]; then
+  ok "the execute spec is <id>:<kind>:<phase> from the selector"
+else
+  fail "expected spec 'tactic-fixture-node:tactic:qa', got '$(cat "$TMP/exec.args")'"
+fi
+
+run_case "conflict-lane is a launch (a session IS running) " \
+  "$SPEC" "conflict-lane tactic-fixture-node" 0 "launched tactic-fixture-node tactic qa /dispatch-conflict"
+
+run_case "waiting maps to idle (exit 10)" \
+  "$SPEC" "waiting tactic-fixture-node" 10 "idle tactic-fixture-node ci-waiting"
+
+run_case "skipped maps to idle (exit 10)" \
+  "$SPEC" "skipped tactic-fixture-node" 10 "idle tactic-fixture-node stale-selection"
+
+run_case "scope-stale maps to idle (exit 10)" \
+  "$SPEC" "scope-stale tactic-fixture-node" 10 "idle tactic-fixture-node scope-stale-demoted"
+
+run_case "parked maps to throw (exit 11)" \
+  "$SPEC" "parked tactic-fixture-node" 11 "throw tactic-fixture-node parked"
+
+run_case "held maps to throw (exit 11)" \
+  "$SPEC" "held tactic-fixture-node" 11 "throw tactic-fixture-node held"
+
+run_case "failed maps to throw (exit 11)" \
+  "$SPEC" "failed tactic-fixture-node spawn-failed" 11 "throw tactic-fixture-node execute-failed"
+
+# An unrecognized disposition must NOT be read as success. dispatch-graph-execute
+# grows dispositions over time, and a new one falling through to `launched` would
+# make the loop wait forever for a session nobody started.
+run_case "an unknown disposition throws rather than passing (exit 11)" \
+  "$SPEC" "some-new-disposition tactic-fixture-node" 11 "throw tactic-fixture-node execute-failed"
+
+# --- Selection outcomes ----------------------------------------------------
+run_case "an empty selection is idle, not an error (exit 10)" \
+  "empty" "launched tactic-fixture-node /qa-fix" 10 "idle tactic-fixture-node not-selectable"
+
+# A selector line for a DIFFERENT node must not be consumed as this node's
+# directive — the grep is anchored on the id for exactly this reason.
+run_case "a selector line for another node is not consumed (exit 10)" \
+  "node tactic-other-node tactic qa" "launched x /qa-fix" 10 "idle tactic-fixture-node not-selectable"
+
+# --- Claim refusals --------------------------------------------------------
+# A live session registered under the node's worktree name blocks the launch.
+# This is the dispatch/rsi mutual exclusion; nothing may proceed past it.
+cat >"$AGENTS_JSON" <<'JSON'
+[{"pid":999,"id":"aaaa","cwd":"/x","sessionId":"aaaa-1","name":"tactic-fixture-node","status":"busy","state":"working"}]
+JSON
+printf '%s\n' "$SPEC" >"$SELECT_OUT"
+printf 'launched tactic-fixture-node /qa-fix\n' >"$EXEC_OUT"
+rm -f "$DISPATCH_RESERVATION_DIR"/* 2>/dev/null
+OUT=$("$ADVANCE" tactic-fixture-node 2>/dev/null); RC=$?
+if [[ "$RC" == 13 && "$OUT" == "claimed tactic-fixture-node live-session" ]]; then
+  ok "a live session on the node refuses the launch (exit 13)"
+else
+  fail "live-session claim should exit 13 with 'claimed ...', got exit $RC / '$OUT'"
+fi
+echo '[]' >"$AGENTS_JSON"
+
+# An unreleased reservation marker likewise refuses — the boot-window half of
+# the same mutual exclusion.
+printf 'issue=\nsession=someone-else\ntimestamp=1\n' >"$DISPATCH_RESERVATION_DIR/tactic-fixture-node"
+OUT=$("$ADVANCE" tactic-fixture-node 2>/dev/null); RC=$?
+if [[ "$RC" == 13 && "$OUT" == claimed\ tactic-fixture-node\ reservation:* ]]; then
+  ok "an existing reservation marker refuses the launch (exit 13)"
+else
+  fail "reservation claim should exit 13 with 'claimed ... reservation:', got exit $RC / '$OUT'"
+fi
+rm -f "$DISPATCH_RESERVATION_DIR"/*
+
+# --- The claim is written BEFORE the spawn ---------------------------------
+# The marker must exist by the time dispatch-graph-execute runs, or the boot
+# window is unguarded and a concurrent tick can select the same node.
+cat >"$DISPATCH/dispatch-graph-execute" <<STUB
+#!/usr/bin/env bash
+if [[ -f "$DISPATCH_RESERVATION_DIR/tactic-fixture-node" ]]; then
+  echo "MARKER-PRESENT" > "$TMP/marker-check"
+else
+  echo "MARKER-ABSENT" > "$TMP/marker-check"
+fi
+echo "launched tactic-fixture-node /qa-fix"
+STUB
+chmod +x "$DISPATCH/dispatch-graph-execute"
+printf '%s\n' "$SPEC" >"$SELECT_OUT"
+"$ADVANCE" tactic-fixture-node >/dev/null 2>&1
+if [[ "$(cat "$TMP/marker-check" 2>/dev/null)" == "MARKER-PRESENT" ]]; then
+  ok "the reservation marker is written before dispatch-graph-execute runs"
+else
+  fail "the reservation marker was NOT present when dispatch-graph-execute ran"
+fi
+
+# And it carries origin=explicit — the origin reservation_sweep's TTL rule
+# already reclaims. A marker with no reclaimable origin leaks the slot forever
+# if this script dies before the worker registers.
+if grep -qx 'origin=explicit' "$DISPATCH_RESERVATION_DIR/tactic-fixture-node" 2>/dev/null; then
+  ok "the reservation marker carries origin=explicit (sweep-reclaimable)"
+else
+  fail "the reservation marker should carry origin=explicit; got: $(cat "$DISPATCH_RESERVATION_DIR/tactic-fixture-node" 2>/dev/null)"
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+(( FAIL == 0 )) || exit 1

--- a/.claude/skills/rsi/scripts/test-rsi-await.sh
+++ b/.claude/skills/rsi/scripts/test-rsi-await.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Unit tests for rsi-await — the wait-and-verify half of the rsi-implement loop.
+#
+# Two things are worth testing and both are invisible in production until they
+# are wrong:
+#
+#   1. SESSION-STATE CLASSIFICATION. A reaped session and a held one look
+#      similar in the registry and mean opposite things — one is a clean
+#      completion, the other is a stuck worker holding a slot and blocking the
+#      node. Collapsing them would make the loop step over a stuck phase.
+#   2. GRAPH-VERDICT PRECEDENCE. An absent node satisfies `.phase != <from>`, so
+#      a pruned node and an advanced node are indistinguishable unless absence
+#      is checked FIRST; a parked node may also have advanced, so the park must
+#      outrank the phase change. Both orderings are asserted here, because
+#      getting them backwards produces a plausible-looking wrong answer rather
+#      than an error.
+#
+# The Claude registry and verify-landed are both stubbed — no daemon, no
+# network, no gh. Polling is driven at --poll-s 1 so the suite runs in seconds.
+#
+# Runs from anywhere; creates and removes its own temp tree.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+PASS=0
+FAIL=0
+fail() { printf 'FAIL: %s\n' "$1" >&2; FAIL=$((FAIL + 1)); }
+ok()   { printf 'ok: %s\n' "$1"; PASS=$((PASS + 1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- Fixture ---------------------------------------------------------------
+PROJECT="$TMP/project"
+RSI_SCRIPTS="$PROJECT/.claude/skills/rsi/scripts"
+DISPATCH="$PROJECT/.claude/skills/dispatch-propagate/scripts"
+IUTIL="$PROJECT/packages/intentionsutil/scripts"
+mkdir -p "$RSI_SCRIPTS" "$DISPATCH" "$IUTIL"
+
+cp "$SCRIPT_DIR/rsi-await" "$RSI_SCRIPTS/rsi-await"
+chmod +x "$RSI_SCRIPTS/rsi-await"
+for lib in lib-claude-agents.sh lib-reservation-ledger.sh lib-graph-worktree.sh lib.sh; do
+  src="$SCRIPT_DIR/../../dispatch-propagate/scripts/$lib"
+  [[ -f "$src" ]] && cp "$src" "$DISPATCH/$lib"
+done
+
+AWAIT="$RSI_SCRIPTS/rsi-await"
+export DISPATCH_GRAPH_MAIN_WORKTREE="$PROJECT"
+
+# See test-rsi-advance.sh: the empty-read corroboration needs a visible daemon,
+# and CI has none. Stub the probe so the suite does not depend on whether a real
+# Claude daemon happens to be running on the host.
+PGREP_STUB="$TMP/pgrep-stub"
+printf '#!/usr/bin/env bash\nexit 0\n' >"$PGREP_STUB"
+chmod +x "$PGREP_STUB"
+export CLAUDE_AGENTS_PGREP_CMD="$PGREP_STUB"
+
+# --- Stubs -----------------------------------------------------------------
+# The registry. Each case writes the JSON it wants observed.
+AGENTS_JSON="$TMP/agents.json"
+echo '[]' >"$AGENTS_JSON"
+CLAUDE_STUB="$TMP/claude-stub"
+cat >"$CLAUDE_STUB" <<STUB
+#!/usr/bin/env bash
+cat "$AGENTS_JSON"
+STUB
+chmod +x "$CLAUDE_STUB"
+export CLAUDE_AGENTS_CMD="$CLAUDE_STUB"
+
+# verify-landed. Its three answers (0 landed / 4 not-landed / 1 unknown) are
+# what rsi-await maps, so the stub is keyed on the spec it is asked about: each
+# case writes the exit code it wants for `absent`, `office_hours`, `blocked_by`,
+# and `phase`.
+RC_ABSENT="$TMP/rc.absent"; RC_PARKED="$TMP/rc.parked"
+RC_BLOCKED="$TMP/rc.blocked"; RC_PHASE="$TMP/rc.phase"
+cat >"$IUTIL/verify-landed" <<STUB
+#!/usr/bin/env bash
+args="\$*"
+case "\$args" in
+  *"--blob absent"*)   exit "\$(cat "$RC_ABSENT")" ;;
+  *office_hours*)      exit "\$(cat "$RC_PARKED")" ;;
+  *blocked_by*)        exit "\$(cat "$RC_BLOCKED")" ;;
+  *.phase*)            exit "\$(cat "$RC_PHASE")" ;;
+esac
+exit 1
+STUB
+chmod +x "$IUTIL/verify-landed"
+
+set_graph() { # <absent-rc> <parked-rc> <blocked-rc> <phase-rc>
+  echo "$1" >"$RC_ABSENT"; echo "$2" >"$RC_PARKED"
+  echo "$3" >"$RC_BLOCKED"; echo "$4" >"$RC_PHASE"
+}
+# The ordinary "present, unparked, unblocked, still at <from>" graph.
+set_graph 4 4 4 4
+
+session_rows() { printf '%s\n' "$1" >"$AGENTS_JSON"; }
+
+NODE=tactic-fixture-node
+REAPED='[]'
+WORKING='[{"pid":1,"id":"a","cwd":"/x","sessionId":"a-1","name":"tactic-fixture-node","status":"busy","state":"working"}]'
+HELD='[{"pid":1,"id":"a","cwd":"/x","sessionId":"a-1","name":"tactic-fixture-node","status":"idle","state":"done"}]'
+
+run_await() { # <want-exit> <want-stdout-prefix> <label> [extra args...]
+  local want_rc="$1" want_out="$2" label="$3"; shift 3
+  local out rc
+  # --boot-grace-s 1: every reaped-session case below has no worker to register,
+  # so the full grace would be spent waiting for one that never comes. The grace
+  # itself is exercised by its own case at the end.
+  out=$("$AWAIT" "$NODE" qa --poll-s 1 --boot-grace-s 1 "$@" 2>/dev/null)
+  rc=$?
+  if [[ "$rc" != "$want_rc" ]]; then
+    fail "$label — expected exit $want_rc, got $rc (stdout: $out)"; return
+  fi
+  if [[ "$out" != "$want_out"* ]]; then
+    fail "$label — expected stdout starting '$want_out', got '$out'"; return
+  fi
+  ok "$label (exit=$rc, '$out')"
+}
+
+# --- Usage -----------------------------------------------------------------
+"$AWAIT" >/dev/null 2>&1
+[[ $? == 2 ]] && ok "no arguments is a usage error (exit 2)" || fail "no arguments should exit 2"
+
+"$AWAIT" "$NODE" >/dev/null 2>&1
+[[ $? == 2 ]] && ok "a missing from-phase is a usage error (exit 2)" || fail "missing from-phase should exit 2"
+
+"$AWAIT" "Bad Id" qa >/dev/null 2>&1
+[[ $? == 2 ]] && ok "malformed node id is rejected (exit 2)" || fail "malformed node id should exit 2"
+
+"$AWAIT" "$NODE" qa --poll-s 0 >/dev/null 2>&1
+[[ $? == 2 ]] && ok "--poll-s 0 is rejected (it would spin) (exit 2)" || fail "--poll-s 0 should exit 2"
+
+# --- Reaped session: the graph decides -------------------------------------
+session_rows "$REAPED"
+
+# `--blob absent` satisfied means the node was pruned. Checked FIRST on purpose:
+# an absent node ALSO satisfies `.phase != qa`, so a phase-first ordering would
+# report a pruned node as merely advanced.
+set_graph 0 4 4 4
+run_await 0 "pruned $NODE" "an absent node is reported pruned, not advanced"
+
+set_graph 4 0 4 4
+run_await 11 "throw $NODE parked" "a parked node throws (exit 11)"
+
+# The park outranks a phase change: a phase worker can advance the node AND park
+# it in the same pass, and the park is the part that needs a human.
+set_graph 4 0 4 0
+run_await 11 "throw $NODE parked" "a park outranks an advance"
+
+set_graph 4 4 0 4
+run_await 11 "throw $NODE blocked-by" "a blocked_by edge throws (exit 11)"
+
+set_graph 4 4 4 0
+run_await 0 "advanced $NODE qa" "a phase change is reported advanced (exit 0)"
+
+set_graph 4 4 4 4
+run_await 12 "stalled $NODE qa" "a stopped worker with no graph change is stalled (exit 12)"
+
+# verify-landed's third answer must never collapse into one of the other two —
+# claiming `advanced` on an unreadable graph would step the loop forward on no
+# evidence, and claiming `stalled` would trigger a needless re-run.
+set_graph 1 4 4 4
+run_await 14 "throw $NODE unknown-graph-read" "an unreadable graph is unknown, not a verdict (exit 14)"
+
+set_graph 4 4 4 1
+run_await 14 "throw $NODE unknown-graph-read" "an unknown phase read is also exit 14"
+
+# --- Held session ----------------------------------------------------------
+# `state: done` with the row still present means the worker stopped WITHOUT
+# declaring a terminal disposition, so the Stop hook is holding the job alive. It
+# occupies a slot and keeps the node unselectable until a human runs `claude rm`
+# — so it throws even when the graph looks fine.
+session_rows "$HELD"
+set_graph 4 4 4 0
+run_await 11 "throw $NODE held-session" "a done-but-unreaped session throws even when the phase advanced"
+
+set_graph 4 4 4 4
+run_await 11 "throw $NODE held-session" "a held session throws regardless of the graph"
+
+# --- Still working ---------------------------------------------------------
+# A long phase is the expected case, not a failure: the timeout sits under the
+# Bash tool's own ceiling so a caller gets a real answer and calls again.
+session_rows "$WORKING"
+set_graph 4 4 4 4
+run_await 20 "running $NODE qa" "a working session at the timeout is exit 20 (call again)" --timeout-s 2
+
+# --- UNKNOWN liveness is not 'finished', and not a verdict either ----------
+# A registry read that cannot be answered must keep waiting. Treating it as
+# `absent` would send the loop to the next phase while a worker is live — the
+# duplicate-worker hazard the whole claim discipline exists to prevent.
+#
+# The subtle half: when EVERY read fails, the script must not fall through to a
+# graph verdict either. The graph is readable in this case and says "still at
+# qa", so a fall-through would report `stalled` — a real-looking verdict about a
+# worker nothing ever observed. The `set_graph 4 4 4 4` below is what makes the
+# case bite; with a phase change it would pass for the wrong reason.
+cat >"$CLAUDE_STUB" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod +x "$CLAUDE_STUB"
+set_graph 4 4 4 4
+run_await 20 "running $NODE qa" "an all-unknown registry never yields a graph verdict" --timeout-s 2
+
+# --- The boot grace waits for a LATE registration --------------------------
+# The spawn kick returns before the worker registers. If the wait gave up on the
+# first empty read it would consult the graph mid-boot, see no transition, and
+# report `stalled` for a phase that had not started yet — sending the attended
+# thread to debug a worker that was merely slow to boot. Here the registry is
+# empty for the first two reads and then shows a live worker; the correct answer
+# is `running` (it found the session), not `stalled`.
+COUNTER="$TMP/boot-counter"
+echo 0 >"$COUNTER"
+cat >"$CLAUDE_STUB" <<STUB
+#!/usr/bin/env bash
+n=\$(cat "$COUNTER"); echo \$((n + 1)) > "$COUNTER"
+if (( n < 2 )); then echo '[]'; else cat "$AGENTS_JSON"; fi
+STUB
+chmod +x "$CLAUDE_STUB"
+session_rows "$WORKING"
+set_graph 4 4 4 4
+OUT=$("$AWAIT" "$NODE" qa --poll-s 1 --boot-grace-s 10 --timeout-s 6 2>/dev/null); RC=$?
+if [[ "$RC" == 20 && "$OUT" == "running $NODE qa" ]]; then
+  ok "a late-registering worker is found within the boot grace, not called stalled"
+else
+  fail "late registration should exit 20 'running', got exit $RC / '$OUT'"
+fi
+
+"$AWAIT" "$NODE" qa --boot-grace-s x >/dev/null 2>&1
+[[ $? == 2 ]] && ok "a non-integer --boot-grace-s is rejected (exit 2)" \
+  || fail "non-integer --boot-grace-s should exit 2"
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+(( FAIL == 0 )) || exit 1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -260,6 +260,12 @@ jobs:
         run: packages/intentionsutil/scripts/test-graph-commit.sh
       - name: Run verify-landed tests
         run: packages/intentionsutil/scripts/test-verify-landed.sh
+      - name: Run rsi-claim tests
+        run: .claude/skills/rsi/scripts/test-rsi-claim.sh
+      - name: Run rsi-advance tests
+        run: .claude/skills/rsi/scripts/test-rsi-advance.sh
+      - name: Run rsi-await tests
+        run: .claude/skills/rsi/scripts/test-rsi-await.sh
       - name: Run budget-config-load tests
         run: .claude/skills/budget/scripts/test-budget-config-load.sh
       - name: Run write-phase-log tests


### PR DESCRIPTION
R3 of the rsi bootstrap plan (`intentions/tactic-rsi-implement-skill.md`,
`attributes.rsi_cost: 1`). `/rsi` Step 4b said plainly that its execute lane
"is not built yet"; this builds it.

## What it is

Two thin scripts under `.claude/skills/rsi/scripts/`, plus the Step 4b rewrite
that drives them:

- **`rsi-advance <node-id>`** — launch one phase step.
- **`rsi-await <node-id> <from-phase>`** — wait for the worker, then ask
  `origin/main` what actually happened.

The loop alternates them until the node advances out, is pruned, or throws.

## What they decide: nothing about eligibility

That is the design constraint, not an accident.
`strategy-recursive-self-improvement` forbids rsi maintaining a second
orchestration surface, so `rsi-advance` delegates:

- `graph-select-target --node <id>` for the phase directive — read at
  `origin/main` with **every** environmental gate applied verbatim (claim
  safety, the per-phase CI/PR sensor gates, the fix and conflict interrupts).
  Its own header documents `--node` as a selection-*order* override, not a gate
  bypass, which is exactly the property needed here.
- `dispatch-graph-execute <id>:<kind>:<phase>` for the launch — provisioning,
  the phase-skill mapping, the spawn, the reservation handoff, and every
  park/hold disposition.

Everything else in `rsi-advance` is argument marshalling and exit-code mapping.
`rsi-await` likewise takes its verdict from `verify-landed` against
`origin/main`, never from a session's exit status — the
`tactic-graph-commit-landing-signal-unreliable` premise, reused rather than
re-derived.

Neither script merges, writes to the graph, or calls `gh`. The tick's merge
lane runs even while dispatch is paused and it owns every merge.

## Two decisions worth review

**No `--standalone` on the selector.** It would have folded in the lock, the
ledger claim, and the headroom cap — but it also applies the pace curve, and
its header says a `--standalone` caller is treated as unattended. `/rsi` is
attended (strategy condition 9) and pace-exempt (condition 7). Concretely:
rsi's execute lane exists *for* the bootstrap-deadlock case, where dispatch is
paused and the fix is what would unpause it. Under a pause the worker target is
0, so `--standalone` would print `empty` on every call and the lane would be
dead in precisely the situation it was built for. The ledger claim it would
have written is made explicitly instead, with `origin=explicit` — the origin
`dispatch-select-tick`'s own explicit named-node lane uses, so
`reservation_sweep`'s existing TTL rule already reclaims it. No new origin, no
new sweep branch.

**A held session throws even when the graph looks fine.** A worker that stops
without writing a node-terminal marker is kept alive by `dispatch-stop.sh`; its
registry row survives with `state: done` instead of disappearing. It occupies a
worker slot *and* keeps the node unselectable until someone runs `claude rm`, so
it is reported as a throw regardless of whether the phase advanced — with a
note when it did.

## Ordering traps the tests pin

Both produce plausible-looking wrong answers rather than errors:

- An **absent** node satisfies `.phase != <from>`, so absence is checked first —
  otherwise a pruned node reports as merely advanced.
- A **park** outranks a phase change, since a worker can advance a node and park
  it in the same pass, and the park is the half that needs a human.
- An **all-unknown** registry read never yields a graph verdict. Falling through
  would report `stalled` for a worker that was alive and merely invisible —
  the same "trust an unanswerable probe" failure `rsi-claim` refuses to make.

## Tests

`test-rsi-advance.sh` (20) and `test-rsi-await.sh` (18), both stubbing the
Claude registry, `verify-landed`, and the two dispatch siblings — no daemon, no
network, no `gh`.

This also wires **all three** rsi suites into `unit-tests.yml`.
`test-rsi-claim.sh` shipped with R2 in #3065 and was never added, so it has
never run in CI; it passes (11/11).

## Verification

- `test-rsi-advance.sh` 20/20, `test-rsi-await.sh` 18/18, `test-rsi-claim.sh`
  11/11.
- `run-lint.sh`, `run-typecheck.sh`, `run-dead-code.sh` all pass.
- Smoke-tested against the live graph on a born-parked node: `rsi-advance`
  returns exit 10 `idle ... not-selectable` and surfaces the selector's own
  reason, leaking no reservation marker; `rsi-await` returns exit 11
  `throw ... parked` from a real `verify-landed` read of `origin/main`. Neither
  launched anything.

Driving a node end-to-end through the loop is a separate cost-1 rsi task, not
this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
