### PR TITLE
Extract the dispatch-emulation loop into /dispatch-emulate

### DIFF
--- a/.claude/skills/dispatch-emulate/SKILL.md
+++ b/.claude/skills/dispatch-emulate/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: dispatch-emulate
+description: Drive ONE tactic node through the real dispatch phase ladder by hand, one phase at a time, as spawned sessions reusing the dispatch phase skills verbatim — for when the dispatch tick structurally cannot reach the node.
+user-invocable: true
+---
+
+# Dispatch Emulate
+
+Emulate one dispatch tick's worth of work per phase, for a single node, serially,
+until it leaves the ladder. Each phase runs as a real spawned session running the
+real dispatch phase skill — nothing here re-implements a phase.
+
+The dispatch router normally owns this. `/dispatch-emulate` is for when it cannot
+reach the node — dispatch is paused and the fix is what would unpause it, or any
+other bootstrap deadlock the tick has no route into — or when the author wants
+one node driven under supervision.
+
+The loop is attended because its callers are — invoked directly by an author, or
+by `/rsi`'s execute step. It has no attended or pace-exempt status of its own.
+
+## What this is not
+
+Not a scheduler, not a selector, not a second orchestration surface. Every
+eligibility question belongs to the selector; the two scripts decide nothing.
+
+- `dispatch-emulate-advance` takes the phase directive from
+  `graph-select-target --node <id>`, read at `origin/main` with **every**
+  environmental gate applied — claim safety, the per-phase CI/PR sensor gates,
+  the fix and conflict interrupts. `--node` is a selection-**order** override,
+  not a gate bypass.
+- It hands the launch to `dispatch-graph-execute`, which owns provisioning, the
+  phase-skill mapping, the spawn, the reservation handoff, and every park/hold
+  disposition.
+- `dispatch-emulate-await` takes its verdict from `verify-landed` against
+  `origin/main`, never from a session's exit status.
+
+**If a rule about when a node may run ever appears in these scripts, it is in the
+wrong place.**
+
+## Argument
+
+`/dispatch-emulate <node-id>` — one **tactic** id.
+
+A strategy id is refused: `dispatch-emulate-advance` gates on the selector's own
+`kind` and prints `refused <id> strategy`, exit **2**. An `/align-tactics` pass on
+a strategy decomposes it into child tactic ids rather than advancing the strategy
+itself, so there is no single node for the loop to follow. Run `/align-tactics
+<strategy-id>` directly, then invoke this on a child tactic.
+
+A tactic whose selector rung is `align-tactics` — a draft, raw or frozen tactic —
+is a legitimate starting point: `/align-tactics <tactic-id>` finalizes that same
+node in place, so the loop launches it normally.
+
+## The ladder
+
+The phase → skill map is `dispatch-graph-execute`'s, read from the persisted
+phase and never re-derived:
+
+| phase | skill |
+| --- | --- |
+| `align-tactics` | `/align-tactics` |
+| `implement` | `/implement` |
+| `fix` | `/fix-checks` |
+| `conflict` | `/dispatch-conflict` |
+| `review` | `/review-fix` |
+| `qa` | `/qa-fix` |
+| `main-qa` | `/qa-main` |
+
+`fix` and `conflict` are **interrupts** the selector injects, not rungs the caller
+schedules. The loop starts wherever the node's persisted phase says, and each
+`dispatch-emulate-advance` re-reads that phase from `origin/main` — nothing is
+threaded between iterations.
+
+## The loop
+
+```bash
+.claude/skills/dispatch-emulate/scripts/dispatch-emulate-advance <node-id>          # launch one phase
+.claude/skills/dispatch-emulate/scripts/dispatch-emulate-await   <node-id> <phase>  # wait, then verify
+```
+
+Both need `dangerouslyDisableSandbox: true` (gh, the Claude daemon Unix socket,
+git, direnv — `.claude/rules/sandbox.md`). `dispatch-emulate-advance` prints
+`launched <id> <kind> <phase> <skill>`; hand that `<phase>` to
+`dispatch-emulate-await` as the from-phase.
+
+1. `dispatch-emulate-advance <id>`. Exit **0** (`launched`) means a session is
+   running — go to 2. Exit **10** (`idle`) means there is nothing to launch — not
+   selectable, ci-waiting, stale-selection, or scope-stale-demoted; stop the loop
+   and read its stderr event lines. Exit **11** (`throw`) — go to step 5. Exit
+   **13** (`claimed`) means a live session or an unreclaimed reservation marker
+   holds the node; **stop**, and never work around it. Exit **2** is a usage
+   error or the strategy refusal above.
+2. `dispatch-emulate-await <id> <phase>`. Exit **20** (`running`) means still
+   working — this is the **expected** result for any phase longer than the 540s
+   `--timeout-s` window; call it again with identical arguments, as many times as
+   it takes. Exit **0** means the node `advanced`, or was `pruned` and the loop is
+   done. Exit **11** (`throw`: parked, blocked-by, or a held session), **12**
+   (`stalled`), and **14** (`unknown-graph-read`) go to step 5.
+3. On exit 0, return to 1.
+4. Stop when advance reports `idle` or await reports `pruned`. A node that reaches
+   `main-qa` and merges leaves through `idle` — the tick's merge lane, not this
+   loop, finishes it.
+5. On any throw: **do not push through and do not retry blindly.** Stop the loop,
+   report, and conduct the engagement in the calling thread, attended. A `stalled`
+   (12) means the worker stopped having changed nothing — read its transcript
+   before re-running.
+
+## Three rules, none negotiable
+
+- **Never hand-merge.** The tick's merge lane runs even while dispatch is paused.
+  Let it. Neither script makes a merge, a graph write, or a `gh` call.
+- **Never run a phase skill in an Agent-tool subagent.** `/qa-fix`, `/review-fix`
+  and `/align-tactics` depend on the Workflow tool, which a subagent cannot use.
+  They must be spawned sessions — which is what `dispatch-graph-execute` does.
+- **Never work a node dispatch is working.** Exit 13 is the mutual exclusion, not
+  an obstacle to route around.
+
+## Report
+
+On exit, state: the node and the phases it traversed this run; the terminal
+disposition and which script produced it; what landed at `origin/main` (commits,
+PR); and what a next invocation would pick up.

--- a/.claude/skills/dispatch-emulate/scripts/dispatch-emulate-advance
+++ b/.claude/skills/dispatch-emulate/scripts/dispatch-emulate-advance
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-# rsi-advance — kick ONE phase step of ONE node, through the dispatch lane.
+# dispatch-emulate-advance — kick ONE phase step of ONE node, through the
+# dispatch lane.
 #
-# Half of the rsi-implement loop (`intentions/tactic-rsi-implement-skill.md`).
-# `rsi-advance` launches a phase; `rsi-await` waits for it and verifies the
-# transition off `origin/main`. The /rsi skill alternates them until the node
-# is done or throws.
+# Half of the dispatch-emulation loop; built by
+# `intentions/tactic-rsi-implement-skill.md`.
+# `dispatch-emulate-advance` launches a phase; `dispatch-emulate-await` waits
+# for it and verifies the transition off `origin/main`. The
+# `/dispatch-emulate` loop alternates them until the node is done or throws.
 #
 # WHAT THIS IS NOT. It is not a scheduler, not a selector, and not a second
 # orchestration surface — `strategy-recursive-self-improvement`'s standing
@@ -30,16 +32,20 @@
 # NO --standalone, DELIBERATELY. `graph-select-target --standalone` would fold
 # in the lock, the ledger claim, and the headroom cap — but it also applies the
 # pace curve, and its header says so plainly: a --standalone caller is treated
-# as unattended and degrades to `empty` at the ceiling. /rsi is attended
-# (strategy condition 9) and pace-exempt (condition 7 — "the budget and the
-# serialization are the throttle, not the pace curve"). More concretely: rsi's
-# execute lane exists FOR the bootstrap-deadlock case, where dispatch is paused
-# and the fix is what would unpause it. Under a pause the worker target is 0,
-# so --standalone would print `empty` on every call and the lane would be dead
-# in precisely the situation it was built for. The ledger claim --standalone
+# as unattended and degrades to `empty` at the ceiling. This script has no
+# attended/pace-exempt status of its own — that property belongs to its
+# caller. `/rsi` is attended (strategy-recursive-self-improvement condition 9)
+# and pace-exempt (condition 7 — "the budget and the serialization are the
+# throttle, not the pace curve"), and `/dispatch-emulate` inherits both from
+# whichever attended thread invokes it. More concretely: the execute lane
+# exists FOR the bootstrap-deadlock case, where dispatch is paused and the fix
+# is what would unpause it. Under a pause the worker target is 0, so
+# --standalone would print `empty` on every call and the lane would be dead in
+# precisely the situation it was built for. The ledger claim --standalone
 # would have written is made explicitly below instead.
 #
-# CLAIM DISCIPLINE. A node must never be worked by dispatch and rsi at once.
+# CLAIM DISCIPLINE. A node must never be worked by dispatch and
+# dispatch-emulate at once.
 # Three things enforce that, none of them new:
 #   1. The pre-launch refusal below — `worktree_has_live_session`, fail-safe
 #      (unknown counts as occupied), plus an existing reservation marker.
@@ -54,25 +60,34 @@
 #      live session registers. From that moment the worktree IS the claim and
 #      graph-select-target skips the node for the router.
 #
-# Usage: rsi-advance <node-id>
+# Usage: dispatch-emulate-advance <node-id>
 #
 # Stdout, one line:
-#   launched <id> <kind> <phase> <skill>   a session is running; call rsi-await
-#                                          with <phase> as the from-phase.
+#   launched <id> <kind> <phase> <skill>   a session is running; call
+#                                          dispatch-emulate-await with <phase>
+#                                          as the from-phase.
 #   idle <id> <reason>                     nothing to launch right now.
 #   throw <id> <reason>                    the node needs the attended thread.
 #   claimed <id> <holder>                  another session holds it.
+#   refused <id> strategy                  <id> is a strategy; run
+#                                          /align-tactics on it directly
+#                                          instead — see exit code 2.
 #
 # Exit codes:
 #   0   launched — a phase session is running.
 #   10  idle: not selectable, ci-waiting, stale-selection, or scope-stale. Not
 #       an error; the loop stops or retries later. The graph-select-target
 #       event lines on stderr say which.
-#   11  throw: parked, held, or a failed launch. The /rsi main thread conducts
-#       the office-hours engagement — this script never pushes through one.
+#   11  throw: parked, held, or a failed launch. The calling thread
+#       (`/dispatch-emulate`, invoked directly or by `/rsi`) conducts the
+#       office-hours engagement — this script never pushes through one.
 #   13  claimed: a live session or an unreclaimed marker holds the node.
-#       NEVER proceed past this; it is the dispatch/rsi mutual exclusion.
-#   2   usage or environment error.
+#       NEVER proceed past this; it is the dispatch/dispatch-emulate mutual
+#       exclusion.
+#   2   usage or environment error, OR the node is a strategy (`refused <id>
+#       strategy`) — /align-tactics decomposes a strategy into child tactic
+#       ids rather than advancing it, so this loop has no single node to
+#       follow; run /align-tactics <id> directly instead.
 #
 # Requires `dangerouslyDisableSandbox: true`: the selector's sensor gates call
 # `gh`, the liveness read reaches the Claude daemon over a Unix socket, and
@@ -83,7 +98,8 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-# .claude/skills/rsi/scripts → the checkout root is four levels up. Used only to
+# .claude/skills/dispatch-emulate/scripts → the checkout root is four levels
+# up. Used only to
 # locate sibling scripts and libraries; the PROJECT root is resolved from git
 # below, because this checkout may itself be a worktree.
 CHECKOUT_ROOT="$(cd -- "$SCRIPT_DIR/../../../.." && pwd)"
@@ -97,7 +113,7 @@ source "$DISPATCH_SCRIPTS/lib-reservation-ledger.sh"
 source "$DISPATCH_SCRIPTS/lib-graph-worktree.sh"
 
 if [[ $# -ne 1 ]]; then
-  echo "usage: rsi-advance <node-id>" >&2
+  echo "usage: dispatch-emulate-advance <node-id>" >&2
   exit 2
 fi
 
@@ -106,13 +122,13 @@ NODE_ID="$1"
 # Validate before the id reaches a spawn prompt or a worktree path — the same
 # slug regex dispatch-graph-execute and provision-node-worktree apply.
 if [[ ! "$NODE_ID" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]]; then
-  echo "rsi-advance: invalid node id '$NODE_ID'" >&2
+  echo "dispatch-emulate-advance: invalid node id '$NODE_ID'" >&2
   exit 2
 fi
 
 PROJECT_ROOT=$(resolve_main_worktree 2>/dev/null)
 if [[ -z "$PROJECT_ROOT" || ! -d "$PROJECT_ROOT" ]]; then
-  echo "rsi-advance: cannot resolve the project root (no worktree with 'main' checked out)" >&2
+  echo "dispatch-emulate-advance: cannot resolve the project root (no worktree with 'main' checked out)" >&2
   exit 2
 fi
 
@@ -120,39 +136,39 @@ fi
 # stale remote-tracking ref would let this launch a phase the graph has already
 # advanced past.
 if ! git -C "$PROJECT_ROOT" fetch origin main --quiet 1>&2; then
-  echo "rsi-advance: git fetch origin main failed; refusing to act on unverified graph state" >&2
+  echo "dispatch-emulate-advance: git fetch origin main failed; refusing to act on unverified graph state" >&2
   exit 2
 fi
 
 # --- Claim safety ----------------------------------------------------------
 # Checked HERE as well as inside the selector, for the message: the selector
 # folds a claimed node into a bare `empty`, and "another session is working
-# this node" is the one disposition the rsi loop must never mistake for
+# this node" is the one disposition the dispatch-emulate loop must never mistake for
 # "nothing to do".
 NODE_WT="$PROJECT_ROOT/.claude/worktrees/$NODE_ID"
 if worktree_has_live_session "$NODE_WT"; then
   echo "claimed $NODE_ID live-session"
-  echo "rsi-advance: REFUSED — a live session is registered on $NODE_WT (or the liveness probe could not answer, which counts as occupied)." >&2
-  echo "rsi-advance: a node is never worked by dispatch and rsi at once. Wait for that session, or release a terminal holder with 'claude rm <session-id>'." >&2
+  echo "dispatch-emulate-advance: REFUSED — a live session is registered on $NODE_WT (or the liveness probe could not answer, which counts as occupied)." >&2
+  echo "dispatch-emulate-advance: a node is never worked by dispatch and dispatch-emulate at once. Wait for that session, or release a terminal holder with 'claude rm <session-id>'." >&2
   exit 13
 fi
 
 if reservation_exists "$NODE_ID"; then
   RES_OWNER=$(reservation_owner "$NODE_ID" 2>/dev/null || echo "unknown")
   echo "claimed $NODE_ID reservation:$RES_OWNER"
-  echo "rsi-advance: REFUSED — an unreleased reservation-ledger marker claims $NODE_ID (owner $RES_OWNER)." >&2
-  echo "rsi-advance: if that claim is stale, reservation_sweep reclaims it on the next dispatch heartbeat; do not clear it by hand while a worker may still be booting." >&2
+  echo "dispatch-emulate-advance: REFUSED — an unreleased reservation-ledger marker claims $NODE_ID (owner $RES_OWNER)." >&2
+  echo "dispatch-emulate-advance: if that claim is stale, reservation_sweep reclaims it on the next dispatch heartbeat; do not clear it by hand while a worker may still be booting." >&2
   exit 13
 fi
 
 # --- Selection: the directive, with every gate applied ---------------------
 # stderr flows through — its event lines are the record of WHY a node was not
-# selectable, and the rsi main thread reads them.
+# selectable, and the calling thread reads them.
 SELECTION=$("$DISPATCH_SCRIPTS/graph-select-target" --node "$NODE_ID")
 select_rc=$?
 if (( select_rc != 0 )); then
   echo "throw $NODE_ID selector-failed"
-  echo "rsi-advance: graph-select-target exited $select_rc for $NODE_ID" >&2
+  echo "dispatch-emulate-advance: graph-select-target exited $select_rc for $NODE_ID" >&2
   exit 11
 fi
 
@@ -160,15 +176,29 @@ fi
 SPEC_LINE=$(grep -E "^node ${NODE_ID} " <<<"$SELECTION" | head -n1)
 if [[ -z "$SPEC_LINE" ]]; then
   echo "idle $NODE_ID not-selectable"
-  echo "rsi-advance: graph-select-target selected nothing for $NODE_ID — the event lines above name the gate that held it (phase null with no align route, a CI verdict still pending, a park, a blocked_by edge, a stale strategy fingerprint)." >&2
+  echo "dispatch-emulate-advance: graph-select-target selected nothing for $NODE_ID — the event lines above name the gate that held it (phase null with no align route, a CI verdict still pending, a park, a blocked_by edge, a stale strategy fingerprint)." >&2
   exit 10
 fi
 
 read -r _ _ KIND PHASE <<<"$SPEC_LINE"
 if [[ -z "$KIND" || -z "$PHASE" ]]; then
   echo "throw $NODE_ID malformed-selection"
-  echo "rsi-advance: could not parse the selector line '$SPEC_LINE'" >&2
+  echo "dispatch-emulate-advance: could not parse the selector line '$SPEC_LINE'" >&2
   exit 11
+fi
+
+# A strategy is refused, never launched: /align-tactics on a strategy
+# decomposes it into CHILD tactic ids rather than advancing the strategy
+# itself up the ladder, so "follow this node to main-qa" has no single node
+# for the loop to follow. Gate on $KIND from the selector's own answer, never
+# a re-derived kind lookup — and gate on kind only, never phase, so a tactic
+# whose selector rung is align-tactics (a draft/raw/frozen tactic starting
+# its own finalize pass) still launches normally.
+if [[ "$KIND" == "strategy" ]]; then
+  echo "refused $NODE_ID strategy"
+  echo "dispatch-emulate-advance: REFUSED — $NODE_ID is a strategy; an /align-tactics pass on a strategy decomposes it into child tactic ids rather than advancing the strategy itself up the ladder, so there is no single node for this loop to follow." >&2
+  echo "dispatch-emulate-advance: run /align-tactics $NODE_ID directly, then /dispatch-emulate <child-tactic-id> on the tactic it produces." >&2
+  exit 2
 fi
 
 # --- Claim, then execute ---------------------------------------------------
@@ -187,7 +217,7 @@ fi
 # to close.
 if ! reservation_write "$NODE_ID" "$NODE_ID" "${CLAUDE_CODE_SESSION_ID:-rsi}" explicit; then
   echo "throw $NODE_ID reservation-write-failed"
-  echo "rsi-advance: could not write the reservation marker for $NODE_ID; refusing to spawn a worker whose claim is unrecorded (a concurrent dispatch tick could select the same node)." >&2
+  echo "dispatch-emulate-advance: could not write the reservation marker for $NODE_ID; refusing to spawn a worker whose claim is unrecorded (a concurrent dispatch tick could select the same node)." >&2
   exit 11
 fi
 
@@ -207,7 +237,7 @@ case "$DISPOSITION" in
     # declares its own terminal disposition on both of its exit paths. The
     # from-phase reported is the node's ladder phase: Lane 3 resolves the
     # conflict and the node re-enters at that phase, so a plain phase-changed
-    # check would read as `stalled`. rsi-await's absent/park checks still fire,
+    # check would read as `stalled`. dispatch-emulate-await's absent/park checks still fire,
     # and the attended thread reads the lane's own report.
     echo "launched $NODE_ID $KIND $PHASE /dispatch-conflict"
     exit 0
@@ -237,7 +267,7 @@ case "$DISPOSITION" in
   failed|*)
     reservation_clear "$NODE_ID" || true
     echo "throw $NODE_ID execute-failed"
-    echo "rsi-advance: dispatch-graph-execute exited $exec_rc with '$EXEC_OUT'" >&2
+    echo "dispatch-emulate-advance: dispatch-graph-execute exited $exec_rc with '$EXEC_OUT'" >&2
     exit 11
     ;;
 esac

--- a/.claude/skills/dispatch-emulate/scripts/dispatch-emulate-await
+++ b/.claude/skills/dispatch-emulate/scripts/dispatch-emulate-await
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
-# rsi-await — wait for one node's phase session to finish, then ask origin/main
-# what actually happened.
+# dispatch-emulate-await — wait for one node's phase session to finish, then
+# ask origin/main what actually happened.
 #
-# The other half of the rsi-implement loop (`intentions/tactic-rsi-implement-skill.md`);
-# `rsi-advance` launches, this waits and verifies. It makes no graph writes, no
-# merges, and no decisions — it reports one of five outcomes and lets the /rsi
-# main thread judge.
+# The other half of the dispatch-emulation loop (built by
+# `intentions/tactic-rsi-implement-skill.md`); `dispatch-emulate-advance`
+# launches, this waits and verifies. It makes no graph writes, no merges, and
+# no decisions — it reports one of five outcomes and lets the calling thread
+# (`/dispatch-emulate`, invoked directly or by `/rsi`) judge.
 #
 # NEVER MERGES. The tick's merge lane runs even while dispatch is paused and it
 # owns every merge (strategy condition, and the node's own plan). A wait loop is
@@ -54,11 +55,12 @@
 # treated as "still running" and keeps polling — never as "finished", which
 # would send the loop on to the next phase while a worker is live.
 #
-# Usage: rsi-await <node-id> <from-phase>
+# Usage: dispatch-emulate-await <node-id> <from-phase>
 #                  [--timeout-s <n>] [--poll-s <n>] [--boot-grace-s <n>]
 #
-#   <from-phase>       the phase rsi-advance printed. The transition check asks
-#                      whether the node has moved off it.
+#   <from-phase>       the phase dispatch-emulate-advance printed. The
+#                      transition check asks whether the node has moved off
+#                      it.
 #   --timeout-s <n>    give up waiting after n seconds (default 540). The
 #                      default sits under the Bash tool's 600s ceiling on
 #                      purpose, so a call from a Claude session returns a real
@@ -81,7 +83,8 @@
 # Exit codes:
 #   0   advanced or pruned — the loop may take another step.
 #   11  throw: the node is parked, or a session is held un-reaped. Both need the
-#       attended /rsi thread; neither is retried here.
+#       calling thread (`/dispatch-emulate`, invoked directly or by `/rsi`);
+#       neither is retried here.
 #   12  stalled: the session ended with no graph change. Needs judgment — it is
 #       the shape a silently-failed phase takes, and retrying blindly would
 #       spend budget on a repeat.
@@ -114,7 +117,7 @@ NODE_ID=""
 FROM_PHASE=""
 
 usage() {
-  echo "usage: rsi-await <node-id> <from-phase> [--timeout-s <n>] [--poll-s <n>] [--boot-grace-s <n>]" >&2
+  echo "usage: dispatch-emulate-await <node-id> <from-phase> [--timeout-s <n>] [--poll-s <n>] [--boot-grace-s <n>]" >&2
   exit 2
 }
 
@@ -123,11 +126,11 @@ while [[ $# -gt 0 ]]; do
     --timeout-s)    [[ $# -ge 2 ]] || usage; TIMEOUT_S="$2"; shift 2 ;;
     --poll-s)       [[ $# -ge 2 ]] || usage; POLL_S="$2"; shift 2 ;;
     --boot-grace-s) [[ $# -ge 2 ]] || usage; BOOT_GRACE_S="$2"; shift 2 ;;
-    --*)            echo "rsi-await: unknown flag $1" >&2; usage ;;
+    --*)            echo "dispatch-emulate-await: unknown flag $1" >&2; usage ;;
     *)
       if [[ -z "$NODE_ID" ]]; then NODE_ID="$1"
       elif [[ -z "$FROM_PHASE" ]]; then FROM_PHASE="$1"
-      else echo "rsi-await: unexpected argument $1" >&2; usage
+      else echo "dispatch-emulate-await: unexpected argument $1" >&2; usage
       fi
       shift ;;
   esac
@@ -135,19 +138,19 @@ done
 
 [[ -n "$NODE_ID" && -n "$FROM_PHASE" ]] || usage
 [[ "$NODE_ID" =~ ^[a-z][a-z0-9]*(-[a-z0-9]+)*$ ]] || {
-  echo "rsi-await: invalid node id '$NODE_ID'" >&2; exit 2; }
+  echo "dispatch-emulate-await: invalid node id '$NODE_ID'" >&2; exit 2; }
 [[ "$TIMEOUT_S" =~ ^[0-9]+$ && "$BOOT_GRACE_S" =~ ^[0-9]+$ && "$POLL_S" =~ ^[1-9][0-9]*$ ]] || {
-  echo "rsi-await: --timeout-s, --poll-s and --boot-grace-s must be integers (--poll-s positive)" >&2; exit 2; }
+  echo "dispatch-emulate-await: --timeout-s, --poll-s and --boot-grace-s must be integers (--poll-s positive)" >&2; exit 2; }
 
 PROJECT_ROOT=$(resolve_main_worktree 2>/dev/null)
 if [[ -z "$PROJECT_ROOT" || ! -d "$PROJECT_ROOT" ]]; then
-  echo "rsi-await: cannot resolve the project root (no worktree with 'main' checked out)" >&2
+  echo "dispatch-emulate-await: cannot resolve the project root (no worktree with 'main' checked out)" >&2
   exit 2
 fi
 
 VERIFY_LANDED="$PROJECT_ROOT/packages/intentionsutil/scripts/verify-landed"
 [[ -x "$VERIFY_LANDED" ]] || {
-  echo "rsi-await: verify-landed not found or not executable at $VERIFY_LANDED" >&2; exit 2; }
+  echo "dispatch-emulate-await: verify-landed not found or not executable at $VERIFY_LANDED" >&2; exit 2; }
 
 # --- Session state ---------------------------------------------------------
 # Echoes one of: working | done-held | absent | unknown.
@@ -221,26 +224,26 @@ report_graph_verdict() { # <session-note>
   case "$verdict" in
     pruned)
       echo "pruned $NODE_ID"
-      echo "rsi-await: $NODE_ID is absent from origin/main — it completed and was pruned ($note)." >&2
+      echo "dispatch-emulate-await: $NODE_ID is absent from origin/main — it completed and was pruned ($note)." >&2
       exit 0 ;;
     parked)
       echo "throw $NODE_ID parked"
-      echo "rsi-await: $NODE_ID carries office_hours at origin/main ($note). The attended /rsi thread conducts the engagement; this script never clears a park." >&2
+      echo "dispatch-emulate-await: $NODE_ID carries office_hours at origin/main ($note). The calling thread (/dispatch-emulate, invoked directly or by /rsi) conducts the engagement; this script never clears a park." >&2
       exit 11 ;;
     blocked)
       echo "throw $NODE_ID blocked-by"
-      echo "rsi-await: $NODE_ID has a non-empty blocked_by at origin/main ($note) — most likely a tracked hold born by a mechanical producer. Resolve the hold, not the source." >&2
+      echo "dispatch-emulate-await: $NODE_ID has a non-empty blocked_by at origin/main ($note) — most likely a tracked hold born by a mechanical producer. Resolve the hold, not the source." >&2
       exit 11 ;;
     advanced)
       echo "advanced $NODE_ID $FROM_PHASE -> origin/main"
       exit 0 ;;
     unchanged)
       echo "stalled $NODE_ID $FROM_PHASE"
-      echo "rsi-await: the worker stopped ($note) but $NODE_ID is still at phase '$FROM_PHASE' on origin/main, unparked and unblocked. Read the session transcript before re-running — a blind retry spends budget on a repeat of whatever failed silently." >&2
+      echo "dispatch-emulate-await: the worker stopped ($note) but $NODE_ID is still at phase '$FROM_PHASE' on origin/main, unparked and unblocked. Read the session transcript before re-running — a blind retry spends budget on a repeat of whatever failed silently." >&2
       exit 12 ;;
     *)
       echo "throw $NODE_ID unknown-graph-read"
-      echo "rsi-await: could not read $NODE_ID at origin/main (verify-landed's 'unknown'). Nothing is claimed either way — re-run once the read works." >&2
+      echo "dispatch-emulate-await: could not read $NODE_ID at origin/main (verify-landed's 'unknown'). Nothing is claimed either way — re-run once the read works." >&2
       exit 14 ;;
   esac
 }
@@ -268,8 +271,8 @@ if (( SAW_SESSION == 0 && GOT_ANSWER == 0 )); then
   # is the same "trust an unanswerable probe" failure rsi-claim refuses to make.
   # Report `running` instead — the caller re-runs, and nothing is claimed.
   echo "running $NODE_ID $FROM_PHASE"
-  echo "rsi-await: the Claude session registry could not be read at all during the ${BOOT_GRACE_S}s boot window, so nothing is known about $NODE_ID's worker — and an unanswerable probe is never read as 'finished'." >&2
-  echo "rsi-await: the usual cause is running sandboxed, which blocks the daemon's Unix socket silently (.claude/rules/sandbox.md). Re-run with dangerouslyDisableSandbox: true." >&2
+  echo "dispatch-emulate-await: the Claude session registry could not be read at all during the ${BOOT_GRACE_S}s boot window, so nothing is known about $NODE_ID's worker — and an unanswerable probe is never read as 'finished'." >&2
+  echo "dispatch-emulate-await: the usual cause is running sandboxed, which blocks the daemon's Unix socket silently (.claude/rules/sandbox.md). Re-run with dangerouslyDisableSandbox: true." >&2
   exit 20
 fi
 
@@ -293,11 +296,11 @@ while (( SECONDS < DEADLINE )); do
       # session is a throw either way: it occupies a worker slot and keeps the
       # node unselectable until a human releases it.
       echo "throw $NODE_ID held-session"
-      echo "rsi-await: the session named $NODE_ID has state 'done' but was NOT reaped — it stopped without writing a node-terminal marker, so dispatch-stop.sh is holding the job alive." >&2
-      echo "rsi-await: it occupies a worker slot AND keeps $NODE_ID unselectable (worktree_has_live_session is name-keyed) until released with 'claude rm <session-id>'. Read its transcript first — the missing marker usually means it stopped mid-phase." >&2
+      echo "dispatch-emulate-await: the session named $NODE_ID has state 'done' but was NOT reaped — it stopped without writing a node-terminal marker, so dispatch-stop.sh is holding the job alive." >&2
+      echo "dispatch-emulate-await: it occupies a worker slot AND keeps $NODE_ID unselectable (worktree_has_live_session is name-keyed) until released with 'claude rm <session-id>'. Read its transcript first — the missing marker usually means it stopped mid-phase." >&2
       "$VERIFY_LANDED" -C "$PROJECT_ROOT" --node "$NODE_ID" \
         --jq ".phase != \"$FROM_PHASE\"" >/dev/null 2>&1 && \
-        echo "rsi-await: NOTE — $NODE_ID HAS moved off '$FROM_PHASE' at origin/main despite the missing marker; the phase work may be complete." >&2
+        echo "dispatch-emulate-await: NOTE — $NODE_ID HAS moved off '$FROM_PHASE' at origin/main despite the missing marker; the phase work may be complete." >&2
       exit 11
       ;;
   esac
@@ -305,5 +308,5 @@ while (( SECONDS < DEADLINE )); do
 done
 
 echo "running $NODE_ID $FROM_PHASE"
-echo "rsi-await: $NODE_ID is still working after ${TIMEOUT_S}s. This is the expected result for a long phase — call rsi-await again with the same arguments." >&2
+echo "dispatch-emulate-await: $NODE_ID is still working after ${TIMEOUT_S}s. This is the expected result for a long phase — call dispatch-emulate-await again with the same arguments." >&2
 exit 20

--- a/.claude/skills/dispatch-emulate/scripts/test-dispatch-emulate-advance.sh
+++ b/.claude/skills/dispatch-emulate/scripts/test-dispatch-emulate-advance.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# Unit tests for rsi-advance — the launch half of the rsi-implement loop.
+# Unit tests for dispatch-emulate-advance — the launch half of the
+# dispatch-emulation loop.
 #
 # What is worth testing here is the DISPOSITION MAPPING and the REFUSALS, not
-# the dispatch machinery: rsi-advance's whole design is that it delegates
+# the dispatch machinery: dispatch-emulate-advance's whole design is that it delegates
 # selection and execution verbatim, so the tests stub both siblings and assert
 # that every line they can emit maps to the documented exit code. A mapping
 # regression is silent in production — an unmapped `parked` that fell through to
@@ -27,16 +28,16 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 # --- Fixture ---------------------------------------------------------------
-# A real checkout layout, because rsi-advance resolves its siblings from its own
-# on-disk location (four levels up) — a resolution that is itself a regression
-# risk.
+# A real checkout layout, because dispatch-emulate-advance resolves its
+# siblings from its own on-disk location (four levels up) — a resolution that
+# is itself a regression risk.
 PROJECT="$TMP/project"
-RSI_SCRIPTS="$PROJECT/.claude/skills/rsi/scripts"
+EMULATE_SCRIPTS="$PROJECT/.claude/skills/dispatch-emulate/scripts"
 DISPATCH="$PROJECT/.claude/skills/dispatch-propagate/scripts"
-mkdir -p "$RSI_SCRIPTS" "$DISPATCH"
+mkdir -p "$EMULATE_SCRIPTS" "$DISPATCH"
 
-cp "$SCRIPT_DIR/rsi-advance" "$RSI_SCRIPTS/rsi-advance"
-chmod +x "$RSI_SCRIPTS/rsi-advance"
+cp "$SCRIPT_DIR/dispatch-emulate-advance" "$EMULATE_SCRIPTS/dispatch-emulate-advance"
+chmod +x "$EMULATE_SCRIPTS/dispatch-emulate-advance"
 for lib in lib-claude-agents.sh lib-reservation-ledger.sh lib-graph-worktree.sh lib.sh; do
   src="$SCRIPT_DIR/../../dispatch-propagate/scripts/$lib"
   [[ -f "$src" ]] && cp "$src" "$DISPATCH/$lib"
@@ -48,13 +49,13 @@ git -C "$PROJECT" config user.name Test
 git -C "$PROJECT" add -A >/dev/null 2>&1
 git -C "$PROJECT" commit -qm init >/dev/null 2>&1
 
-ADVANCE="$RSI_SCRIPTS/rsi-advance"
+ADVANCE="$EMULATE_SCRIPTS/dispatch-emulate-advance"
 
 export DISPATCH_GRAPH_MAIN_WORKTREE="$PROJECT"
 export DISPATCH_RESERVATION_DIR="$TMP/reservations"
 mkdir -p "$DISPATCH_RESERVATION_DIR"
 
-# `git fetch origin main` must succeed — rsi-advance refuses to act on an
+# `git fetch origin main` must succeed — dispatch-emulate-advance refuses to act on an
 # unverified graph otherwise. Give the fixture a real local "remote".
 REMOTE="$TMP/remote.git"
 git init -q --bare "$REMOTE"
@@ -194,9 +195,50 @@ run_case "an empty selection is idle, not an error (exit 10)" \
 run_case "a selector line for another node is not consumed (exit 10)" \
   "node tactic-other-node tactic qa" "launched x /qa-fix" 10 "idle tactic-fixture-node not-selectable"
 
+# --- Strategy refusal -------------------------------------------------------
+# A strategy id must be refused mechanically, not launched: an /align-tactics
+# pass on a strategy decomposes it into CHILD tactic ids rather than
+# advancing the strategy itself up the ladder, so there is no single node for
+# this loop to follow. Cannot use run_case — it hardcodes tactic-fixture-node
+# as the argument; this case needs a strategy id instead.
+printf 'node strategy-fixture-node strategy align-tactics\n' >"$SELECT_OUT"
+printf 'launched strategy-fixture-node /align-tactics\n' >"$EXEC_OUT"
+rm -f "$DISPATCH_RESERVATION_DIR"/* 2>/dev/null
+rm -f "$TMP/exec.args"
+OUT=$("$ADVANCE" strategy-fixture-node 2>/dev/null); RC=$?
+if [[ "$RC" == 2 && "$OUT" == "refused strategy-fixture-node strategy" ]]; then
+  ok "a strategy id is refused before any claim or execute (exit 2)"
+else
+  fail "strategy refusal should exit 2 with 'refused ...', got exit $RC / '$OUT'"
+fi
+if [[ ! -s "$TMP/exec.args" ]]; then
+  ok "dispatch-graph-execute was never invoked for a refused strategy"
+else
+  fail "dispatch-graph-execute should not run for a refused strategy; args: $(cat "$TMP/exec.args")"
+fi
+if [[ ! -f "$DISPATCH_RESERVATION_DIR/strategy-fixture-node" ]]; then
+  ok "no reservation marker is written for a refused strategy"
+else
+  fail "a reservation marker should not exist for a refused strategy"
+fi
+
+# --- Complement: a tactic at the align-tactics rung still launches --------
+# The refusal gates on KIND only, never PHASE — a draft/raw/frozen tactic
+# starting its own /align-tactics finalize pass is the legitimate "start at
+# align-tactics" case, so it must not be caught by the strategy refusal.
+printf 'node tactic-fixture-node tactic align-tactics\n' >"$SELECT_OUT"
+printf 'launched tactic-fixture-node /align-tactics\n' >"$EXEC_OUT"
+rm -f "$DISPATCH_RESERVATION_DIR"/* 2>/dev/null
+OUT=$("$ADVANCE" tactic-fixture-node 2>/dev/null); RC=$?
+if [[ "$RC" == 0 && "$OUT" == "launched tactic-fixture-node tactic align-tactics /align-tactics" ]]; then
+  ok "a tactic at the align-tactics rung still launches (exit 0)"
+else
+  fail "tactic at the align-tactics rung should launch (exit 0), got exit $RC / '$OUT'"
+fi
+
 # --- Claim refusals --------------------------------------------------------
 # A live session registered under the node's worktree name blocks the launch.
-# This is the dispatch/rsi mutual exclusion; nothing may proceed past it.
+# This is the dispatch/dispatch-emulate mutual exclusion; nothing may proceed past it.
 cat >"$AGENTS_JSON" <<'JSON'
 [{"pid":999,"id":"aaaa","cwd":"/x","sessionId":"aaaa-1","name":"tactic-fixture-node","status":"busy","state":"working"}]
 JSON

--- a/.claude/skills/dispatch-emulate/scripts/test-dispatch-emulate-await.sh
+++ b/.claude/skills/dispatch-emulate/scripts/test-dispatch-emulate-await.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Unit tests for rsi-await — the wait-and-verify half of the rsi-implement loop.
+# Unit tests for dispatch-emulate-await — the wait-and-verify half of the
+# dispatch-emulation loop.
 #
 # Two things are worth testing and both are invisible in production until they
 # are wrong:
@@ -34,22 +35,22 @@ trap 'rm -rf "$TMP"' EXIT
 
 # --- Fixture ---------------------------------------------------------------
 PROJECT="$TMP/project"
-RSI_SCRIPTS="$PROJECT/.claude/skills/rsi/scripts"
+EMULATE_SCRIPTS="$PROJECT/.claude/skills/dispatch-emulate/scripts"
 DISPATCH="$PROJECT/.claude/skills/dispatch-propagate/scripts"
 IUTIL="$PROJECT/packages/intentionsutil/scripts"
-mkdir -p "$RSI_SCRIPTS" "$DISPATCH" "$IUTIL"
+mkdir -p "$EMULATE_SCRIPTS" "$DISPATCH" "$IUTIL"
 
-cp "$SCRIPT_DIR/rsi-await" "$RSI_SCRIPTS/rsi-await"
-chmod +x "$RSI_SCRIPTS/rsi-await"
+cp "$SCRIPT_DIR/dispatch-emulate-await" "$EMULATE_SCRIPTS/dispatch-emulate-await"
+chmod +x "$EMULATE_SCRIPTS/dispatch-emulate-await"
 for lib in lib-claude-agents.sh lib-reservation-ledger.sh lib-graph-worktree.sh lib.sh; do
   src="$SCRIPT_DIR/../../dispatch-propagate/scripts/$lib"
   [[ -f "$src" ]] && cp "$src" "$DISPATCH/$lib"
 done
 
-AWAIT="$RSI_SCRIPTS/rsi-await"
+AWAIT="$EMULATE_SCRIPTS/dispatch-emulate-await"
 export DISPATCH_GRAPH_MAIN_WORKTREE="$PROJECT"
 
-# See test-rsi-advance.sh: the empty-read corroboration needs a visible daemon,
+# See test-dispatch-emulate-advance.sh: the empty-read corroboration needs a visible daemon,
 # and CI has none. Stub the probe so the suite does not depend on whether a real
 # Claude daemon happens to be running on the host.
 PGREP_STUB="$TMP/pgrep-stub"
@@ -70,7 +71,7 @@ chmod +x "$CLAUDE_STUB"
 export CLAUDE_AGENTS_CMD="$CLAUDE_STUB"
 
 # verify-landed. Its three answers (0 landed / 4 not-landed / 1 unknown) are
-# what rsi-await maps, so the stub is keyed on the spec it is asked about: each
+# what dispatch-emulate-await maps, so the stub is keyed on the spec it is asked about: each
 # case writes the exit code it wants for `absent`, `office_hours`, `blocked_by`,
 # and `phase`.
 RC_ABSENT="$TMP/rc.absent"; RC_PARKED="$TMP/rc.parked"

--- a/.claude/skills/rsi/SKILL.md
+++ b/.claude/skills/rsi/SKILL.md
@@ -115,61 +115,17 @@ identified, as graph nodes serving the right strategy. Land via `graph-commit`;
 verify by parsing `origin/main`, never by exit code. Most iterations should be
 mostly this: the harness does the work, rsi decides what the work is.
 
-**4b — Execute (cost 1 each).** Drive a claimed node through the dispatch phase
-skills, one phase at a time, with two scripts:
+**4b — Execute (cost 1 each).** Drive the claimed node through the dispatch
+phase skills with **`/dispatch-emulate <node-id>`**, invoked **in this thread**
+— never in an Agent-tool subagent. That skill is the loop's only home: it owns
+the advance/await cycle, its exit-code contract, the phase ladder, and the three
+non-negotiable rules that hold throughout. Read it there; do not restate any of
+it here. It refuses a strategy id — run `/align-tactics <strategy-id>` first,
+then emulate a child tactic.
 
-```bash
-.claude/skills/rsi/scripts/rsi-advance <node-id>          # launch one phase
-.claude/skills/rsi/scripts/rsi-await   <node-id> <phase>  # wait, then verify
-```
-
-Both need `dangerouslyDisableSandbox: true` (gh, the Claude daemon socket, git,
-direnv — `.claude/rules/sandbox.md`). `rsi-advance` prints
-`launched <id> <kind> <phase> <skill>`; hand that `<phase>` to `rsi-await` as the
-from-phase. The loop is:
-
-1. `rsi-advance <id>`. Exit **0** means a session is running — go to 2. Exit
-   **10** means there is nothing to launch (not selectable, CI still pending, a
-   stale selection); stop the loop and read its stderr. Exit **11** means throw
-   — go to step 5 below. Exit **13** means another session holds the node;
-   **stop**, and never work around it.
-2. `rsi-await <id> <phase>`. Exit **20** means still working — call it again with
-   the same arguments, as many times as it takes. Exit **0** means the node
-   advanced (or was pruned, and the loop is done). Exit **11**, **12** or **14**
-   go to step 5.
-3. On exit 0, return to 1. The next `rsi-advance` re-reads the phase from
-   `origin/main`, so nothing needs to be threaded between iterations.
-4. Stop when `rsi-advance` reports `idle` or `rsi-await` reports `pruned`. A
-   node that reaches `main-qa` and merges leaves the loop through `idle` — the
-   tick's merge lane, not this loop, finishes it.
-5. On any throw: **do not push through and do not retry blindly.** Conduct the
-   office-hours engagement here, attended, and record the outcome in the graph.
-   A `stalled` (12) in particular means the worker stopped having changed
-   nothing — read its transcript before spending budget on a repeat.
-
-**What the scripts do and do not decide.** They decide nothing about
-eligibility. `rsi-advance` delegates the phase directive to
-`graph-select-target --node <id>` — every environmental gate applied verbatim,
-including the CI and PR sensor gates and the fix/conflict interrupts — and the
-launch to `dispatch-graph-execute`, which owns provisioning, the phase-skill
-mapping, the reservation handoff, and every park/hold disposition. `rsi-await`
-takes its verdict from `verify-landed` against `origin/main`, never from a
-session's exit status. **If a rule about when a node may run ever appears in
-these scripts, it is in the wrong place** — that is the second-orchestration-
-surface divergence the record forbids.
-
-Three rules hold, and none of them is negotiable:
-
-- **Never hand-merge.** The tick's merge lane runs even while dispatch is
-  paused. Let it. Neither script makes a merge, a graph write, or a `gh` call.
-- **Never run a phase skill in an Agent-tool subagent.** `/qa-fix`,
-  `/review-fix` and `/align-tactics` depend on the Workflow tool, which a
-  subagent cannot use. They must be spawned sessions — which is what
-  `dispatch-graph-execute` does.
-- **Never work a node dispatch is working.** `rsi-advance` refuses on exit 13
-  when a live session or an unreleased ledger marker claims the node, and it
-  writes its own marker before spawning so the boot window is covered. Exit 13
-  is the mutual exclusion, not an obstacle to route around.
+`/rsi` keeps what is rsi's: the budget above, and the throw. When
+`/dispatch-emulate` stops on a throw, conduct the office-hours engagement here,
+attended, and record the outcome in the graph.
 
 ## Pause and resume authority
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -262,10 +262,10 @@ jobs:
         run: packages/intentionsutil/scripts/test-verify-landed.sh
       - name: Run rsi-claim tests
         run: .claude/skills/rsi/scripts/test-rsi-claim.sh
-      - name: Run rsi-advance tests
-        run: .claude/skills/rsi/scripts/test-rsi-advance.sh
-      - name: Run rsi-await tests
-        run: .claude/skills/rsi/scripts/test-rsi-await.sh
+      - name: Run dispatch-emulate-advance tests
+        run: .claude/skills/dispatch-emulate/scripts/test-dispatch-emulate-advance.sh
+      - name: Run dispatch-emulate-await tests
+        run: .claude/skills/dispatch-emulate/scripts/test-dispatch-emulate-await.sh
       - name: Run budget-config-load tests
         run: .claude/skills/budget/scripts/test-budget-config-load.sh
       - name: Run write-phase-log tests


### PR DESCRIPTION
## What this does

`/rsi` Step 4b (`.claude/skills/rsi/SKILL.md:104-172`) was the only written home
for the *dispatch emulation* procedure: drive ONE graph node through the real
dispatch phase skills, one phase at a time, as spawned background sessions —
`align-tactics → implement → (fix) → review → qa → main-qa` — reusing the
dispatch machinery verbatim rather than re-implementing scheduling.

It exists for the case the tick structurally cannot reach (dispatch paused and
the fix is what would unpause it; a bootstrap deadlock), and it is useful on its
own — but today it is reachable only by running a full `/rsi` iteration with its
claim, its plan render, its judgment step and its budget.

This gives the procedure its own home: a user-invocable `/dispatch-emulate
<node-id>` skill that owns the loop, its two scripts, and their tests. `/rsi`
Step 4b becomes a delegation, so the instructions have exactly one home and rsi
keeps only what is rsi's (budget, attendedness, the judgment step, pause
authority).

## What was extracted, and from where

| new | from |
| --- | --- |
| `.claude/skills/dispatch-emulate/SKILL.md` | `.claude/skills/rsi/SKILL.md:104-172` |
| `.claude/skills/dispatch-emulate/scripts/dispatch-emulate-advance` | `.claude/skills/rsi/scripts/rsi-advance` |
| `.claude/skills/dispatch-emulate/scripts/dispatch-emulate-await` | `.claude/skills/rsi/scripts/rsi-await` |
| `.claude/skills/dispatch-emulate/scripts/test-dispatch-emulate-advance.sh` | `.claude/skills/rsi/scripts/test-rsi-advance.sh` |
| `.claude/skills/dispatch-emulate/scripts/test-dispatch-emulate-await.sh` | `.claude/skills/rsi/scripts/test-rsi-await.sh` |

All four script moves are `git mv` renames — history preserved, path depth
unchanged, so both scripts' `CHECKOUT_ROOT` resolution and the tests'
sibling-lib copy keep working untouched.

`.github/workflows/unit-tests.yml` repoints the two suites (they are
hand-registered, not glob-discovered).

## The two author decisions

**1. The scripts move and are renamed.** They are the loop, not rsi's, once the
loop has its own skill. `rsi-claim` and `test-rsi-claim.sh` **stay** in `/rsi` —
they serialize rsi *sessions*, not nodes.

**2. A strategy id is refused, mechanically.** An `/align-tactics` pass on a
strategy decomposes it into *child* tactic ids rather than advancing the given
node up the ladder, so "follow this node to main-qa" is not a coherent request
for a strategy. `dispatch-emulate-advance` now prints `refused <id> strategy`
and exits 2. The refusal gates on the **selector's own** `kind`, never a
re-derived one, and never on phase — so a tactic whose rung is `align-tactics`
(a draft, raw or frozen tactic starting its own finalize pass) still launches
normally. It sits after the selector line is parsed and **before**
`reservation_write`, so a refusal writes no claim and spawns nothing.

## Behavior

Unchanged apart from that refusal. This is an extraction: no change to
selection, execution, waiting, the exit-code contract, or the reservation-ledger
protocol. The scripts still decide nothing about eligibility —
`graph-select-target --node <id>` (a selection-*order* override, not a gate
bypass) owns every gate, `dispatch-graph-execute` owns provisioning and the
phase-skill mapping, and the verdict still comes from `verify-landed` against
`origin/main`.

## Verification

Three suites pass locally:

- `test-dispatch-emulate-advance.sh` — **24 passed, 0 failed** (was 20; the
  strategy refusal and its complement add 4 assertions)
- `test-dispatch-emulate-await.sh` — **18 passed, 0 failed**
- `test-rsi-claim.sh` — **11 passed, 0 failed**

No live caller points at the old script paths (`intentions/**` and
`rsi-plan.md` are excluded on purpose — dated records, not live callers).

**Not verified, deliberately:** a real `/dispatch-emulate <node-id>` run. It
spawns live phase sessions against the real queue, writes to the graph, and
opens PRs. The unit suites cover the disposition mapping and the refusals, which
is what changed. The first live run is the author's call, ideally on a node they
already intended to advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
