### PR TITLE
Correct /dispatch-emulate's merge rule: the paused tick does not drain

### DIFF
--- a/.claude/skills/dispatch-emulate/SKILL.md
+++ b/.claude/skills/dispatch-emulate/SKILL.md
@@ -107,8 +107,15 @@ git, direnv — `.claude/rules/sandbox.md`). `dispatch-emulate-advance` prints
 
 ## Three rules, none negotiable
 
-- **Never hand-merge.** The tick's merge lane runs even while dispatch is paused.
-  Let it. Neither script makes a merge, a graph write, or a `gh` call.
+- **Never hand-merge.** Neither script makes a merge, a graph write, or a `gh`
+  call. The merge belongs to `graph-auto-merge`, which the dispatch tick calls —
+  and while dispatch is **paused** that lane does not run: `graph-auto-merge` is
+  invoked only inside `dispatch-select-tick`, which sits past the pause
+  short-circuit. So a paused run stops with its PR reviewed and unmerged, and an
+  operator clears it with `dispatch-tick --manual`. Do not merge it by hand to
+  get past this. (`tactic-pause-disables-merge-lane` makes the paused tick drain;
+  `tactic-dispatch-emulate-owns-merge` gives this loop its own node-scoped merge
+  step, after which this rule is rewritten again.)
 - **Never run a phase skill in an Agent-tool subagent.** `/qa-fix`, `/review-fix`
   and `/align-tactics` depend on the Workflow tool, which a subagent cannot use.
   They must be spawned sessions — which is what `dispatch-graph-execute` does.


### PR DESCRIPTION
## The defect

`/dispatch-emulate`'s first non-negotiable rule shipped as:

> **Never hand-merge.** The tick's merge lane runs even while dispatch is paused.
> Let it.

The second sentence is false. `graph-auto-merge` is invoked only inside
`dispatch-select-tick`, and every `dispatch-select-tick` invocation sits past the
pause short-circuit in `dispatch-tick`, so no node-lane PR merges while the pause
sentinel exists.

This graph already knew that — `strategy-recursive-self-improvement` recorded the
finding on 2026-08-11, including the line anchors. The sentence was inherited
verbatim from `/rsi` Step 4b during the extraction in #3069. That extraction
*removed* it from `/rsi`, so this is now its only home, and the strategy's
locator naming `/rsi`'s SKILL.md is stale — amended in the same `/align` round
that produced this PR.

It matters because the falsehood is load-bearing exactly where the skill is
meant to be used: dispatch is currently paused, which is precisely when someone
reaches for `/dispatch-emulate`, and the rule tells them to wait for a lane that
will not run.

## What this changes

The rule now states the truth as it stands today: the loop never merges, the
merge belongs to `graph-auto-merge`, that lane does not run while paused, a
paused run therefore stops with its PR reviewed and unmerged, and an operator
clears it with `dispatch-tick --manual` rather than a hand merge.

## Deliberately interim

The author's ruling was that patching the sentence is not the real fix: the loop
delegates every other phase to the same scripts dispatch uses, then outsources
the terminal step to the scheduler it exists to route around. The greenfield
design — `graph-auto-merge` owning all its gates including main-known-good, plus
an optional node-id filter, called by both the tick and the loop — is recorded on
`strategy-graph-native-dispatch` under "Who merges an emulated run's PR", and is
carried by `tactic-graph-auto-merge-main-health-gate` and
`tactic-dispatch-emulate-owns-merge`. This paragraph gets rewritten when they
land.

## Scope

One paragraph in one file. No script, test, or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
